### PR TITLE
feat: Add env:push command, remove deployEnv

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ solidactions deploy <project-name> <path>
 | `env:delete <key>` | Delete an environment variable |
 | `env:map <project> <key> <global-key>` | Map a global variable to a project |
 | `env:pull <project>` | Pull resolved env vars (including OAuth tokens) to a local file |
+| `env:push <project> [path]` | Push .env values to a project |
 | `schedule:set <project> <cron>` | Set a cron schedule for a workflow |
 | `schedule:list <project>` | List schedules for a project |
 | `schedule:delete <project> <id>` | Delete a schedule |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -404,6 +404,47 @@ solidactions env:pull my-project --update-oauth --env staging
 
 OAuth tokens are short-lived. Use `--update-oauth` for quick refreshes without re-pulling all variables. Each pull fetches a fresh token from the OAuth provider.
 
+### `env:push <project> [path]`
+
+Push environment variables from a `.env` file to a project.
+
+```bash
+solidactions env:push my-project
+```
+
+**Arguments:**
+- `<project>` - Project name
+- `[path]` - Source directory with `solidactions.yaml` and `.env` file (default: `.`)
+
+**Options:**
+- `-e, --env <environment>` - Target environment: production/staging/dev (default: `dev`)
+- `--new-only` - Only push new or empty variables (skip existing)
+- `--include-undeclared` - Also push vars not declared in `solidactions.yaml`
+- `-y, --yes` - Skip confirmation prompt
+
+**Examples:**
+```bash
+# Push dev env vars from current directory
+solidactions env:push my-project
+
+# Push from a specific directory
+solidactions env:push my-project ./my-app
+
+# Push production env vars
+solidactions env:push my-project --env production
+
+# Only push new variables (don't overwrite existing)
+solidactions env:push my-project --new-only
+
+# Push all .env vars, even those not in solidactions.yaml
+solidactions env:push my-project --include-undeclared
+
+# Push without confirmation prompt
+solidactions env:push my-project -y
+```
+
+By default, only variables declared in `solidactions.yaml` are pushed. Use `--include-undeclared` to push all variables from the `.env` file. Variables with names matching common secret patterns (secret, key, token, password, credential) are automatically marked as secrets.
+
 ---
 
 ## Webhooks
@@ -544,10 +585,13 @@ solidactions env:create API_KEY "..." --secret
 # 3. Deploy your project
 solidactions deploy my-project ./src
 
-# 4. Set up a schedule
+# 4. Push env vars from local .env
+solidactions env:push my-project ./src
+
+# 5. Set up a schedule
 solidactions schedule:set my-project "0 9 * * *"
 
-# 5. Trigger a test run
+# 6. Trigger a test run
 solidactions run my-project main-workflow
 ```
 

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -6,34 +6,7 @@ import FormData from 'form-data';
 import chalk from 'chalk';
 import yaml from 'js-yaml';
 import { getConfig } from './init';
-
-interface WorkflowConfig {
-    id?: string;
-    name: string;
-    command?: string;
-    file?: string;
-    enabled?: boolean;
-}
-
-/**
- * Parsed environment variable declaration from YAML.
- * New format examples:
- *   - TEST_ENV_VAR                    -> { key: "TEST_ENV_VAR", mappedTo: null }
- *   - MAPPED_SECRET: JIMBO            -> { key: "MAPPED_SECRET", mappedTo: "JIMBO" }
- *   - DATABASE_URL: DATABASE_URL      -> { key: "DATABASE_URL", mappedTo: "DATABASE_URL" }
- */
-interface ParsedEnvVar {
-    key: string;
-    mappedTo: string | null;
-    oauthName: string | null;
-}
-
-interface SolidActionsConfig {
-    workflows: WorkflowConfig[];
-    // New format: deployEnv at top level, env is a simple list
-    deployEnv?: boolean;
-    env?: (string | { [key: string]: string | { oauth: string } })[];
-}
+import { SolidActionsConfig, parseYamlEnvVars } from '../utils/env';
 
 /**
  * Validate project structure before deployment.
@@ -118,100 +91,6 @@ function validateProject(sourceDir: string): { valid: boolean; errors: string[];
     return { valid: errors.length === 0, errors, warnings };
 }
 
-/**
- * Parse a .env file into a key-value map.
- */
-function parseEnvFile(filePath: string): Map<string, string> {
-    const envMap = new Map<string, string>();
-
-    if (!fs.existsSync(filePath)) {
-        return envMap;
-    }
-
-    const content = fs.readFileSync(filePath, 'utf8');
-    const lines = content.split('\n');
-
-    for (const line of lines) {
-        const trimmed = line.trim();
-        // Skip empty lines and comments
-        if (!trimmed || trimmed.startsWith('#')) {
-            continue;
-        }
-
-        const equalsIndex = trimmed.indexOf('=');
-        if (equalsIndex === -1) {
-            continue;
-        }
-
-        const key = trimmed.substring(0, equalsIndex).trim();
-        let value = trimmed.substring(equalsIndex + 1).trim();
-
-        // Remove surrounding quotes if present
-        if ((value.startsWith('"') && value.endsWith('"')) ||
-            (value.startsWith("'") && value.endsWith("'"))) {
-            value = value.slice(1, -1);
-        }
-
-        envMap.set(key, value);
-    }
-
-    return envMap;
-}
-
-/**
- * Parse YAML env declarations into structured format.
- * Handles the new simplified format:
- *   - VAR_NAME           -> { key: "VAR_NAME", mappedTo: null }
- *   - VAR_NAME: GLOBAL   -> { key: "VAR_NAME", mappedTo: "GLOBAL" }
- */
-function parseYamlEnvVars(config: SolidActionsConfig): ParsedEnvVar[] {
-    const parsedVars: ParsedEnvVar[] = [];
-
-    if (!config.env || !Array.isArray(config.env)) {
-        return parsedVars;
-    }
-
-    for (const item of config.env) {
-        if (typeof item === 'string') {
-            // Simple string: - VAR_NAME (declared only, needs configuration)
-            parsedVars.push({ key: item, mappedTo: null, oauthName: null });
-        } else if (typeof item === 'object' && item !== null) {
-            // Object: - VAR_NAME: GLOBAL_NAME or - VAR_NAME: { oauth: connection-name }
-            const keys = Object.keys(item);
-            if (keys.length === 1) {
-                const key = keys[0];
-                const value = item[key];
-                if (typeof value === 'object' && value !== null && 'oauth' in value) {
-                    if (typeof value.oauth !== 'string' || !value.oauth) {
-                        throw new Error(`Invalid env config for ${key}: 'oauth' must be a non-empty string`);
-                    }
-                    parsedVars.push({ key, mappedTo: null, oauthName: value.oauth });
-                } else {
-                    parsedVars.push({ key, mappedTo: value || null, oauthName: null });
-                }
-            }
-        }
-    }
-
-    return parsedVars;
-}
-
-/**
- * Extract declared variable keys from solidactions.yaml env config.
- * Returns a set of env var keys that are declared in YAML.
- */
-function getYamlDeclaredVars(config: SolidActionsConfig): Set<string> {
-    const parsedVars = parseYamlEnvVars(config);
-    return new Set(parsedVars.map(v => v.key));
-}
-
-/**
- * Check if deployEnv is enabled in the config.
- * New format has deployEnv at top level.
- */
-function isDeployEnvEnabled(config: SolidActionsConfig): boolean {
-    return config.deployEnv === true;
-}
 
 interface DeployOptions {
     env?: string;
@@ -256,90 +135,6 @@ async function pushYamlDeclarations(
         console.log(chalk.gray(`Synced ${declarations.length} YAML env declarations`));
     } catch (error: any) {
         console.error(chalk.yellow('Warning: Failed to sync YAML declarations:'), error.response?.data?.message || error.message);
-    }
-}
-
-/**
- * Push environment variables from .env file to project.
- * Only pushes vars that are declared in solidactions.yaml.
- */
-async function pushEnvVars(
-    host: string,
-    apiKey: string,
-    projectSlug: string,
-    sourceDir: string,
-    environment: string,
-    yamlConfig: SolidActionsConfig
-): Promise<void> {
-    // Get vars declared in YAML
-    const declaredVars = getYamlDeclaredVars(yamlConfig);
-    if (declaredVars.size === 0) {
-        console.log(chalk.gray('No environment variables declared in solidactions.yaml'));
-        return;
-    }
-
-    // Read the .env file for this environment
-    const envFileName = environment === 'production' ? '.env' : `.env.${environment}`;
-    const envFilePath = path.join(sourceDir, envFileName);
-
-    if (!fs.existsSync(envFilePath)) {
-        console.log(chalk.yellow(`⚠ ${envFileName} not found, skipping env push`));
-        // Warn about each missing declared var
-        for (const key of declaredVars) {
-            console.log(chalk.yellow(`  ⚠ ${key}: no value (not in ${envFileName})`));
-        }
-        return;
-    }
-
-    // Parse the .env file
-    const envValues = parseEnvFile(envFilePath);
-
-    // Filter to only YAML-declared vars
-    const variables: { key: string; value: string; is_secret: boolean }[] = [];
-    const missing: string[] = [];
-
-    for (const key of declaredVars) {
-        const value = envValues.get(key);
-        if (value !== undefined) {
-            // Mark vars containing "secret", "key", "token", "password" as secrets
-            const isSecret = /secret|key|token|password|credential/i.test(key);
-            variables.push({ key, value, is_secret: isSecret });
-        } else {
-            missing.push(key);
-        }
-    }
-
-    // Warn about missing vars
-    for (const key of missing) {
-        console.log(chalk.yellow(`⚠ ${key}: not found in ${envFileName}`));
-    }
-
-    if (variables.length === 0) {
-        console.log(chalk.yellow('No matching environment variables to push'));
-        return;
-    }
-
-    // Push to API
-    try {
-        const response = await axios.post(
-            `${host}/api/v1/projects/${projectSlug}/variable-mappings/bulk`,
-            { variables },
-            {
-                headers: {
-                    'Authorization': `Bearer ${apiKey}`,
-                    'Accept': 'application/json',
-                    'Content-Type': 'application/json',
-                },
-            }
-        );
-
-        const { created, updated } = response.data;
-        console.log(chalk.green(`✓ Pushed ${variables.length} environment variables from ${envFileName}`));
-        if (created > 0 || updated > 0) {
-            console.log(chalk.gray(`  (${created} created, ${updated} updated)`));
-        }
-    } catch (error: any) {
-        console.error(chalk.red('Failed to push environment variables:'), error.response?.data?.message || error.message);
     }
 }
 
@@ -501,19 +296,6 @@ export async function deploy(projectName: string, sourcePath?: string, options: 
                                 config.host,
                                 config.apiKey,
                                 projectSlug,
-                                yamlConfig
-                            );
-                        }
-
-                        // Push .env values if deployEnv is enabled
-                        if (yamlConfig && isDeployEnvEnabled(yamlConfig)) {
-                            console.log(chalk.blue('\nPushing environment variables...'));
-                            await pushEnvVars(
-                                config.host,
-                                config.apiKey,
-                                projectSlug,
-                                sourceDir,
-                                environment,
                                 yamlConfig
                             );
                         }

--- a/src/commands/env-push.ts
+++ b/src/commands/env-push.ts
@@ -1,0 +1,245 @@
+import fs from 'fs';
+import path from 'path';
+import axios from 'axios';
+import chalk from 'chalk';
+import prompts from 'prompts';
+import { getConfig } from './init';
+import { SolidActionsConfig, parseEnvFile, getYamlDeclaredVars, loadSolidActionsConfig } from '../utils/env';
+
+interface EnvPushOptions {
+    env?: string;
+    newOnly?: boolean;
+    includeUndeclared?: boolean;
+    yes?: boolean;
+}
+
+export async function envPush(projectName: string, sourcePath: string, options: EnvPushOptions = {}): Promise<void> {
+    const config = getConfig();
+    if (!config?.apiKey) {
+        console.error(chalk.red('Not initialized. Run "solidactions init <api-key>" first.'));
+        process.exit(1);
+    }
+
+    const sourceDir = path.resolve(sourcePath);
+    const environment = options.env || 'dev';
+
+    // Read solidactions.yaml
+    const yamlPath = path.join(sourceDir, 'solidactions.yaml');
+    if (!fs.existsSync(yamlPath)) {
+        console.error(chalk.red('solidactions.yaml not found in ' + sourceDir));
+        console.log(chalk.gray('Make sure you\'re in a SolidActions project directory.'));
+        process.exit(1);
+    }
+
+    let yamlConfig: SolidActionsConfig;
+    try {
+        yamlConfig = loadSolidActionsConfig(yamlPath);
+    } catch (err: any) {
+        console.error(chalk.red('Failed to parse solidactions.yaml:'), err.message);
+        process.exit(1);
+    }
+
+    // Get YAML-declared vars
+    const declaredVars = getYamlDeclaredVars(yamlConfig);
+
+    // Determine env file
+    const envFileName = environment === 'production' ? '.env' : `.env.${environment}`;
+    const envFilePath = path.join(sourceDir, envFileName);
+
+    if (!fs.existsSync(envFilePath)) {
+        console.error(chalk.red(`${envFileName} not found in ${sourceDir}`));
+        console.log(chalk.gray(`Create ${envFileName} with your environment variables, or use a different --env.`));
+        process.exit(1);
+    }
+
+    // Parse the .env file
+    const envValues = parseEnvFile(envFilePath);
+
+    if (envValues.size === 0) {
+        console.log(chalk.yellow(`${envFileName} is empty — nothing to push.`));
+        process.exit(0);
+    }
+
+    // Filter to YAML-declared vars only (unless --include-undeclared)
+    let keysToProcess: string[];
+    if (options.includeUndeclared) {
+        keysToProcess = Array.from(envValues.keys());
+    } else {
+        if (declaredVars.size === 0) {
+            console.log(chalk.yellow('No environment variables declared in solidactions.yaml.'));
+            console.log(chalk.gray('Use --include-undeclared to push all vars from the .env file.'));
+            process.exit(0);
+        }
+        keysToProcess = Array.from(envValues.keys()).filter(k => declaredVars.has(k));
+
+        // Warn about YAML-declared vars missing from .env
+        for (const key of declaredVars) {
+            if (!envValues.has(key)) {
+                console.log(chalk.yellow(`⚠ ${key}: declared in YAML but not found in ${envFileName}`));
+            }
+        }
+    }
+
+    if (keysToProcess.length === 0) {
+        console.log(chalk.yellow('No matching variables to push.'));
+        if (!options.includeUndeclared && envValues.size > 0) {
+            console.log(chalk.gray('Your .env has variables not declared in solidactions.yaml. Use --include-undeclared to push them.'));
+        }
+        process.exit(0);
+    }
+
+    // Build project slug
+    const projectSlug = environment === 'production'
+        ? projectName
+        : `${projectName}-${environment}`;
+
+    console.log(chalk.blue(`Pushing env vars to "${projectName}" (${environment})...`));
+
+    // Fetch current server state
+    let serverMappings: any[] = [];
+    try {
+        const response = await axios.get(`${config.host}/api/v1/projects/${projectSlug}/variable-mappings`, {
+            headers: {
+                'Authorization': `Bearer ${config.apiKey}`,
+                'Accept': 'application/json',
+            },
+        });
+        serverMappings = response.data || [];
+    } catch (error: any) {
+        if (error.response?.status === 401) {
+            console.error(chalk.red('Authentication failed. Run "solidactions init <api-key>" to re-configure.'));
+            process.exit(1);
+        } else if (error.response?.status === 404) {
+            console.error(chalk.red(`Project "${projectSlug}" not found.`));
+            console.log(chalk.gray(`Deploy first with: solidactions deploy ${projectName} --env ${environment}` + (environment !== 'production' ? ' --create' : '')));
+            process.exit(1);
+        }
+        throw error;
+    }
+
+    // Build a lookup of server state by env_name
+    const serverState = new Map<string, any>();
+    for (const mapping of serverMappings) {
+        serverState.set(mapping.env_name, mapping);
+    }
+
+    // Build diff
+    interface PushEntry {
+        key: string;
+        value: string;
+        is_secret: boolean;
+        action: 'create' | 'update' | 'skip';
+    }
+
+    const entries: PushEntry[] = [];
+
+    for (const key of keysToProcess) {
+        const value = envValues.get(key)!;
+        const isSecret = /secret|key|token|password|credential/i.test(key);
+        const existing = serverState.get(key);
+
+        let action: 'create' | 'update' | 'skip';
+        if (!existing || existing.status === 'not_configured' || existing.has_value === false) {
+            action = 'create';
+        } else {
+            action = 'update';
+        }
+
+        // If --new-only, skip updates
+        if (options.newOnly && action === 'update') {
+            action = 'skip';
+        }
+
+        entries.push({ key, value, is_secret: isSecret, action });
+    }
+
+    const toCreate = entries.filter(e => e.action === 'create');
+    const toUpdate = entries.filter(e => e.action === 'update');
+    const toSkip = entries.filter(e => e.action === 'skip');
+    const toPush = entries.filter(e => e.action !== 'skip');
+
+    if (toPush.length === 0) {
+        console.log(chalk.yellow('Nothing to push — all variables are already configured.'));
+        if (toSkip.length > 0) {
+            console.log(chalk.gray(`${toSkip.length} variable(s) skipped (--new-only).`));
+        }
+        process.exit(0);
+    }
+
+    // Display diff table
+    console.log('');
+    console.log(chalk.bold('  KEY'.padEnd(36) + 'ACTION'.padEnd(12) + 'NOTES'));
+    console.log(chalk.gray('  ' + '─'.repeat(56)));
+
+    for (const entry of entries) {
+        const keyCol = ('  ' + entry.key).padEnd(36);
+        let actionCol: string;
+        let notesCol: string;
+
+        switch (entry.action) {
+            case 'create':
+                actionCol = chalk.green('create'.padEnd(12));
+                notesCol = chalk.gray('(new)');
+                break;
+            case 'update':
+                actionCol = chalk.yellow('update'.padEnd(12));
+                notesCol = chalk.gray('(has existing value)');
+                break;
+            case 'skip':
+                actionCol = chalk.gray('skip'.padEnd(12));
+                notesCol = chalk.gray('(--new-only)');
+                break;
+        }
+
+        console.log(keyCol + actionCol + notesCol);
+    }
+    console.log('');
+
+    // Confirm unless --yes
+    if (!options.yes) {
+        const summary = [];
+        if (toCreate.length > 0) summary.push(`${toCreate.length} create`);
+        if (toUpdate.length > 0) summary.push(`${toUpdate.length} update`);
+        if (toSkip.length > 0) summary.push(`${toSkip.length} skip`);
+
+        const response = await prompts({
+            type: 'confirm',
+            name: 'confirm',
+            message: `Push ${toPush.length} variable(s) to ${projectSlug}? (${summary.join(', ')})`,
+            initial: true,
+        });
+
+        if (!response.confirm) {
+            console.log(chalk.gray('Cancelled.'));
+            return;
+        }
+    }
+
+    // Push via bulk API
+    const variables = toPush.map(e => ({
+        key: e.key,
+        value: e.value,
+        is_secret: e.is_secret,
+    }));
+
+    try {
+        const response = await axios.post(
+            `${config.host}/api/v1/projects/${projectSlug}/variable-mappings/bulk`,
+            { variables },
+            {
+                headers: {
+                    'Authorization': `Bearer ${config.apiKey}`,
+                    'Accept': 'application/json',
+                    'Content-Type': 'application/json',
+                },
+            }
+        );
+
+        const { created, updated } = response.data;
+        console.log(chalk.green(`\n✓ Pushed ${toPush.length} variable(s) to ${projectSlug}`));
+        console.log(chalk.gray(`  ${created} created, ${updated} updated` + (toSkip.length > 0 ? `, ${toSkip.length} skipped` : '')));
+    } catch (error: any) {
+        console.error(chalk.red('Failed to push environment variables:'), error.response?.data?.message || error.message);
+        process.exit(1);
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { envList } from './commands/env-list';
 import { envDelete } from './commands/env-delete';
 import { envMap } from './commands/env-map';
 import { envPull } from './commands/env-pull';
+import { envPush } from './commands/env-push';
 import { scheduleSet } from './commands/schedule-set';
 import { scheduleList } from './commands/schedule-list';
 import { scheduleDelete } from './commands/schedule-delete';
@@ -193,6 +194,19 @@ program
     .option('--update-oauth', 'Only pull OAuth tokens and merge into existing .env file')
     .action((project, options) => {
         envPull(project, options);
+    });
+
+program
+    .command('env:push')
+    .description('Push environment variables from .env file to a project')
+    .argument('<project>', 'Project name')
+    .argument('[path]', 'Source directory with solidactions.yaml and .env file', '.')
+    .option('-e, --env <environment>', 'Target environment (production/staging/dev)', 'dev')
+    .option('--new-only', 'Only push new or empty variables (skip existing)')
+    .option('--include-undeclared', 'Also push vars not declared in solidactions.yaml')
+    .option('-y, --yes', 'Skip confirmation prompt')
+    .action((project, path, options) => {
+        envPush(project, path, options);
     });
 
 // =============================================================================

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,0 +1,115 @@
+import fs from 'fs';
+import yaml from 'js-yaml';
+
+/**
+ * Parsed environment variable declaration from YAML.
+ * New format examples:
+ *   - TEST_ENV_VAR                    -> { key: "TEST_ENV_VAR", mappedTo: null }
+ *   - MAPPED_SECRET: JIMBO            -> { key: "MAPPED_SECRET", mappedTo: "JIMBO" }
+ *   - DATABASE_URL: DATABASE_URL      -> { key: "DATABASE_URL", mappedTo: "DATABASE_URL" }
+ */
+export interface ParsedEnvVar {
+    key: string;
+    mappedTo: string | null;
+    oauthName: string | null;
+}
+
+export interface SolidActionsConfig {
+    workflows: { id?: string; name: string; command?: string; file?: string; enabled?: boolean }[];
+    env?: (string | { [key: string]: string | { oauth: string } })[];
+}
+
+/**
+ * Parse a .env file into a key-value map.
+ */
+export function parseEnvFile(filePath: string): Map<string, string> {
+    const envMap = new Map<string, string>();
+
+    if (!fs.existsSync(filePath)) {
+        return envMap;
+    }
+
+    const content = fs.readFileSync(filePath, 'utf8');
+    const lines = content.split('\n');
+
+    for (const line of lines) {
+        const trimmed = line.trim();
+        // Skip empty lines and comments
+        if (!trimmed || trimmed.startsWith('#')) {
+            continue;
+        }
+
+        const equalsIndex = trimmed.indexOf('=');
+        if (equalsIndex === -1) {
+            continue;
+        }
+
+        const key = trimmed.substring(0, equalsIndex).trim();
+        let value = trimmed.substring(equalsIndex + 1).trim();
+
+        // Remove surrounding quotes if present
+        if ((value.startsWith('"') && value.endsWith('"')) ||
+            (value.startsWith("'") && value.endsWith("'"))) {
+            value = value.slice(1, -1);
+        }
+
+        envMap.set(key, value);
+    }
+
+    return envMap;
+}
+
+/**
+ * Parse YAML env declarations into structured format.
+ * Handles the new simplified format:
+ *   - VAR_NAME           -> { key: "VAR_NAME", mappedTo: null }
+ *   - VAR_NAME: GLOBAL   -> { key: "VAR_NAME", mappedTo: "GLOBAL" }
+ */
+export function parseYamlEnvVars(config: SolidActionsConfig): ParsedEnvVar[] {
+    const parsedVars: ParsedEnvVar[] = [];
+
+    if (!config.env || !Array.isArray(config.env)) {
+        return parsedVars;
+    }
+
+    for (const item of config.env) {
+        if (typeof item === 'string') {
+            // Simple string: - VAR_NAME (declared only, needs configuration)
+            parsedVars.push({ key: item, mappedTo: null, oauthName: null });
+        } else if (typeof item === 'object' && item !== null) {
+            // Object: - VAR_NAME: GLOBAL_NAME or - VAR_NAME: { oauth: connection-name }
+            const keys = Object.keys(item);
+            if (keys.length === 1) {
+                const key = keys[0];
+                const value = item[key];
+                if (typeof value === 'object' && value !== null && 'oauth' in value) {
+                    if (typeof value.oauth !== 'string' || !value.oauth) {
+                        throw new Error(`Invalid env config for ${key}: 'oauth' must be a non-empty string`);
+                    }
+                    parsedVars.push({ key, mappedTo: null, oauthName: value.oauth });
+                } else {
+                    parsedVars.push({ key, mappedTo: value || null, oauthName: null });
+                }
+            }
+        }
+    }
+
+    return parsedVars;
+}
+
+/**
+ * Extract declared variable keys from solidactions.yaml env config.
+ * Returns a set of env var keys that are declared in YAML.
+ */
+export function getYamlDeclaredVars(config: SolidActionsConfig): Set<string> {
+    const parsedVars = parseYamlEnvVars(config);
+    return new Set(parsedVars.map(v => v.key));
+}
+
+/**
+ * Load and parse a solidactions.yaml config file.
+ */
+export function loadSolidActionsConfig(yamlPath: string): SolidActionsConfig {
+    const content = fs.readFileSync(yamlPath, 'utf8');
+    return yaml.load(content) as SolidActionsConfig;
+}


### PR DESCRIPTION
## Summary
- Add new `env:push` CLI command to explicitly push `.env` values to a project (replaces implicit `deployEnv` auto-push on deploy)
- Extract shared env helpers (`parseEnvFile`, `parseYamlEnvVars`, etc.) to `src/utils/env.ts`
- Remove `deployEnv`, `isDeployEnvEnabled`, and `pushEnvVars` from deploy command
- Update README and docs with `env:push` documentation

## Test plan
- [x] `npm run build` compiles cleanly
- [x] `env:push` shows diff table and pushes vars to server
- [x] `--new-only` skips existing vars
- [x] `--yes` skips confirmation prompt
- [x] Missing path / 404 project errors handled gracefully
- [x] `solidactions env:push --help` shows correct usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)