### PR TITLE
feat: enrich run list with step details, workflow output, and --has-errors filter

### DIFF
--- a/src/commands/run-list.ts
+++ b/src/commands/run-list.ts
@@ -133,19 +133,25 @@ function displayDetailedList(runsList: any[], projectName?: string) {
 
         // Workflow output
         if (run.output) {
-            console.log('');
-            console.log(chalk.bold('    Output:'));
             const outputStr = JSON.stringify(unwrapOutput(run.output), null, 2);
-            for (const line of outputStr.split('\n')) {
-                console.log(chalk.gray(`      ${line}`));
+            const lines = outputStr.split('\n');
+            if (lines.length === 1) {
+                console.log(`    Output:    ${chalk.gray(truncate(outputStr, 60))}`);
+            } else {
+                console.log(`    Output:`);
+                for (const line of lines.slice(0, 5)) {
+                    console.log(chalk.gray(`      ${line}`));
+                }
+                if (lines.length > 5) {
+                    console.log(chalk.gray(`      ... (${lines.length - 5} more lines)`));
+                }
             }
         }
 
         // Workflow error
         if (run.error) {
-            console.log('');
-            console.log(chalk.bold.red('    Error:'));
-            console.log(chalk.red(`      ${run.error}`));
+            const errMsg = typeof run.error === 'string' ? run.error : JSON.stringify(run.error);
+            console.log(`    ${chalk.bold.red('Error:')}    ${chalk.red(truncate(errMsg, 60))}`);
         }
 
         // Logs snippet (first errors or last 3 lines)
@@ -177,20 +183,24 @@ function displayStepsDetail(steps: any[]) {
     console.log(`    Steps:     ${chalk.gray(summary)}`);
 
     // Per-step detail table
-    console.log(chalk.gray(`      ${'STEP'.padEnd(22)}${'STATUS'.padEnd(12)}${'DURATION'.padEnd(10)}ERROR`));
-    console.log(chalk.gray(`      ${'─'.repeat(66)}`));
+    console.log(chalk.gray(`      ${'NAME'.padEnd(24)}${'STATUS'.padEnd(12)}${'DURATION'.padEnd(10)}OUTPUT`));
+    console.log(chalk.gray(`      ${'─'.repeat(70)}`));
 
     for (const step of steps) {
-        const name = truncate(step.name || '?', 21).padEnd(22);
+        const name = truncate(step.name || '?', 23).padEnd(24);
         const stepStatus = getStepStatus(step);
         const stepStatusColor = getStepStatusColor(stepStatus);
         const duration = formatDuration(step.duration_ms);
-        const error = step.error ? truncate(String(step.error), 30) : '-';
-        const errorColor = step.error ? chalk.red : chalk.gray;
+        const output = step.output ? truncate(JSON.stringify(unwrapOutput(step.output)), 40) : '-';
 
         console.log(
-            `      ${name}${stepStatusColor(stepStatus.padEnd(12))}${chalk.gray(duration.padEnd(10))}${errorColor(error)}`
+            `      ${name}${stepStatusColor(stepStatus.padEnd(12))}${chalk.gray(duration.padEnd(10))}${chalk.gray(output)}`
         );
+
+        if (step.error) {
+            const errMsg = typeof step.error === 'string' ? step.error : JSON.stringify(step.error);
+            console.log(chalk.red(`        error: ${truncate(errMsg, 70)}`));
+        }
     }
 }
 

--- a/src/commands/run-list.ts
+++ b/src/commands/run-list.ts
@@ -9,6 +9,7 @@ interface RunListOptions {
     since?: string;
     workflow?: string;
     detailed?: boolean;
+    hasErrors?: boolean;
     json?: boolean;
 }
 
@@ -28,6 +29,7 @@ export async function runs(projectName?: string, options: RunListOptions = {}) {
         if (options.since) params.since = parseSince(options.since);
         if (options.workflow) params.workflow = options.workflow;
         if (options.detailed) params.detailed = '1';
+        if (options.hasErrors) params.has_errors = '1';
 
         const response = await axios.get(`${config.host}/api/v1/runs`, {
             headers: getApiHeaders(config),
@@ -108,9 +110,11 @@ function displayDetailedList(runsList: any[], projectName?: string) {
         const status = run.execution_status || run.status || '?';
         const statusColor = getStatusColor(status);
         const exitStr = run.exit_code !== null && run.exit_code !== undefined ? ` (exit ${run.exit_code})` : '';
+        const isSilentFailure = hasRunErrors(run) && isSuccessStatus(status);
 
         console.log('');
-        console.log(chalk.bold(`  Run #${run.id}`) + chalk.gray(` — ${run.workflow_name || '?'} (${run.project_name || '?'})`));
+        const silentTag = isSilentFailure ? chalk.yellow(' [DEGRADED]') : '';
+        console.log(chalk.bold(`  Run #${run.id}`) + chalk.gray(` — ${run.workflow_name || '?'} (${run.project_name || '?'})`) + silentTag);
         console.log(`    Status:    ${statusColor(status)}${chalk.gray(exitStr)}`);
         console.log(`    Trigger:   ${chalk.gray(run.triggered_by || '-')}`);
 
@@ -122,11 +126,26 @@ function displayDetailedList(runsList: any[], projectName?: string) {
             console.log(`    Completed: ${chalk.gray(formatTs(run.timeline.completed))}`);
         }
 
-        // Steps summary
+        // Steps detail
         if (run.steps && run.steps.length > 0) {
-            const completed = run.steps.filter((s: any) => s.completed_at || s.completed_at_epoch_ms).length;
-            const totalDuration = run.steps.reduce((sum: number, s: any) => sum + (s.duration_ms || 0), 0);
-            console.log(`    Steps:     ${chalk.gray(`${completed}/${run.steps.length} completed (${formatDuration(totalDuration)} total)`)}`);
+            displayStepsDetail(run.steps);
+        }
+
+        // Workflow output
+        if (run.output) {
+            console.log('');
+            console.log(chalk.bold('    Output:'));
+            const outputStr = JSON.stringify(unwrapOutput(run.output), null, 2);
+            for (const line of outputStr.split('\n')) {
+                console.log(chalk.gray(`      ${line}`));
+            }
+        }
+
+        // Workflow error
+        if (run.error) {
+            console.log('');
+            console.log(chalk.bold.red('    Error:'));
+            console.log(chalk.red(`      ${run.error}`));
         }
 
         // Logs snippet (first errors or last 3 lines)
@@ -134,7 +153,7 @@ function displayDetailedList(runsList: any[], projectName?: string) {
             const lines = run.logs.trim().split('\n');
             const errorLines = lines.filter((l: string) => /error|fail|exception/i.test(l));
             if (errorLines.length > 0) {
-                console.log(`    Errors:`);
+                console.log(`    Logs:`);
                 for (const line of errorLines.slice(0, 3)) {
                     console.log(chalk.red(`      ${truncate(line, 80)}`));
                 }
@@ -146,7 +165,92 @@ function displayDetailedList(runsList: any[], projectName?: string) {
     console.log(chalk.gray(`Showing ${runsList.length} run(s)`));
 }
 
+function displayStepsDetail(steps: any[]) {
+    const completed = steps.filter((s: any) => s.completed_at || s.completed_at_epoch_ms).length;
+    const totalDuration = steps.reduce((sum: number, s: any) => sum + (s.duration_ms || 0), 0);
+    const errorCount = steps.filter((s: any) => s.error || s.status === 'error' || s.status === 'failed').length;
+    const retryCount = steps.filter((s: any) => s.retried || s.status === 'retried').length;
+
+    let summary = `${completed}/${steps.length} completed (${formatDuration(totalDuration)} total)`;
+    if (errorCount > 0) summary += chalk.red(` · ${errorCount} errored`);
+    if (retryCount > 0) summary += chalk.yellow(` · ${retryCount} retried`);
+    console.log(`    Steps:     ${chalk.gray(summary)}`);
+
+    // Per-step detail table
+    console.log(chalk.gray(`      ${'STEP'.padEnd(22)}${'STATUS'.padEnd(12)}${'DURATION'.padEnd(10)}ERROR`));
+    console.log(chalk.gray(`      ${'─'.repeat(66)}`));
+
+    for (const step of steps) {
+        const name = truncate(step.name || '?', 21).padEnd(22);
+        const stepStatus = getStepStatus(step);
+        const stepStatusColor = getStepStatusColor(stepStatus);
+        const duration = formatDuration(step.duration_ms);
+        const error = step.error ? truncate(String(step.error), 30) : '-';
+        const errorColor = step.error ? chalk.red : chalk.gray;
+
+        console.log(
+            `      ${name}${stepStatusColor(stepStatus.padEnd(12))}${chalk.gray(duration.padEnd(10))}${errorColor(error)}`
+        );
+    }
+}
+
 // ─── Utility ───────────────────────────────────────────────────────────────
+
+function unwrapOutput(output: any): any {
+    if (output && output.__solidactions_serializer === 'superjson' && output.json) {
+        return output.json;
+    }
+    return output;
+}
+
+/**
+ * Determine if a run has any errors (step errors, retries, or non-empty error arrays in output).
+ */
+function hasRunErrors(run: any): boolean {
+    // Check step-level errors
+    if (run.steps && run.steps.some((s: any) => s.error || s.status === 'error' || s.status === 'failed' || s.retried || s.status === 'retried')) {
+        return true;
+    }
+    // Check workflow-level error
+    if (run.error) return true;
+    // Check output.errors array
+    const output = unwrapOutput(run.output);
+    if (output && Array.isArray(output.errors) && output.errors.length > 0) return true;
+    return false;
+}
+
+function isSuccessStatus(status: string): boolean {
+    const s = status?.toLowerCase();
+    return s === 'completed' || s === 'success';
+}
+
+function getStepStatus(step: any): string {
+    if (step.status) return step.status;
+    if (step.error) return 'error';
+    if (step.completed_at || step.completed_at_epoch_ms) return 'completed';
+    if (step.started_at || step.started_at_epoch_ms) return 'running';
+    return 'pending';
+}
+
+function getStepStatusColor(status: string): (text: string) => string {
+    switch (status?.toLowerCase()) {
+        case 'completed':
+        case 'success':
+            return chalk.green;
+        case 'running':
+            return chalk.blue;
+        case 'pending':
+        case 'queued':
+            return chalk.yellow;
+        case 'failed':
+        case 'error':
+            return chalk.red;
+        case 'retried':
+            return chalk.yellow;
+        default:
+            return chalk.gray;
+    }
+}
 
 /**
  * Parse --since value into epoch ms.

--- a/src/index.ts
+++ b/src/index.ts
@@ -142,6 +142,7 @@ runCmd
     .option('--since <duration>', 'Filter to runs since (e.g., 1h, 30m, 2d, 1w)')
     .option('--workflow <name>', 'Filter by workflow name')
     .option('--detailed', 'Include timeline, steps, and logs per run (default limit: 5)')
+    .option('--has-errors', 'Show only runs with errors (step errors, retries, or degraded results)')
     .option('--json', 'Output as JSON')
     .action((projectName, options) => {
         runs(projectName, options);


### PR DESCRIPTION
## Summary

Closes SolidActions/solidactions-work#6

- Adds `--has-errors` flag to `run list` that passes `?has_errors=1` to the API, surfacing runs where any step errored/retried, workflow output contains errors, or the run succeeded with degraded results
- Enriches `--detailed` view with per-step detail table (name, status, duration, error) instead of just a summary count
- Displays workflow-level `output` and `error` fields in both human-readable and JSON output
- Adds visual indicators: `[DEGRADED]` tag for silent failures (SUCCESS + errors), red highlighting for errored steps, yellow for retried steps, error/retry counts in summary line

## Test plan

- [ ] Verify `solidactions run list --has-errors` passes `has_errors=1` query param to API
- [ ] Verify `solidactions run list --detailed` shows per-step table with status, duration, error columns
- [ ] Verify `solidactions run list --detailed` shows workflow output and error sections
- [ ] Verify `solidactions run list --detailed --json` includes all enriched fields in JSON output
- [ ] Verify `[DEGRADED]` tag appears on runs with SUCCESS status but step errors/retries
- [ ] Verify errored steps show in red, retried steps show in yellow
- [ ] Verify `npm run build` succeeds with no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)