### PR TITLE
feat: enrich bulk run output with step details, workflow output, and error filtering

### DIFF
--- a/src/commands/run-list.ts
+++ b/src/commands/run-list.ts
@@ -10,6 +10,7 @@ interface RunListOptions {
     workflow?: string;
     detailed?: boolean;
     json?: boolean;
+    hasErrors?: boolean;
 }
 
 export async function runs(projectName?: string, options: RunListOptions = {}) {
@@ -28,6 +29,7 @@ export async function runs(projectName?: string, options: RunListOptions = {}) {
         if (options.since) params.since = parseSince(options.since);
         if (options.workflow) params.workflow = options.workflow;
         if (options.detailed) params.detailed = '1';
+        if (options.hasErrors) params.has_errors = '1';
 
         const response = await axios.get(`${config.host}/api/v1/runs`, {
             headers: getApiHeaders(config),
@@ -122,11 +124,57 @@ function displayDetailedList(runsList: any[], projectName?: string) {
             console.log(`    Completed: ${chalk.gray(formatTs(run.timeline.completed))}`);
         }
 
-        // Steps summary
+        // Steps detail
         if (run.steps && run.steps.length > 0) {
-            const completed = run.steps.filter((s: any) => s.completed_at || s.completed_at_epoch_ms).length;
+            const errorSteps = run.steps.filter((s: any) => s.error);
+            const completedCount = run.steps.filter((s: any) => s.completed_at_epoch_ms).length;
             const totalDuration = run.steps.reduce((sum: number, s: any) => sum + (s.duration_ms || 0), 0);
-            console.log(`    Steps:     ${chalk.gray(`${completed}/${run.steps.length} completed (${formatDuration(totalDuration)} total)`)}`);
+            const summary = `${completedCount}/${run.steps.length} completed (${formatDuration(totalDuration)} total)`;
+            const errorSuffix = errorSteps.length > 0 ? chalk.red(` — ${errorSteps.length} with errors`) : '';
+            console.log(`    Steps:     ${chalk.gray(summary)}${errorSuffix}`);
+
+            console.log(chalk.gray(`      ${'NAME'.padEnd(24)}${'STATUS'.padEnd(12)}${'DURATION'.padEnd(10)}OUTPUT`));
+            console.log(chalk.gray(`      ${'─'.repeat(70)}`));
+
+            for (const step of run.steps) {
+                const name = truncate(step.name || '?', 23).padEnd(24);
+                const stepStatus = step.error ? 'error' : step.completed_at_epoch_ms ? 'completed' : step.started_at_epoch_ms ? 'running' : 'pending';
+                const stepStatusColor = getStatusColor(stepStatus);
+                const duration = formatDuration(step.duration_ms);
+                const output = step.output ? truncate(JSON.stringify(unwrapOutput(step.output)), 40) : '-';
+
+                console.log(
+                    `      ${name}${stepStatusColor(stepStatus.padEnd(12))}${chalk.gray(duration.padEnd(10))}${chalk.gray(output)}`
+                );
+
+                if (step.error) {
+                    const errMsg = typeof step.error === 'string' ? step.error : JSON.stringify(step.error);
+                    console.log(chalk.red(`        error: ${truncate(errMsg, 70)}`));
+                }
+            }
+        }
+
+        // Workflow output
+        if (run.output) {
+            const outputStr = JSON.stringify(unwrapOutput(run.output), null, 2);
+            const lines = outputStr.split('\n');
+            if (lines.length === 1) {
+                console.log(`    Output:    ${chalk.gray(truncate(outputStr, 60))}`);
+            } else {
+                console.log(`    Output:`);
+                for (const line of lines.slice(0, 5)) {
+                    console.log(chalk.gray(`      ${line}`));
+                }
+                if (lines.length > 5) {
+                    console.log(chalk.gray(`      ... (${lines.length - 5} more lines)`));
+                }
+            }
+        }
+
+        // Workflow error
+        if (run.error) {
+            const errMsg = typeof run.error === 'string' ? run.error : JSON.stringify(run.error);
+            console.log(`    ${chalk.bold.red('Error:')}    ${chalk.red(truncate(errMsg, 60))}`);
         }
 
         // Logs snippet (first errors or last 3 lines)
@@ -134,7 +182,7 @@ function displayDetailedList(runsList: any[], projectName?: string) {
             const lines = run.logs.trim().split('\n');
             const errorLines = lines.filter((l: string) => /error|fail|exception/i.test(l));
             if (errorLines.length > 0) {
-                console.log(`    Errors:`);
+                console.log(`    Log errors:`);
                 for (const line of errorLines.slice(0, 3)) {
                     console.log(chalk.red(`      ${truncate(line, 80)}`));
                 }
@@ -181,6 +229,13 @@ function formatDuration(ms: number | null): string {
 function truncate(str: string, max: number): string {
     if (str.length <= max) return str;
     return str.substring(0, max - 3) + '...';
+}
+
+function unwrapOutput(output: any): any {
+    if (output && output.__solidactions_serializer === 'superjson' && output.json) {
+        return output.json;
+    }
+    return output;
 }
 
 function getStatusColor(status: string): (text: string) => string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -142,6 +142,7 @@ runCmd
     .option('--since <duration>', 'Filter to runs since (e.g., 1h, 30m, 2d, 1w)')
     .option('--workflow <name>', 'Filter by workflow name')
     .option('--detailed', 'Include timeline, steps, and logs per run (default limit: 5)')
+    .option('--has-errors', 'Show only runs with step errors or run-level errors')
     .option('--json', 'Output as JSON')
     .action((projectName, options) => {
         runs(projectName, options);


### PR DESCRIPTION
## Summary

- **Step-level detail in `--detailed` output**: each step now shows status (completed/running/error/pending), output preview, error messages, and duration — previously only showed name and timing
- **Workflow output in `--detailed` output**: the run's return value and error are now displayed in both human-readable and JSON output
- **`--has-errors` filter**: new flag passes `?has_errors=1` to the API, surfacing runs with step errors or run-level errors (catches silent failures where status is SUCCESS but steps have errors)

Depends on SolidActions/solidactions-app#59 which adds the enriched fields to the API response.

Closes SolidActions/solidactions-app#61

## Test plan

- [ ] `solidactions run list --detailed` shows per-step status, output preview, error messages
- [ ] `solidactions run list --detailed --json` includes output/error per step and run-level output/error
- [ ] `solidactions run list --has-errors` only returns runs with errors
- [ ] `solidactions run list --has-errors --detailed` combines both flags correctly
- [ ] Existing `run list` behavior unchanged (summary table, basic flags)

🤖 Generated with [Claude Code](https://claude.com/claude-code)