### PR TITLE
feat: install AI skills during ai-init (v1.4.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,16 @@ Use `solidactions <command> --help` for full flag details on any command.
 
 | Command | Key Flags | Description |
 |---------|-----------|-------------|
-| `ai init` | `--claude`, `--agents` | Install AI helper docs |
+| `ai init` | `--claude`, `--agents`, `--no-skills` | Install AI helper docs |
 | `ai examples [names...]` | `--all`, `--overwrite` | Install example workflows |
+
+By default, `ai init` also installs three lazy-loaded SolidActions skills
+into `.claude/skills/`. These activate automatically when you scaffold a
+project, write workflow code, or deploy. The CLAUDE.md injection becomes
+a slim pointer to keep always-loaded context light.
+
+Pass `--no-skills` to skip the skill install and get the legacy full
+CLAUDE.md content instead.
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solidactions/cli",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "description": "SolidActions CLI - Deploy and manage workflow automation",
     "main": "dist/index.js",
     "bin": {

--- a/src/commands/ai-init.ts
+++ b/src/commands/ai-init.ts
@@ -2,12 +2,15 @@ import fs from 'fs';
 import chalk from 'chalk';
 import prompts from 'prompts';
 import fsExtra from 'fs-extra';
+import path from 'path';
 import { fetchRawFile } from '../utils/github';
 import { upsertMarkerSection } from '../utils/markers';
+import { detectSkillTargets, installSkills, fetchClaudeMdContent } from '../utils/skills';
 
 interface AiInitOptions {
     claude?: boolean;
     agents?: boolean;
+    skills?: boolean;  // commander auto-negates --no-skills into skills: false
 }
 
 export async function aiInit(options: AiInitOptions = {}) {
@@ -43,18 +46,54 @@ export async function aiInit(options: AiInitOptions = {}) {
             targetFile = response.file;
         }
 
+        // Decide whether to install skills (default true; --no-skills opts out)
+        const installSkillsEnabled = options.skills !== false;
+
+        // Determine skill targets if installing.
+        // Skills are Claude Code-specific (.claude/skills/) and not meaningful for other AI tools.
+        let skillTargets: string[] = [];
+        if (installSkillsEnabled && targetFile === 'CLAUDE.md') {
+            skillTargets = detectSkillTargets();
+            if (skillTargets.length === 0) {
+                const resp = await prompts({
+                    type: 'confirm',
+                    name: 'create',
+                    message: 'No `.claude/` directory found. Create `.claude/skills/` for SolidActions skills?',
+                    initial: true,
+                });
+                if (resp.create === undefined) {
+                    // User cancelled (Ctrl+C) — treat as abort, not decline
+                    console.log(chalk.yellow('Cancelled.'));
+                    process.exit(0);
+                } else if (resp.create) {
+                    skillTargets = [path.join(process.cwd(), '.claude', 'skills')];
+                } else {
+                    console.log(chalk.yellow('Skipping skill install. Run with --no-skills to silence this prompt.'));
+                }
+            }
+        }
+
         console.log(chalk.blue('Fetching AI helper content...'));
 
-        // Fetch AI helper content from examples repo
-        const aiContent = await fetchRawFile('SolidActions', 'solidactions-examples', 'CLAUDE.md');
+        // Fetch CLAUDE.md content (slim pointer if skills installed, else full)
+        const aiContent = await fetchClaudeMdContent(skillTargets.length > 0);
 
-        // Fetch SDK reference
+        // Fetch SDK reference (always)
         const sdkContent = await fetchRawFile('SolidActions', 'solidactions-ts-sdk', 'docs/sdk-reference.md');
 
         // Save SDK reference to .solidactions/sdk-reference.md
         fsExtra.ensureDirSync('.solidactions');
         fs.writeFileSync('.solidactions/sdk-reference.md', sdkContent, 'utf8');
         console.log(chalk.green('✓ SDK reference saved to .solidactions/sdk-reference.md'));
+
+        // Install skills if enabled and targets exist
+        if (skillTargets.length > 0) {
+            console.log(chalk.blue('Installing SolidActions skills...'));
+            const { written } = await installSkills(skillTargets);
+            for (const f of written) {
+                console.log(chalk.green(`✓ ${path.relative(process.cwd(), f)}`));
+            }
+        }
 
         // Upsert main AI helper section
         upsertMarkerSection(targetFile, 'SolidActions', aiContent);

--- a/src/index.ts
+++ b/src/index.ts
@@ -349,6 +349,7 @@ ai
     .description('Install AI helper documentation (CLAUDE.md or AGENTS.md) for AI-assisted workflow development')
     .option('--claude', 'Use CLAUDE.md (for Claude Code)')
     .option('--agents', 'Use AGENTS.md (for Cursor, Windsurf, etc.)')
+    .option('--no-skills', 'Skip installing SolidActions skill files (uses legacy full CLAUDE.md injection)')
     .action((options) => { aiInit(options); });
 
 ai

--- a/src/utils/skills.ts
+++ b/src/utils/skills.ts
@@ -1,0 +1,72 @@
+import fs from 'fs';
+import path from 'path';
+import fsExtra from 'fs-extra';
+import { fetchRawFile } from './github';
+
+const SKILL_NAMES = [
+    'solidactions-getting-started',
+    'solidactions-workflow-coding',
+    'solidactions-deploy-and-config',
+] as const;
+
+const EXAMPLES_OWNER = 'SolidActions';
+const EXAMPLES_REPO = 'solidactions-examples';
+const SKILLS_PATH_PREFIX = 'skills';
+
+/**
+ * Detect which AI-tool skill directories should receive skills.
+ * Returns absolute paths to the target skills/ subdirectories.
+ *
+ * v1 supports Claude Code only. Codex was resolved as user-global
+ * (~/.codex/skills) with no project-local equivalent, so it is
+ * intentionally NOT a target here.
+ *
+ * Detection rules:
+ * - If `.claude/` exists in cwd → include `.claude/skills/`
+ * - If neither exists → return empty (caller should prompt)
+ */
+export function detectSkillTargets(cwd: string = process.cwd()): string[] {
+    const targets: string[] = [];
+    if (fs.existsSync(path.join(cwd, '.claude'))) {
+        targets.push(path.join(cwd, '.claude', 'skills'));
+    }
+    return targets;
+}
+
+/**
+ * Fetch all SolidActions skill files from the examples repo and write
+ * them into each target directory. Overwrites existing files (skills
+ * are versioned upstream).
+ */
+export async function installSkills(targetDirs: string[]): Promise<{ written: string[] }> {
+    const written: string[] = [];
+
+    for (const dir of targetDirs) {
+        fsExtra.ensureDirSync(dir);
+    }
+
+    for (const skillName of SKILL_NAMES) {
+        const remotePath = `${SKILLS_PATH_PREFIX}/${skillName}.md`;
+        const content = await fetchRawFile(EXAMPLES_OWNER, EXAMPLES_REPO, remotePath);
+
+        for (const dir of targetDirs) {
+            const filePath = path.join(dir, `${skillName}.md`);
+            fs.writeFileSync(filePath, content, 'utf8');
+            written.push(filePath);
+        }
+    }
+
+    return { written };
+}
+
+/**
+ * Pick the right CLAUDE.md content variant from the examples repo
+ * based on whether skills are being installed.
+ *
+ * - skillsInstalled = true  → fetches CLAUDE-skills-pointer.md (slim)
+ * - skillsInstalled = false → fetches CLAUDE.md (full, legacy)
+ */
+export async function fetchClaudeMdContent(skillsInstalled: boolean): Promise<string> {
+    const file = skillsInstalled ? 'CLAUDE-skills-pointer.md' : 'CLAUDE.md';
+    return fetchRawFile(EXAMPLES_OWNER, EXAMPLES_REPO, file);
+}


### PR DESCRIPTION
## Summary

- Extends `solidactions ai init` to fetch + install 3 lazy-loaded AI skills into `.claude/skills/` by default
- Slims the CLAUDE.md injection to a thin pointer when skills are installed (heavy content moves into on-demand skills)
- Adds `--no-skills` flag for opt-out — preserves the legacy full-CLAUDE.md injection
- Skill content lives in `solidactions-examples/skills/` (merged in SolidActions/solidactions-examples#3)
- Bumps version 1.3.0 → 1.4.0

## Design

- **New `src/utils/skills.ts`** — `detectSkillTargets`, `installSkills`, `fetchClaudeMdContent`. Single clear responsibility, uses existing `fetchRawFile` + `fsExtra` patterns.
- **Claude Code only in v1.** Codex was resolved as user-global only (`~/.codex/skills`) with no project-local equivalent. Supporting Codex would require a different install strategy (user-level, not per-project) and is deferred.
- **Skills probe/prompt gated on `targetFile === 'CLAUDE.md'`.** `--agents` users (Cursor/Windsurf) get legacy AGENTS.md content unchanged — no meaningless `.claude/skills/` prompt.
- **Ctrl+C during prompt** exits cleanly (matches existing file-type prompt pattern) instead of showing misleading opt-out guidance.

## Test plan

Ran each in a fresh tmp dir against the `feat/ai-skills` branch of solidactions-examples (now merged to `main`):

- [x] `ai init --claude` (with `.claude/` present) — 3 skills fetched, slim CLAUDE.md (19 lines) injected, `.solidactions/sdk-reference.md` written
- [x] `ai init --claude --no-skills` — no skills written, full CLAUDE.md (1200 lines) injected
- [x] `ai init --agents` (no `.claude/`) — no prompt shown, no skill fetch, full AGENTS.md (1200 lines) injected
- [x] Re-run idempotency — same line count, 2 marker pairs (not 4), skills overwritten cleanly

## Spec / Plan

- Spec: https://github.com/SolidActions/solidactions-app/blob/main/docs/superpowers/specs/2026-04-15-ai-skills-design.md
- Plan: https://github.com/SolidActions/solidactions-app/blob/main/docs/superpowers/plans/2026-04-15-issue-93-ai-skills.md
- Closes the CLI side of SolidActions/solidactions-app#93

🤖 Generated with [Claude Code](https://claude.com/claude-code)