### PR TITLE
feat: require -e on first deploy of a new project (v1.5.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@solidactions/cli",
-    "version": "1.4.0",
+    "version": "1.5.0",
     "description": "SolidActions CLI - Deploy and manage workflow automation",
     "main": "dist/index.js",
     "bin": {

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -138,12 +138,55 @@ export async function deploy(projectName: string, sourcePath?: string, options: 
     const config = await requireConfigWithWorkspace();
 
     const sourceDir = sourcePath ? path.resolve(sourcePath) : process.cwd();
-    const environment = options.env || 'dev';
+
+    // Capture whether -e was explicitly passed by the caller. Commander leaves
+    // options.env as undefined when no default is set and the flag is omitted.
+    const explicitEnv: string | undefined = options.env;
 
     if (!fs.existsSync(sourceDir)) {
         console.error(chalk.red(`Source directory not found: ${sourceDir}`));
         process.exit(1);
     }
+
+    // -------------------------------------------------------------------------
+    // Production-existence check — must happen BEFORE we apply any env default
+    // so that first-time deploys without -e get a helpful error instead of
+    // silently creating a dev-only project with no production root.
+    // -------------------------------------------------------------------------
+    let productionExists: boolean | null = null; // null = unknown (error path)
+    let productionSlug: string | null = null;
+
+    try {
+        const prodResponse = await axios.get(`${config.host}/api/v1/projects/${projectName}`, {
+            headers: getApiHeaders(config),
+        });
+        productionExists = true;
+        productionSlug = prodResponse.data.slug || prodResponse.data.name;
+    } catch (error: any) {
+        if (error.response?.status === 404) {
+            productionExists = false;
+        } else {
+            // 5xx, network error, auth failure, etc. — fail conservatively rather
+            // than treating the project as non-existent and potentially creating it.
+            console.error(chalk.red('Failed to check project existence:'), error.response?.data?.message || error.message);
+            process.exit(1);
+        }
+    }
+
+    // Decision: if production does not exist and no -e flag was given, the user
+    // must pick an environment explicitly to avoid creating a broken dev-only project.
+    if (productionExists === false && explicitEnv === undefined) {
+        console.error(chalk.red(`\nThis is the first deploy of "${projectName}" — please pick an environment explicitly:\n`));
+        console.error(`  solidactions project deploy ${projectName} <path> -e production    # most projects start here`);
+        console.error(`  solidactions project deploy ${projectName} <path> -e dev            # dev-only (uncommon; no production root will exist)`);
+        console.error(`  solidactions project deploy ${projectName} <path> -e staging        # staging-only (uncommon)`);
+        console.error(chalk.gray('\nTip: most projects should start with `-e production`. A project needs a production root before dev/staging children can attach to it.'));
+        process.exit(1);
+    }
+
+    // Apply default: if production already exists and the user didn't pass -e,
+    // use 'dev' — this preserves existing behavior for mature projects.
+    const environment = explicitEnv ?? 'dev';
 
     const envLabel = environment !== 'production' ? ` (${environment})` : '';
     console.log(chalk.blue(`Deploying to project "${projectName}"${envLabel}...`));
@@ -180,24 +223,35 @@ export async function deploy(projectName: string, sourcePath?: string, options: 
 
     console.log(chalk.green('✓ Project structure validated'));
 
-    // Check if project exists, create if not
+    // Check if the target environment's project record exists; create if needed.
+    // For production deploys where we already confirmed existence above, reuse
+    // the cached slug to avoid a duplicate GET.
     let projectSlug = projectName;
     try {
-        // For non-production environments, append the environment to the slug for lookup
-        const lookupSlug = environment === 'production'
-            ? projectName
-            : `${projectName}-${environment}`;
+        if (environment === 'production' && productionExists === true && productionSlug !== null) {
+            // Already confirmed — skip the re-lookup.
+            projectSlug = productionSlug;
+        } else {
+            // For non-production environments, append the environment to the slug for lookup
+            const lookupSlug = environment === 'production'
+                ? projectName
+                : `${projectName}-${environment}`;
 
-        const checkResponse = await axios.get(`${config.host}/api/v1/projects/${lookupSlug}`, {
-            headers: getApiHeaders(config),
-        });
-        projectSlug = checkResponse.data.slug || checkResponse.data.name;
+            const checkResponse = await axios.get(`${config.host}/api/v1/projects/${lookupSlug}`, {
+                headers: getApiHeaders(config),
+            });
+            projectSlug = checkResponse.data.slug || checkResponse.data.name;
+        }
     } catch (error: any) {
         if (error.response?.status === 404) {
-            // For non-production environments, check if we should create
+            // For non-production environments, require --create or give a clear hint
             if (environment !== 'production' && !options.create) {
-                console.log(chalk.yellow(`Project "${projectName}" doesn't have a ${environment} environment.`));
-                console.log(chalk.gray('Use --create to create it, or deploy to production first.'));
+                console.error(chalk.red(`\nProject "${projectName}" doesn't have a ${environment} environment.\n`));
+                console.error(`  If production is the intended target:`);
+                console.error(`    solidactions project deploy ${projectName} <path> -e production`);
+                console.error('');
+                console.error(`  If you really want a new ${environment} environment:`);
+                console.error(`    solidactions project deploy ${projectName} <path> -e ${environment} --create`);
                 process.exit(1);
             }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,7 +108,7 @@ project
     .description('Deploy a project to SolidActions')
     .argument('<project-name>', 'Project name (will be created if it doesn\'t exist)')
     .argument('[path]', 'Source directory to deploy (defaults to current directory)')
-    .option('-e, --env <environment>', 'Target environment (production/staging/dev)', 'dev')
+    .option('-e, --env <environment>', 'Target environment (production/staging/dev). Required on first deploy of a new project.')
     .option('--create', 'Create environment project if it doesn\'t exist')
     .option('--config-only', 'Sync YAML env declarations without building/deploying')
     .action((projectName, path, options) => {


### PR DESCRIPTION
## Summary

Prevents the failure mode surfaced in Phase 3 validation of SolidActions/solidactions-app#93 (scenario 7): AIs running bare `solidactions project deploy X .` on new projects silently created dev-only projects with no production root, violating the platform's "production must exist first" invariant.

## Changes

**`src/commands/deploy.ts`** — adds an upfront project-existence check before any `-e` default is applied:
- GET `${host}/api/v1/projects/${projectName}` (production slug) before applying default.
- 404 + no explicit `-e` → new error listing env choices and recommending `-e production`.
- 200 → caches `productionSlug`, skips the later redundant lookup for `-e production` deploys.
- Any other error (5xx, network, auth) → fails conservatively instead of assuming non-existence.
- Existing `-e dev` default preserved for mature projects (production already exists, `-e` omitted).
- "Target env doesn't exist" error rewritten to lead with existing env, demote `--create`.

**`src/index.ts`** — `-e, --env` option registration: removed hardcoded `'dev'` default; description updated to note it's required on first deploy.

**`package.json`** — bumped `1.4.0 → 1.5.0` (minor, additive — no breaking changes to existing deploy invocations with explicit `-e`).

## New error on first deploy without `-e`

```
This is the first deploy of "my-project" — please pick an environment explicitly:

  solidactions project deploy my-project <path> -e production    # most projects start here
  solidactions project deploy my-project <path> -e dev            # dev-only (uncommon; no production root will exist)
  solidactions project deploy my-project <path> -e staging        # staging-only (uncommon)

Tip: most projects should start with `-e production`. A project needs a production root before dev/staging children can attach to it.
```

## Improved error when target env doesn't exist

Old:
```
Project "X" doesn't have a dev environment.
Use --create to create it, or deploy to production first.
```

New:
```
Project "X" doesn't have a dev environment.

  If production is the intended target:
    solidactions project deploy X <path> -e production

  If you really want a new dev environment:
    solidactions project deploy X <path> -e dev --create
```

## Test plan

- [x] Build passes (`npm run build`)
- [x] Help output: `-e, --env` no longer shows a default
- [ ] Integration: bare `project deploy NEW_PROJECT .` → new first-deploy error (requires server reachability)
- [ ] Integration: `project deploy EXISTING_PROJECT .` (bare) → defaults to dev as before
- [ ] Integration: `project deploy EXISTING_PROJECT . -e dev` when only production exists → new error message
- [ ] Re-run Phase 3 scenario 7 after this merges, confirm AI gets nudged to `-e production`

Tracking: SolidActions/solidactions-app#93

🤖 Generated with [Claude Code](https://claude.com/claude-code)