### PR TITLE
chore: drop 'Pica' word from snippet renderer JSDoc + bump 1.10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solidactions/cli",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "SolidActions CLI - Deploy and manage workflow automation",
   "main": "dist/index.js",
   "bin": {

--- a/src/commands/oauth-actions-show.ts
+++ b/src/commands/oauth-actions-show.ts
@@ -178,7 +178,7 @@ function indent(text: string, prefix = '  '): string {
 /**
  * Defense-in-depth: even though the SAA API sanitizes `Authorization`,
  * `x-pica-*`, and `x-one-*` out of `ioExample.input.headers` before serving,
- * filter them again here so any future drift can't leak Pica internals into
+ * filter them again here so any future drift can't leak proxy internals into
  * a workflow's outbound request.
  */
 function isProxyManagedHeader(name: string): boolean {


### PR DESCRIPTION
Tiny cleanup: the JSDoc on `isProxyManagedHeader` said 'Pica internals'. Neutralized to 'proxy internals'. Header literal prefixes (`x-pica-*`) stay since those are real identifiers. No behavior change.