### PR TITLE
fix(deploy): use requested slug as fallback when create response omits it (1.10.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solidactions/cli",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "SolidActions CLI - Deploy and manage workflow automation",
   "main": "dist/index.js",
   "bin": {

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -277,15 +277,23 @@ export async function deploy(projectName: string, sourcePath?: string, options: 
             }
 
             console.log(chalk.yellow(`Project "${projectName}"${envLabel} not found. Creating...`));
+            const requestedSlug = projectName.toLowerCase().replace(/[^a-z0-9-]/g, '-') + (environment !== 'production' ? `-${environment}` : '');
             try {
                 const createResponse = await axios.post(`${config.host}/api/v1/projects`, {
                     name: projectName,
-                    slug: projectName.toLowerCase().replace(/[^a-z0-9-]/g, '-') + (environment !== 'production' ? `-${environment}` : ''),
+                    slug: requestedSlug,
                     environment: environment,
                 }, {
                     headers: getApiHeaders(config, 'application/json'),
                 });
-                projectSlug = createResponse.data.slug || createResponse.data.name;
+                // Fallback chain: prefer the server-echoed slug; if absent, use the slug we
+                // *requested* in the POST body (server stored that value). Falling back to
+                // `name` strips the env suffix and causes the polling GET to 404 with
+                // "Project 'X' not found in your active workspace 'Y'.".
+                projectSlug = createResponse.data.slug || requestedSlug;
+                if (process.env.SOLIDACTIONS_DEPLOY_DEBUG === '1') {
+                    process.stderr.write(`[deploy-debug] requestedSlug=${requestedSlug} responseSlug=${createResponse.data.slug ?? '(missing)'} responseName=${createResponse.data.name ?? '(missing)'} resolvedSlug=${projectSlug}\n`);
+                }
                 console.log(chalk.green(`Project "${projectName}"${envLabel} created.`));
             } catch (createError: any) {
                 console.error(chalk.red('Failed to create project:'), createError.response?.data?.message || createError.message);
@@ -321,6 +329,9 @@ export async function deploy(projectName: string, sourcePath?: string, options: 
             form.append('source', fs.createReadStream(archivePath));
 
             console.log(chalk.yellow('Uploading...'));
+            if (process.env.SOLIDACTIONS_DEPLOY_DEBUG === '1') {
+                process.stderr.write(`[deploy-debug] POST ${config.host}/api/v1/projects/${projectSlug}/deploy (workspace=${config.workspaceId ?? '(none)'})\n`);
+            }
 
             await axios.post(`${config.host}/api/v1/projects/${projectSlug}/deploy`, form, {
                 headers: {
@@ -333,6 +344,9 @@ export async function deploy(projectName: string, sourcePath?: string, options: 
 
             console.log(chalk.green('Deployment successfully queued!'));
             console.log(chalk.yellow('Waiting for build to complete...\n'));
+            if (process.env.SOLIDACTIONS_DEPLOY_DEBUG === '1') {
+                process.stderr.write(`[deploy-debug] poll URL = ${config.host}/api/v1/projects/${projectSlug} (workspace=${config.workspaceId ?? '(none)'})\n`);
+            }
 
             // Poll for completion
             let attempts = 0;


### PR DESCRIPTION
## Investigation summary

[SAA e2e regression report](https://github.com/SolidActions/solidactions-app) (PR #153 onward, every run failing identically): \`solidactions project deploy <name> --create -e dev\` succeeds at creating the project + uploading the archive, then build-poll 404s with \"Project 'X' not found in your active workspace 'Y'.\".

**The CLI diff between v1.9.0 and v1.10.1 is bit-clean for all deploy code:**

\`\`\`
$ git diff v1.9.0..v1.10.1 -- src/commands/deploy.ts src/utils/api.ts src/utils/config.ts src/commands/workspaces.ts package-lock.json
(empty — 0 lines changed)
\`\`\`

The CLI cannot have introduced a regression in code paths it didn't touch. v1.10.x's diff is purely additive in the new \`oauth-actions\` namespace. So this PR is **not a regression revert** — it's a defensive improvement that addresses a latent bug in deploy.ts which happens to produce exactly the observed symptom whenever the server's create response omits the \`slug\` field.

## The latent bug

\`\`\`ts
projectSlug = createResponse.data.slug || createResponse.data.name;
\`\`\`

If \`data.slug\` is missing/empty, this falls back to \`data.name\` — which equals \`projectName\` (e.g. \`\"sdk-test\"\`), stripping the env suffix that the CLI itself just stored on the server (e.g. \`\"sdk-test-dev\"\`). The subsequent build-poll GET \`/api/v1/projects/sdk-test\` then 404s with the workspace-mismatch message, even though the project exists at \`sdk-test-dev\` in the same workspace.

## Fix

Extract the slug the CLI sends in the POST body to a \`requestedSlug\` const and use it as the fallback. This is what the server actually stored regardless of how the response shape changes downstream.

## Diagnostic logging

Adds opt-in \`SOLIDACTIONS_DEPLOY_DEBUG=1\` env var that logs to stderr:
- \`[deploy-debug] requestedSlug=… responseSlug=… responseName=… resolvedSlug=…\` after create
- \`[deploy-debug] POST <url>\` before upload
- \`[deploy-debug] poll URL = <url>\` before polling loop

If this fix doesn't resolve the SAA e2e failure, set \`SOLIDACTIONS_DEPLOY_DEBUG=1\` in the workflow and the next failed run will surface the resolved slug and full polling URL — eliminates guesswork.

## Important caveat for SAA team

If the e2e is *still* failing after v1.10.2 ships, the root cause is server-side (project not actually being stored in the active workspace, or some workspace-context drift between create and poll on the SAA backend). The CLI fix is opportunistic — it makes the CLI more robust to a server response shape change, but it can't fix a true server-side workspace assignment bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)