### PR TITLE
chore: bump 1.10.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solidactions/cli",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "description": "SolidActions CLI - Deploy and manage workflow automation",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
Patch release pairing the skill rename merged in #28. No behavior change at the CLI surface — `solidactions ai init` still works the same; just fetches the new `solidactions-oauth-actions.md` filename.