### PR TITLE
feat(run-list): distinguish recovered/degraded runs in the summary table

### DIFF
--- a/src/commands/run-list.ts
+++ b/src/commands/run-list.ts
@@ -74,6 +74,32 @@ export async function runs(projectName?: string, options: RunListOptions = {}) {
 
 // ─── Display modes ─────────────────────────────────────────────────────────
 
+/**
+ * Summary-table status label for a run. Recovered/degraded runs share SUCCESS's
+ * execution_status, so without this they'd be indistinguishable from a clean success in
+ * the summary view. Returns the label to display and whether it's an "attention" outcome
+ * (rendered yellow). Falls back to the raw status for servers that don't send `outcome`.
+ */
+export function summaryStatusLabel(run: { outcome?: string; execution_status?: string; status?: string }): {
+    label: string;
+    attention: boolean;
+} {
+    if (run.outcome === 'recovered') return { label: 'recovered', attention: true };
+    if (run.outcome === 'degraded') return { label: 'degraded', attention: true };
+    return { label: run.execution_status || run.status || '?', attention: false };
+}
+
+/**
+ * Detailed-view tag appended to a run header ('' when none). Prefers the API `outcome`;
+ * falls back to the local hasRunErrors heuristic for servers that don't send `outcome`.
+ */
+export function detailedOutcomeTag(run: any): string {
+    if (run.outcome === 'recovered') return ' [RECOVERED]';
+    if (run.outcome === 'degraded') return ' [DEGRADED]';
+    if (hasRunErrors(run) && isSuccessStatus(run.execution_status || run.status || '')) return ' [DEGRADED]';
+    return '';
+}
+
 function displaySummaryTable(runsList: any[], projectName?: string) {
     const header = projectName ? `Recent runs for "${projectName}":` : 'Recent runs:';
     console.log(chalk.blue(header));
@@ -84,8 +110,8 @@ function displaySummaryTable(runsList: any[], projectName?: string) {
     for (const run of runsList) {
         const id = String(run.id || '?').padEnd(8);
         const workflow = truncate(run.workflow_name || '?', 24).padEnd(25);
-        const status = run.execution_status || run.status || '?';
-        const statusColor = getStatusColor(status);
+        const { label: status, attention } = summaryStatusLabel(run);
+        const statusColor = attention ? chalk.yellow : getStatusColor(status);
         const triggeredAt = run.triggered_at ? new Date(run.triggered_at).toLocaleString() : '-';
         const triggeredBy = run.triggered_by || '-';
 
@@ -110,10 +136,10 @@ function displayDetailedList(runsList: any[], projectName?: string) {
         const status = run.execution_status || run.status || '?';
         const statusColor = getStatusColor(status);
         const exitStr = run.exit_code !== null && run.exit_code !== undefined ? ` (exit ${run.exit_code})` : '';
-        const isSilentFailure = hasRunErrors(run) && isSuccessStatus(status);
 
         console.log('');
-        const silentTag = isSilentFailure ? chalk.yellow(' [DEGRADED]') : '';
+        const outcomeTag = detailedOutcomeTag(run);
+        const silentTag = outcomeTag ? chalk.yellow(outcomeTag) : '';
         console.log(chalk.bold(`  Run #${run.id}`) + chalk.gray(` — ${run.workflow_name || '?'} (${run.project_name || '?'})`) + silentTag);
         console.log(`    Status:    ${statusColor(status)}${chalk.gray(exitStr)}`);
         console.log(`    Trigger:   ${chalk.gray(run.triggered_by || '-')}`);

--- a/tests/run-list.test.ts
+++ b/tests/run-list.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { detailedOutcomeTag, summaryStatusLabel } from '../src/commands/run-list';
+
+describe('summaryStatusLabel', () => {
+    it('labels a recovered run as an attention "recovered"', () => {
+        expect(summaryStatusLabel({ outcome: 'recovered', execution_status: 'SUCCESS' }))
+            .toEqual({ label: 'recovered', attention: true });
+    });
+
+    it('labels a degraded run as an attention "degraded"', () => {
+        expect(summaryStatusLabel({ outcome: 'degraded', execution_status: 'SUCCESS' }))
+            .toEqual({ label: 'degraded', attention: true });
+    });
+
+    it('shows the raw execution_status (no attention) for a clean success', () => {
+        expect(summaryStatusLabel({ outcome: 'success', execution_status: 'SUCCESS' }))
+            .toEqual({ label: 'SUCCESS', attention: false });
+    });
+
+    it('shows the raw status (no attention) for a hard failure', () => {
+        expect(summaryStatusLabel({ outcome: 'failed', execution_status: 'ERROR' }))
+            .toEqual({ label: 'ERROR', attention: false });
+    });
+
+    it('falls back to execution_status when outcome is absent (older server)', () => {
+        expect(summaryStatusLabel({ execution_status: 'RUNNING' }))
+            .toEqual({ label: 'RUNNING', attention: false });
+    });
+
+    it('falls back to status, then "?", when execution_status is missing', () => {
+        expect(summaryStatusLabel({ status: 'pending' })).toEqual({ label: 'pending', attention: false });
+        expect(summaryStatusLabel({})).toEqual({ label: '?', attention: false });
+    });
+});
+
+describe('detailedOutcomeTag', () => {
+    it('tags a recovered run [RECOVERED]', () => {
+        expect(detailedOutcomeTag({ outcome: 'recovered' })).toBe(' [RECOVERED]');
+    });
+
+    it('tags a degraded run [DEGRADED]', () => {
+        expect(detailedOutcomeTag({ outcome: 'degraded' })).toBe(' [DEGRADED]');
+    });
+
+    it('returns no tag for a clean success or a hard failure', () => {
+        expect(detailedOutcomeTag({ outcome: 'success', execution_status: 'SUCCESS' })).toBe('');
+        expect(detailedOutcomeTag({ outcome: 'failed', execution_status: 'ERROR' })).toBe('');
+    });
+
+    it('falls back to the local heuristic ([DEGRADED]) for older servers: a success with step errors', () => {
+        const run = {
+            execution_status: 'SUCCESS',
+            steps: [{ name: 'a', error: '{"message":"boom"}' }],
+        };
+        expect(detailedOutcomeTag(run)).toBe(' [DEGRADED]');
+    });
+
+    it('returns no tag for an older-server clean success with no error evidence', () => {
+        expect(detailedOutcomeTag({ execution_status: 'SUCCESS', steps: [{ name: 'a', error: null }] })).toBe('');
+    });
+});


### PR DESCRIPTION
## What

Surfaces the new `outcome` field from the SolidActions API (`/api/v1/runs`) in `solidactions run list`:

- **Summary table:** recovered/degraded runs — previously shown as plain `SUCCESS`, indistinguishable from a clean success — now render as yellow `recovered` / `degraded` labels.
- **Detailed view:** tags runs `[RECOVERED]` / `[DEGRADED]`, driven by the API `outcome` (previously a local `hasRunErrors` heuristic only).

Implemented as two pure exported helpers (`summaryStatusLabel`, `detailedOutcomeTag`) with unit tests; falls back to the raw status for older API servers that don't send `outcome`.

## Companion change

The API side — the derived `outcome` (`failed`/`recovered`/`degraded`/`success`) + `had_errors` on `/api/v1/runs` — ships in `solidactions-app` **PR #227**. This CLI change is backward-compatible and degrades gracefully against an older API.

## Tests

`tests/run-list.test.ts` — **11 passing** (`npx vitest run tests/run-list.test.ts`); `tsc` build clean. The rest of the suite is green except the pre-existing, unrelated `dev.test.ts` failures (missing `@solidactions/sdk` link in a fresh checkout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
