### PR TITLE
fix(skill-push): recursively ingest references/ subfolder + bundled files (#247)

### DIFF
--- a/src/commands/skill-push.ts
+++ b/src/commands/skill-push.ts
@@ -78,21 +78,35 @@ export function parseSkillFile(content: string): {
 }
 
 /**
- * Read top-level (non-recursive) files in dir, excluding SKILL.md.
- * Returns a map of filename → utf8 contents.
+ * Recursively read every bundled file under a skill dir, excluding the
+ * top-level SKILL.md. Returns a map of reference-key → utf8 contents.
+ *
+ * Keys are the file's POSIX path relative to the skill dir: top-level files
+ * keep a bare-filename key (e.g. "helper.py"), and files in subfolders keep
+ * their relative path (e.g. "references/member-roles.md") — matching how
+ * SKILL.md cites them, so bundled reference docs land complete (#247).
  */
-export function readTopLevelReferences(dir: string): Record<string, string> {
-    const entries = fs.readdirSync(dir, { withFileTypes: true });
+export function readReferences(dir: string): Record<string, string> {
     const references: Record<string, string> = {};
 
-    for (const entry of entries) {
-        if (!entry.isFile()) continue;
-        if (entry.name === 'SKILL.md') continue;
+    const walk = (current: string): void => {
+        for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+            const abs = path.join(current, entry.name);
+            if (entry.isDirectory()) {
+                walk(abs);
+                continue;
+            }
+            if (!entry.isFile()) continue;
 
-        const filePath = path.join(dir, entry.name);
-        references[entry.name] = fs.readFileSync(filePath, 'utf8');
-    }
+            // POSIX-normalised path relative to the skill dir, used as the key.
+            const key = path.relative(dir, abs).split(path.sep).join('/');
+            if (key === 'SKILL.md') continue; // exclude only the top-level skill file
 
+            references[key] = fs.readFileSync(abs, 'utf8');
+        }
+    };
+
+    walk(dir);
     return references;
 }
 
@@ -133,8 +147,8 @@ export async function skillPushWithConfig(
 
     const { name, description, properties, body } = parsed;
 
-    // 4. Read sibling reference files
-    const references = readTopLevelReferences(absDir);
+    // 4. Read bundled reference files (recursively, keyed by relative path)
+    const references = readReferences(absDir);
 
     // 5. Compose an idempotent upsert: try create; on name_collision, edit.
     const isRole = !!options.role;

--- a/tests/skill-push.test.ts
+++ b/tests/skill-push.test.ts
@@ -11,7 +11,7 @@ import * as http from 'http';
 import * as os from 'os';
 import * as path from 'path';
 import { describe, expect, it, beforeAll, afterAll, beforeEach } from 'vitest';
-import { parseSkillFile, readTopLevelReferences, skillPushWithConfig } from '../src/commands/skill-push';
+import { parseSkillFile, readReferences, skillPushWithConfig } from '../src/commands/skill-push';
 import type { SkillPushOptions } from '../src/commands/skill-push';
 import type { Config } from '../src/utils/config';
 
@@ -240,10 +240,10 @@ describe('parseSkillFile', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Unit tests: readTopLevelReferences
+// Unit tests: readReferences
 // ---------------------------------------------------------------------------
 
-describe('readTopLevelReferences', () => {
+describe('readReferences', () => {
     it('reads top-level files and excludes SKILL.md', () => {
         const { dir, cleanup } = makeTmpSkillDir(
             '---\nname: S\ndescription: D\n---\nbody',
@@ -254,7 +254,7 @@ describe('readTopLevelReferences', () => {
         );
 
         try {
-            const refs = readTopLevelReferences(dir);
+            const refs = readReferences(dir);
             expect(refs).toEqual({
                 'example.ts': 'const x = 1;',
                 'notes.txt': 'some notes',
@@ -265,22 +265,45 @@ describe('readTopLevelReferences', () => {
         }
     });
 
-    it('does not recurse into subdirectories', () => {
+    it('recurses into subdirectories, keyed by relative path', () => {
         const { dir, cleanup } = makeTmpSkillDir(
             '---\nname: S\ndescription: D\n---\nbody',
             { 'top.ts': 'top' },
         );
 
         try {
-            // Create a subdirectory with a file
+            // Create a nested subdirectory with a file
             const sub = path.join(dir, 'subdir');
             fs.mkdirSync(sub);
             fs.writeFileSync(path.join(sub, 'nested.ts'), 'nested', 'utf8');
 
-            const refs = readTopLevelReferences(dir);
-            expect(refs).toHaveProperty('top.ts');
-            expect(refs).not.toHaveProperty('nested.ts');
-            expect(Object.keys(refs)).not.toContain('subdir');
+            const refs = readReferences(dir);
+            expect(refs).toHaveProperty('top.ts', 'top');
+            // nested file is included, keyed by its POSIX relative path
+            expect(refs).toHaveProperty('subdir/nested.ts', 'nested');
+        } finally {
+            cleanup();
+        }
+    });
+
+    it('recurses into a references/ subfolder, keyed by path relative to the skill dir (#247)', () => {
+        const { dir, cleanup } = makeTmpSkillDir(
+            '---\nname: S\ndescription: D\n---\nbody references references/member-roles.md',
+            { 'top.md': 'top content' },
+        );
+
+        try {
+            const sub = path.join(dir, 'references');
+            fs.mkdirSync(sub);
+            fs.writeFileSync(path.join(sub, 'member-roles.md'), 'roles content', 'utf8');
+
+            const refs = readReferences(dir);
+            // top-level files keep bare-filename keys (backward compatible)
+            expect(refs).toHaveProperty('top.md', 'top content');
+            // subfolder files are keyed by their POSIX path relative to the skill dir,
+            // matching how SKILL.md cites them (references/member-roles.md)
+            expect(refs).toHaveProperty('references/member-roles.md', 'roles content');
+            expect(refs).not.toHaveProperty('SKILL.md');
         } finally {
             cleanup();
         }
@@ -290,7 +313,7 @@ describe('readTopLevelReferences', () => {
         const { dir, cleanup } = makeTmpSkillDir('---\nname: S\ndescription: D\n---\nbody');
 
         try {
-            const refs = readTopLevelReferences(dir);
+            const refs = readReferences(dir);
             expect(refs).toEqual({});
         } finally {
             cleanup();


### PR DESCRIPTION
## Summary
`solidactions skill push <dir>` dropped a skill's `references/` subfolder — `readTopLevelReferences` only read top-level sibling files (`if (!entry.isFile()) continue`), so skills bundling reference docs pushed incomplete (`reference_doc_ids: {}`, dangling `SKILL.md` pointers).

Replaced it with `readReferences`, which walks the whole skill dir (excluding the top-level `SKILL.md`) and keys each file by its **POSIX path relative to the skill dir**: top-level files keep bare-name keys (backward compatible), subfolder files keep their relative path (`references/member-roles.md`) — matching how `SKILL.md` cites them. The crews API already accepts + persists references correctly, so this is a CLI-only fix.

## Test Plan
- [x] Unit: `readReferences` recurses into `references/`, keys by relative path; top-level files unchanged (red→green)
- [x] Full CLI suite: **73 passed**, `tsc` build clean, Pint-equivalent style preserved
- [x] **Live verification:** a Sonnet MCP agent pushed a `references/`-bundled skill via this build against a local backend → `reference_doc_ids` = `{notes.md, references/folder-structure.md, references/member-roles.md}`, and crews MCP `skills read` confirmed all three stored under their relative-path keys

Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)