### PR TITLE
ci: bump publish.yml actions to v6 (Node 24)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,9 +11,9 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
 


### PR DESCRIPTION
## What
Bumps `actions/checkout@v4` → `@v6` and `actions/setup-node@v4` → `@v6` in `.github/workflows/publish.yml`.

## Why
The `@v4` actions run on Node.js 20, which GitHub forces to Node 24 on **2026-06-02** and removes on **2026-09-16** (deprecation surfaced as an annotation on the v1.14.0 publish run). Bumping to the current major (v6, runs on Node 24) clears it.

## Scope
CI-only — does not touch package source or published contents. Takes effect on the next release; no release needed for this change itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)