### PR TITLE
feat(cli): docs push — recursive markdown upload to SA-Docs (#255)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@solidactions/cli",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@solidactions/cli",
-      "version": "1.14.0",
+      "version": "1.15.0",
       "license": "MIT",
       "dependencies": {
         "archiver": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solidactions/cli",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "description": "SolidActions CLI - Deploy and manage workflow automation",
   "main": "dist/index.js",
   "bin": {

--- a/src/commands/docs-push.ts
+++ b/src/commands/docs-push.ts
@@ -1,0 +1,286 @@
+/**
+ * solidactions docs push <dir>
+ *
+ * Recursively uploads a local markdown tree into SA-Docs via the docs MCP
+ * server's `docs_vault bulk_create` tool, mirroring folder structure.
+ *
+ * Prints a report distinguishing fully-published docs from "properties pending"
+ * ones (docs whose frontmatter properties couldn't be validated yet).
+ */
+
+import fs from 'fs';
+import path from 'path';
+import chalk from 'chalk';
+import { Config } from '../utils/config';
+import { requireConfigWithWorkspace } from '../utils/api';
+import { callDocsTool } from '../utils/mcp';
+
+export interface DocsPushOptions {
+    onConflict?: 'skip' | 'overwrite' | 'rename';
+    type?: string;
+    dryRun?: boolean;
+    json?: boolean;
+}
+
+const CHUNK_SIZE = 50;
+
+interface DocItem {
+    title: string;
+    body: string;
+    relative_folder_path?: string;
+    /** local file path for correlating results back to filenames */
+    _filePath: string;
+}
+
+interface BulkCreateResultRow {
+    index: number;
+    status: string;
+    id?: string;
+    folder_path?: string;
+    action?: string;
+    property_validation?: {
+        status: string;
+        missing: string[];
+        invalid: Array<{ key: string; reason: string }>;
+        schema: unknown[];
+    };
+}
+
+interface BulkCreateSummary {
+    created?: number;
+    overwritten?: number;
+    skipped?: number;
+    renamed?: number;
+    errors?: number;
+    folders_created?: number;
+    planned_create?: number;
+    planned_overwrite?: number;
+    planned_skip?: number;
+    planned_rename?: number;
+}
+
+interface PendingItem {
+    file: string;
+    missing: string[];
+    invalid: Array<{ key: string; reason: string }>;
+}
+
+interface ResultRow extends BulkCreateResultRow {
+    file: string;
+}
+
+/**
+ * Recursively walk `dir` and collect all *.md files.
+ * Returns a list of absolute paths.
+ */
+function walkMarkdownFiles(dir: string): string[] {
+    const results: string[] = [];
+
+    const walk = (current: string): void => {
+        for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+            const abs = path.join(current, entry.name);
+            if (entry.isDirectory()) {
+                walk(abs);
+            } else if (entry.isFile() && entry.name.endsWith('.md')) {
+                results.push(abs);
+            }
+        }
+    };
+
+    walk(dir);
+    return results;
+}
+
+/**
+ * Convert an absolute file path to a bulk_create item, relative to `rootDir`.
+ */
+function fileToItem(absPath: string, rootDir: string): DocItem {
+    const title = path.basename(absPath, '.md');
+    const body = fs.readFileSync(absPath, 'utf8');
+    const relDir = path.relative(rootDir, path.dirname(absPath));
+    // Use POSIX separators; omit if file is in the root dir
+    const relative_folder_path = relDir === '' ? undefined : relDir.split(path.sep).join('/');
+
+    const item: DocItem = { title, body, _filePath: absPath };
+    if (relative_folder_path !== undefined) {
+        item.relative_folder_path = relative_folder_path;
+    }
+    return item;
+}
+
+/**
+ * Merge two BulkCreateSummary objects by summing all numeric fields.
+ */
+function mergeSummaries(a: BulkCreateSummary, b: BulkCreateSummary): BulkCreateSummary {
+    const keys: Array<keyof BulkCreateSummary> = [
+        'created', 'overwritten', 'skipped', 'renamed', 'errors', 'folders_created',
+        'planned_create', 'planned_overwrite', 'planned_skip', 'planned_rename',
+    ];
+    const result: BulkCreateSummary = {};
+    for (const key of keys) {
+        const aVal = a[key] ?? 0;
+        const bVal = b[key] ?? 0;
+        if (aVal !== 0 || bVal !== 0) {
+            (result as any)[key] = aVal + bVal;
+        }
+    }
+    return result;
+}
+
+/**
+ * Format the merged summary into human-readable totals line.
+ * Normal run: created/overwritten/skipped/renamed. Dry-run: planned_*.
+ */
+function formatSummaryLine(summary: BulkCreateSummary, dryRun: boolean): string {
+    const parts: string[] = [];
+    if (dryRun) {
+        if (summary.planned_create) parts.push(`${summary.planned_create} planned create`);
+        if (summary.planned_overwrite) parts.push(`${summary.planned_overwrite} planned overwrite`);
+        if (summary.planned_skip) parts.push(`${summary.planned_skip} planned skip`);
+        if (summary.planned_rename) parts.push(`${summary.planned_rename} planned rename`);
+    } else {
+        if (summary.created) parts.push(`${summary.created} created`);
+        if (summary.overwritten) parts.push(`${summary.overwritten} updated`);
+        if (summary.skipped) parts.push(`${summary.skipped} skipped`);
+        if (summary.renamed) parts.push(`${summary.renamed} renamed`);
+        if (summary.errors) parts.push(`${summary.errors} errors`);
+    }
+    return parts.join(', ') || '0 docs';
+}
+
+/**
+ * Core implementation — accepts an injected config so tests can point at a
+ * stub server without touching the filesystem config.
+ */
+export async function docsPushWithConfig(
+    dir: string,
+    options: DocsPushOptions,
+    config: Config,
+): Promise<void> {
+    const absDir = path.resolve(dir);
+
+    if (!fs.existsSync(absDir) || !fs.statSync(absDir).isDirectory()) {
+        process.stderr.write(chalk.red(`error: "${dir}" is not a directory.\n`));
+        process.exit(1);
+    }
+
+    const allFiles = walkMarkdownFiles(absDir);
+
+    if (allFiles.length === 0) {
+        process.stderr.write(chalk.red(`error: no .md files found under "${dir}" — nothing to push.\n`));
+        process.exit(1);
+    }
+
+    const items: DocItem[] = allFiles.map((f) => fileToItem(f, absDir));
+
+    // Chunk into groups of CHUNK_SIZE
+    const chunks: DocItem[][] = [];
+    for (let i = 0; i < items.length; i += CHUNK_SIZE) {
+        chunks.push(items.slice(i, i + CHUNK_SIZE));
+    }
+
+    const onConflict = options.onConflict ?? 'skip';
+    const allResultRows: ResultRow[] = [];
+    let mergedSummary: BulkCreateSummary = {};
+
+    for (const chunk of chunks) {
+        const callArgs: Record<string, unknown> = {
+            action: 'bulk_create',
+            on_conflict: onConflict,
+            items: chunk.map(({ title, body, relative_folder_path }) => {
+                const item: Record<string, unknown> = { title, body };
+                if (relative_folder_path !== undefined) {
+                    item.relative_folder_path = relative_folder_path;
+                }
+                return item;
+            }),
+        };
+
+        if (options.type) {
+            callArgs.type = options.type;
+        }
+        if (options.dryRun) {
+            callArgs.dry_run = true;
+        }
+
+        let mcpResult: Awaited<ReturnType<typeof callDocsTool>>;
+        try {
+            mcpResult = await callDocsTool(config, 'docs_vault', callArgs);
+        } catch (e: any) {
+            process.stderr.write(chalk.red(`error: MCP request failed — ${e.message}\n`));
+            process.exit(1);
+        }
+
+        if (!mcpResult.ok) {
+            const code = mcpResult.data?.code ?? 'unknown_error';
+            const message = mcpResult.data?.message ?? 'MCP returned an error with no message';
+            process.stderr.write(chalk.red(`error: ${code}: ${message}\n`));
+            process.exit(1);
+        }
+
+        const data = mcpResult.data;
+        const rows: BulkCreateResultRow[] = data?.results ?? [];
+        const summary: BulkCreateSummary = data?.summary ?? {};
+
+        // Correlate rows back to source files using chunk index
+        for (const row of rows) {
+            const sourceFile = chunk[row.index]?._filePath ?? '(unknown)';
+            allResultRows.push({
+                ...row,
+                file: path.relative(absDir, sourceFile),
+            });
+        }
+
+        mergedSummary = mergeSummaries(mergedSummary, summary);
+    }
+
+    // Collect pending items (results that have property_validation)
+    const pendingItems: PendingItem[] = allResultRows
+        .filter((r) => r.property_validation != null)
+        .map((r) => ({
+            file: r.file,
+            missing: r.property_validation!.missing ?? [],
+            invalid: r.property_validation!.invalid ?? [],
+        }));
+
+    // --json: output single JSON object
+    if (options.json) {
+        console.log(JSON.stringify({
+            summary: mergedSummary,
+            pending: pendingItems,
+            results: allResultRows,
+        }));
+        process.exit(0);
+    }
+
+    // Human-readable output
+    const summaryLine = formatSummaryLine(mergedSummary, !!options.dryRun);
+    if (options.dryRun) {
+        console.log(chalk.cyan(`[dry-run preview] ${summaryLine}`));
+    } else {
+        console.log(chalk.green(`done: ${summaryLine}`));
+    }
+
+    if (pendingItems.length > 0) {
+        console.log(chalk.yellow(`\nProperties pending (${pendingItems.length} doc${pendingItems.length === 1 ? '' : 's'}):`));
+        for (const item of pendingItems) {
+            console.log(chalk.yellow(`  ${item.file}`));
+            if (item.missing.length > 0) {
+                console.log(chalk.yellow(`    missing: ${item.missing.join(', ')}`));
+            }
+            for (const inv of item.invalid) {
+                console.log(chalk.yellow(`    invalid: ${inv.key} — ${inv.reason}`));
+            }
+        }
+    }
+
+    process.exit(0);
+}
+
+/**
+ * Entry point called from index.ts.
+ */
+export async function docsPush(dir: string, options: DocsPushOptions): Promise<void> {
+    const config = await requireConfigWithWorkspace();
+    await docsPushWithConfig(dir, options, config);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ import { skillList } from './commands/skill-list';
 import { skillView } from './commands/skill-view';
 import { skillDelete } from './commands/skill-delete';
 import { rolePush } from './commands/role-push';
+import { docsPush } from './commands/docs-push';
 import { setCliWorkspaceOverride } from './utils/config';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -509,6 +510,24 @@ role
     .option('--json', 'Output result as JSON')
     .action(async (dir, options) => {
         await rolePush(dir, options);
+    });
+
+// =============================================================================
+// docs <subcommand>  (SA-Docs surface)
+// =============================================================================
+
+const docs = program.command('docs').description('Manage docs in SA-Docs');
+
+docs
+    .command('push')
+    .description('Recursively upload a local markdown tree into SA-Docs')
+    .argument('<dir>', 'Path to the directory containing markdown files')
+    .option('--on-conflict <mode>', 'Conflict resolution: skip|overwrite|rename (default: skip)', 'skip')
+    .option('--type <slug>', 'Doc-type slug to apply to all uploaded docs')
+    .option('--dry-run', 'Preview what would be created without writing')
+    .option('--json', 'Output result as JSON')
+    .action(async (dir, options) => {
+        await docsPush(dir, { onConflict: options.onConflict, type: options.type, dryRun: options.dryRun, json: options.json });
     });
 
 program.parseAsync().catch((err) => {

--- a/src/utils/mcp.ts
+++ b/src/utils/mcp.ts
@@ -1,9 +1,9 @@
 /**
- * Minimal MCP client for the SolidActions crews MCP server.
+ * Minimal MCP client for the SolidActions in-app MCP servers.
  *
  * Sends a single stateless JSON-RPC tools/call POST.  No initialize handshake
- * required — the streamable-HTTP transport at /mcp/crews accepts single
- * stateless POSTs (confirmed live).
+ * required — the streamable-HTTP transport accepts single stateless POSTs
+ * (confirmed live).
  */
 
 import * as http from 'http';
@@ -18,11 +18,11 @@ export interface McpToolResult {
 }
 
 /**
- * Call a single MCP tool on /mcp/crews.
+ * Internal: call a single MCP tool on the given endpoint path.
  *
  * Returns { ok: true, data: <success shape> } or { ok: false, data: { code, message } }.
  */
-export async function callCrewsTool(config: Config, toolName: string, args: Record<string, unknown>): Promise<McpToolResult> {
+async function callMcpTool(config: Config, endpointPath: string, toolName: string, args: Record<string, unknown>): Promise<McpToolResult> {
     const baseHeaders = getApiHeaders(config, 'application/json');
     // Override Accept to include text/event-stream for streamable-HTTP transport
     const headers: Record<string, string> = {
@@ -40,7 +40,7 @@ export async function callCrewsTool(config: Config, toolName: string, args: Reco
         },
     });
 
-    const parsed = new URL(`${config.host}/mcp/crews`);
+    const parsed = new URL(`${config.host}${endpointPath}`);
     const isHttps = parsed.protocol === 'https:';
     const transport = isHttps ? https : http;
 
@@ -92,4 +92,18 @@ export async function callCrewsTool(config: Config, toolName: string, args: Reco
     }
 
     return { ok: !isError, data: toolData };
+}
+
+/**
+ * Call a single MCP tool on /mcp/crews.
+ */
+export async function callCrewsTool(config: Config, toolName: string, args: Record<string, unknown>): Promise<McpToolResult> {
+    return callMcpTool(config, '/mcp/crews', toolName, args);
+}
+
+/**
+ * Call a single MCP tool on /mcp/docs.
+ */
+export async function callDocsTool(config: Config, toolName: string, args: Record<string, unknown>): Promise<McpToolResult> {
+    return callMcpTool(config, '/mcp/docs', toolName, args);
 }

--- a/tests/docs-push.test.ts
+++ b/tests/docs-push.test.ts
@@ -1,0 +1,839 @@
+/**
+ * Tests for `solidactions docs push <dir>`
+ *
+ * Uses a real in-process HTTP server (Node's http.createServer) to stub the
+ * /mcp/docs endpoint.  No mock/spy/stub libraries — follows the pattern in
+ * skill-push.test.ts.
+ */
+
+import * as fs from 'fs';
+import * as http from 'http';
+import * as os from 'os';
+import * as path from 'path';
+import { describe, expect, it, beforeAll, afterAll, beforeEach } from 'vitest';
+import { docsPushWithConfig } from '../src/commands/docs-push';
+import type { DocsPushOptions } from '../src/commands/docs-push';
+import type { Config } from '../src/utils/config';
+
+// ---------------------------------------------------------------------------
+// Stub MCP server
+// ---------------------------------------------------------------------------
+
+interface CapturedRequest {
+    method: string | undefined;
+    path: string | undefined;
+    headers: http.IncomingHttpHeaders;
+    body: any;
+}
+
+let stubServer: http.Server;
+let stubPort: number;
+let allCaptures: CapturedRequest[] = [];
+
+/** Build a canned MCP success response wrapping toolData. */
+function makeMcpSuccess(toolData: object): string {
+    return JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        result: {
+            isError: false,
+            content: [{ type: 'text', text: JSON.stringify(toolData) }],
+        },
+    });
+}
+
+// Server state — a FIFO queue of canned responses; falls back to a default bulk_create success.
+function makeDefaultBulkSuccess(count: number): string {
+    const results = Array.from({ length: count }, (_, i) => ({
+        index: i,
+        status: 'created',
+        id: `doc-${i}`,
+        folder_path: '/root',
+    }));
+    return makeMcpSuccess({
+        results,
+        summary: { created: count, overwritten: 0, skipped: 0, renamed: 0, errors: 0, folders_created: 0 },
+    });
+}
+
+let responseQueue: Array<string | ((body: any) => string)> = [];
+
+function nextResponseBody(body: any): string {
+    const entry = responseQueue.length > 0 ? responseQueue.shift()! : null;
+    if (entry === null) {
+        // Default: a bulk_create success for however many items were sent
+        const items = body?.params?.arguments?.items ?? [];
+        return makeDefaultBulkSuccess(items.length);
+    }
+    if (typeof entry === 'function') return entry(body);
+    return entry;
+}
+
+beforeAll(async () => {
+    stubServer = http.createServer((req, res) => {
+        let rawBody = '';
+        req.on('data', (chunk) => { rawBody += chunk; });
+        req.on('end', () => {
+            let parsedBody: any = null;
+            try { parsedBody = JSON.parse(rawBody); } catch { /* ignore */ }
+
+            const capture: CapturedRequest = {
+                method: req.method,
+                path: req.url,
+                headers: req.headers,
+                body: parsedBody,
+            };
+
+            allCaptures.push(capture);
+
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(nextResponseBody(parsedBody));
+        });
+    });
+
+    await new Promise<void>((resolve) => {
+        stubServer.listen(0, '127.0.0.1', () => {
+            stubPort = (stubServer.address() as { port: number }).port;
+            resolve();
+        });
+    });
+});
+
+afterAll(() => {
+    return new Promise<void>((resolve, reject) => {
+        stubServer.close((err) => (err ? reject(err) : resolve()));
+    });
+});
+
+beforeEach(() => {
+    allCaptures = [];
+    responseQueue = [];
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a Config that points at the stub server. */
+function stubConfig(workspaceId = 'ws-test-uuid'): Config {
+    return {
+        host: `http://127.0.0.1:${stubPort}`,
+        apiKey: 'test-api-key',
+        workspaceId,
+    };
+}
+
+/** Sentinel thrown by the patched process.exit so execution stops. */
+class ProcessExitError extends Error {
+    constructor(public readonly code: number | undefined) {
+        super(`process.exit(${code})`);
+    }
+}
+
+/** Patch process.exit to throw ProcessExitError so tests can catch it. */
+function patchProcessExit(): () => void {
+    const orig = process.exit.bind(process);
+    (process as any).exit = (code?: number) => { throw new ProcessExitError(code); };
+    return () => { (process as any).exit = orig; };
+}
+
+/** Patch process.stderr.write to capture output. */
+function captureStderr(): { lines: string[]; restore: () => void } {
+    const lines: string[] = [];
+    const orig = process.stderr.write.bind(process.stderr);
+    (process.stderr as any).write = (chunk: string) => { lines.push(String(chunk)); return true; };
+    return { lines, restore: () => { (process.stderr as any).write = orig; } };
+}
+
+/** Patch console.log to capture output lines. */
+function captureStdout(): { lines: string[]; restore: () => void } {
+    const lines: string[] = [];
+    const orig = console.log;
+    console.log = (m?: any) => { lines.push(String(m ?? '')); };
+    return { lines, restore: () => { console.log = orig; } };
+}
+
+/**
+ * Build a temp directory with a nested markdown tree.
+ * Returns the dir path and a cleanup function.
+ */
+function makeTmpDocsDir(files: Record<string, string>): { dir: string; cleanup: () => void } {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sa-docs-test-'));
+
+    for (const [relPath, content] of Object.entries(files)) {
+        const abs = path.join(dir, relPath);
+        fs.mkdirSync(path.dirname(abs), { recursive: true });
+        fs.writeFileSync(abs, content, 'utf8');
+    }
+
+    return {
+        dir,
+        cleanup: () => fs.rmSync(dir, { recursive: true, force: true }),
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Tests: chunking — 57 files → exactly 2 bulk_create calls (50 + 7)
+// ---------------------------------------------------------------------------
+
+describe('docsPushWithConfig — chunking', () => {
+    it('sends exactly 2 bulk_create calls for 57 files (50 + 7), total items = 57', async () => {
+        // Build 57 md files: 55 root-level + 2 in a subfolder
+        const files: Record<string, string> = {};
+        for (let i = 0; i < 55; i++) {
+            files[`doc-${i}.md`] = `# Doc ${i}\n\nContent for doc ${i}.`;
+        }
+        files['sub/doc-55.md'] = '# Sub doc 55\n\nIn a subfolder.';
+        files['sub/doc-56.md'] = '# Sub doc 56\n\nAlso in a subfolder.';
+
+        const { dir, cleanup } = makeTmpDocsDir(files);
+        const restoreExit = patchProcessExit();
+        const { restore: restoreStdout } = captureStdout();
+
+        try {
+            let caughtExit: ProcessExitError | null = null;
+            try {
+                await docsPushWithConfig(dir, { onConflict: 'skip' }, stubConfig());
+            } catch (e) {
+                if (e instanceof ProcessExitError) caughtExit = e;
+                else throw e;
+            }
+
+            expect(caughtExit?.code).toBe(0);
+
+            // Exactly 2 bulk_create calls
+            expect(allCaptures.length).toBe(2);
+
+            const firstItems = allCaptures[0].body.params.arguments.items;
+            const secondItems = allCaptures[1].body.params.arguments.items;
+
+            // First chunk: 50 items; second chunk: 7 items
+            expect(firstItems.length).toBe(50);
+            expect(secondItems.length).toBe(7);
+
+            // Total = 57
+            expect(firstItems.length + secondItems.length).toBe(57);
+
+            // All calls go to /mcp/docs with tools/call method
+            for (const cap of allCaptures) {
+                expect(cap.path).toBe('/mcp/docs');
+                expect(cap.body.method).toBe('tools/call');
+                expect(cap.body.params.name).toBe('docs_vault');
+                expect(cap.body.params.arguments.action).toBe('bulk_create');
+            }
+        } finally {
+            restoreExit();
+            restoreStdout();
+            cleanup();
+        }
+    });
+
+    it('a subfolder file carries the correct relative_folder_path using / separators', async () => {
+        const files: Record<string, string> = {
+            'root-doc.md': '# Root\n\nRoot content.',
+            'guides/intro.md': '# Intro\n\nIntro content.',
+            'guides/deep/nested.md': '# Nested\n\nNested content.',
+        };
+
+        const { dir, cleanup } = makeTmpDocsDir(files);
+        const restoreExit = patchProcessExit();
+        const { restore: restoreStdout } = captureStdout();
+
+        try {
+            let caughtExit: ProcessExitError | null = null;
+            try {
+                await docsPushWithConfig(dir, { onConflict: 'skip' }, stubConfig());
+            } catch (e) {
+                if (e instanceof ProcessExitError) caughtExit = e;
+                else throw e;
+            }
+
+            expect(caughtExit?.code).toBe(0);
+            expect(allCaptures.length).toBe(1);
+
+            const items: any[] = allCaptures[0].body.params.arguments.items;
+            expect(items.length).toBe(3);
+
+            // Root file: no relative_folder_path
+            const rootItem = items.find((it: any) => it.title === 'root-doc');
+            expect(rootItem).toBeDefined();
+            expect(rootItem).not.toHaveProperty('relative_folder_path');
+
+            // Subfolder file: relative_folder_path = 'guides'
+            const guidesItem = items.find((it: any) => it.title === 'intro');
+            expect(guidesItem).toBeDefined();
+            expect(guidesItem.relative_folder_path).toBe('guides');
+
+            // Deep nested file: relative_folder_path = 'guides/deep'
+            const deepItem = items.find((it: any) => it.title === 'nested');
+            expect(deepItem).toBeDefined();
+            expect(deepItem.relative_folder_path).toBe('guides/deep');
+        } finally {
+            restoreExit();
+            restoreStdout();
+            cleanup();
+        }
+    });
+
+    it('title is the filename stem (no .md extension)', async () => {
+        const files: Record<string, string> = {
+            'my-document.md': '# My Document\n\nSome content.',
+            'another_file.md': '# Another\n\nMore content.',
+        };
+
+        const { dir, cleanup } = makeTmpDocsDir(files);
+        const restoreExit = patchProcessExit();
+        const { restore: restoreStdout } = captureStdout();
+
+        try {
+            let caughtExit: ProcessExitError | null = null;
+            try {
+                await docsPushWithConfig(dir, { onConflict: 'skip' }, stubConfig());
+            } catch (e) {
+                if (e instanceof ProcessExitError) caughtExit = e;
+                else throw e;
+            }
+
+            expect(caughtExit?.code).toBe(0);
+            const items: any[] = allCaptures[0].body.params.arguments.items;
+            const titles = items.map((it: any) => it.title);
+            expect(titles).toContain('my-document');
+            expect(titles).toContain('another_file');
+            // Must NOT include the .md extension
+            expect(titles).not.toContain('my-document.md');
+        } finally {
+            restoreExit();
+            restoreStdout();
+            cleanup();
+        }
+    });
+
+    it('non-.md files are skipped', async () => {
+        const files: Record<string, string> = {
+            'keep.md': '# Keep',
+            'ignore.txt': 'plain text',
+            'ignore.json': '{"key": "value"}',
+        };
+
+        const { dir, cleanup } = makeTmpDocsDir(files);
+        const restoreExit = patchProcessExit();
+        const { restore: restoreStdout } = captureStdout();
+
+        try {
+            let caughtExit: ProcessExitError | null = null;
+            try {
+                await docsPushWithConfig(dir, { onConflict: 'skip' }, stubConfig());
+            } catch (e) {
+                if (e instanceof ProcessExitError) caughtExit = e;
+                else throw e;
+            }
+
+            expect(caughtExit?.code).toBe(0);
+            const items: any[] = allCaptures[0].body.params.arguments.items;
+            expect(items.length).toBe(1);
+            expect(items[0].title).toBe('keep');
+        } finally {
+            restoreExit();
+            restoreStdout();
+            cleanup();
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: request shape — on_conflict, type, body content
+// ---------------------------------------------------------------------------
+
+describe('docsPushWithConfig — request shape', () => {
+    it('sends on_conflict from options', async () => {
+        const { dir, cleanup } = makeTmpDocsDir({ 'doc.md': '# Doc' });
+        const restoreExit = patchProcessExit();
+        const { restore: restoreStdout } = captureStdout();
+
+        try {
+            let caughtExit: ProcessExitError | null = null;
+            try {
+                await docsPushWithConfig(dir, { onConflict: 'overwrite' }, stubConfig());
+            } catch (e) {
+                if (e instanceof ProcessExitError) caughtExit = e;
+                else throw e;
+            }
+
+            expect(caughtExit?.code).toBe(0);
+            const args = allCaptures[0].body.params.arguments;
+            expect(args.on_conflict).toBe('overwrite');
+        } finally {
+            restoreExit();
+            restoreStdout();
+            cleanup();
+        }
+    });
+
+    it('sends type when --type option is set', async () => {
+        const { dir, cleanup } = makeTmpDocsDir({ 'doc.md': '# Doc' });
+        const restoreExit = patchProcessExit();
+        const { restore: restoreStdout } = captureStdout();
+
+        try {
+            let caughtExit: ProcessExitError | null = null;
+            try {
+                await docsPushWithConfig(dir, { onConflict: 'skip', type: 'tutorial' }, stubConfig());
+            } catch (e) {
+                if (e instanceof ProcessExitError) caughtExit = e;
+                else throw e;
+            }
+
+            expect(caughtExit?.code).toBe(0);
+            const args = allCaptures[0].body.params.arguments;
+            expect(args.type).toBe('tutorial');
+        } finally {
+            restoreExit();
+            restoreStdout();
+            cleanup();
+        }
+    });
+
+    it('omits type when not set', async () => {
+        const { dir, cleanup } = makeTmpDocsDir({ 'doc.md': '# Doc' });
+        const restoreExit = patchProcessExit();
+        const { restore: restoreStdout } = captureStdout();
+
+        try {
+            let caughtExit: ProcessExitError | null = null;
+            try {
+                await docsPushWithConfig(dir, { onConflict: 'skip' }, stubConfig());
+            } catch (e) {
+                if (e instanceof ProcessExitError) caughtExit = e;
+                else throw e;
+            }
+
+            expect(caughtExit?.code).toBe(0);
+            const args = allCaptures[0].body.params.arguments;
+            expect(args).not.toHaveProperty('type');
+        } finally {
+            restoreExit();
+            restoreStdout();
+            cleanup();
+        }
+    });
+
+    it('sends body as raw file contents (UTF-8)', async () => {
+        const content = '---\ntitle: My Doc\n---\n# My Document\n\nContent here.';
+        const { dir, cleanup } = makeTmpDocsDir({ 'my-doc.md': content });
+        const restoreExit = patchProcessExit();
+        const { restore: restoreStdout } = captureStdout();
+
+        try {
+            let caughtExit: ProcessExitError | null = null;
+            try {
+                await docsPushWithConfig(dir, { onConflict: 'skip' }, stubConfig());
+            } catch (e) {
+                if (e instanceof ProcessExitError) caughtExit = e;
+                else throw e;
+            }
+
+            expect(caughtExit?.code).toBe(0);
+            const items: any[] = allCaptures[0].body.params.arguments.items;
+            const item = items.find((it: any) => it.title === 'my-doc');
+            expect(item.body).toBe(content);
+        } finally {
+            restoreExit();
+            restoreStdout();
+            cleanup();
+        }
+    });
+
+    it('sends X-Workspace-Id and Authorization headers', async () => {
+        const { dir, cleanup } = makeTmpDocsDir({ 'doc.md': '# Doc' });
+        const restoreExit = patchProcessExit();
+        const { restore: restoreStdout } = captureStdout();
+
+        try {
+            let caughtExit: ProcessExitError | null = null;
+            try {
+                await docsPushWithConfig(dir, { onConflict: 'skip' }, stubConfig('ws-abc'));
+            } catch (e) {
+                if (e instanceof ProcessExitError) caughtExit = e;
+                else throw e;
+            }
+
+            expect(caughtExit?.code).toBe(0);
+            expect(allCaptures[0].headers['x-workspace-id']).toBe('ws-abc');
+            expect(allCaptures[0].headers['authorization']).toBe('Bearer test-api-key');
+        } finally {
+            restoreExit();
+            restoreStdout();
+            cleanup();
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: dry-run
+// ---------------------------------------------------------------------------
+
+describe('docsPushWithConfig — dry-run', () => {
+    it('sends dry_run: true in bulk_create args and does not throw', async () => {
+        // dry-run response uses planned status
+        responseQueue = [(body: any) => {
+            const items = body?.params?.arguments?.items ?? [];
+            const results = items.map((_: any, i: number) => ({
+                index: i,
+                status: 'planned',
+                action: 'create',
+            }));
+            return makeMcpSuccess({
+                results,
+                summary: { planned_create: items.length, planned_overwrite: 0, planned_skip: 0, planned_rename: 0, errors: 0, folders_created: 0 },
+            });
+        }];
+
+        const { dir, cleanup } = makeTmpDocsDir({
+            'doc1.md': '# Doc 1',
+            'doc2.md': '# Doc 2',
+        });
+
+        const restoreExit = patchProcessExit();
+        const { restore: restoreStdout } = captureStdout();
+
+        try {
+            let caughtExit: ProcessExitError | null = null;
+            try {
+                await docsPushWithConfig(dir, { onConflict: 'skip', dryRun: true }, stubConfig());
+            } catch (e) {
+                if (e instanceof ProcessExitError) caughtExit = e;
+                else throw e;
+            }
+
+            // Should exit 0 without throwing
+            expect(caughtExit?.code).toBe(0);
+
+            // bulk_create was called with dry_run: true
+            expect(allCaptures.length).toBe(1);
+            const args = allCaptures[0].body.params.arguments;
+            expect(args.dry_run).toBe(true);
+        } finally {
+            restoreExit();
+            restoreStdout();
+            cleanup();
+        }
+    });
+
+    it('prints a preview label in dry-run mode', async () => {
+        responseQueue = [(body: any) => {
+            const items = body?.params?.arguments?.items ?? [];
+            const results = items.map((_: any, i: number) => ({ index: i, status: 'planned', action: 'create' }));
+            return makeMcpSuccess({
+                results,
+                summary: { planned_create: items.length, planned_overwrite: 0, planned_skip: 0, planned_rename: 0, errors: 0, folders_created: 0 },
+            });
+        }];
+
+        const { dir, cleanup } = makeTmpDocsDir({ 'doc.md': '# Doc' });
+        const restoreExit = patchProcessExit();
+        const { lines: logLines, restore: restoreStdout } = captureStdout();
+
+        try {
+            let caughtExit: ProcessExitError | null = null;
+            try {
+                await docsPushWithConfig(dir, { onConflict: 'skip', dryRun: true }, stubConfig());
+            } catch (e) {
+                if (e instanceof ProcessExitError) caughtExit = e;
+                else throw e;
+            }
+
+            expect(caughtExit?.code).toBe(0);
+            const out = logLines.join('');
+            // Should include some kind of dry-run / preview label
+            expect(out.toLowerCase()).toMatch(/dry.?run|preview/);
+        } finally {
+            restoreExit();
+            restoreStdout();
+            cleanup();
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: report output — properties pending section
+// ---------------------------------------------------------------------------
+
+describe('docsPushWithConfig — report: properties pending', () => {
+    it('prints "Properties pending" section for files that have property_validation in their result', async () => {
+        // Response with one pending result
+        responseQueue = [makeMcpSuccess({
+            results: [
+                {
+                    index: 0,
+                    status: 'created',
+                    id: 'doc-1',
+                    property_validation: {
+                        status: 'pending',
+                        missing: ['author', 'category'],
+                        invalid: [{ key: 'date', reason: 'must be ISO 8601' }],
+                        schema: [],
+                    },
+                },
+                {
+                    index: 1,
+                    status: 'created',
+                    id: 'doc-2',
+                    // no property_validation
+                },
+            ],
+            summary: { created: 2, overwritten: 0, skipped: 0, renamed: 0, errors: 0, folders_created: 0 },
+        })];
+
+        const { dir, cleanup } = makeTmpDocsDir({
+            'first.md': '# First',
+            'second.md': '# Second',
+        });
+
+        const restoreExit = patchProcessExit();
+        const { lines: logLines, restore: restoreStdout } = captureStdout();
+
+        try {
+            let caughtExit: ProcessExitError | null = null;
+            try {
+                await docsPushWithConfig(dir, { onConflict: 'skip' }, stubConfig());
+            } catch (e) {
+                if (e instanceof ProcessExitError) caughtExit = e;
+                else throw e;
+            }
+
+            expect(caughtExit?.code).toBe(0);
+            const out = logLines.join('\n');
+
+            // Properties pending section must appear
+            expect(out.toLowerCase()).toMatch(/properties pending/);
+
+            // Must list the missing keys
+            expect(out).toContain('author');
+            expect(out).toContain('category');
+
+            // Must list the invalid key + reason
+            expect(out).toContain('date');
+            expect(out).toContain('must be ISO 8601');
+        } finally {
+            restoreExit();
+            restoreStdout();
+            cleanup();
+        }
+    });
+
+    it('does not print "Properties pending" section when no results have property_validation', async () => {
+        responseQueue = [makeMcpSuccess({
+            results: [
+                { index: 0, status: 'created', id: 'doc-1' },
+                { index: 1, status: 'created', id: 'doc-2' },
+            ],
+            summary: { created: 2, overwritten: 0, skipped: 0, renamed: 0, errors: 0, folders_created: 0 },
+        })];
+
+        const { dir, cleanup } = makeTmpDocsDir({
+            'first.md': '# First',
+            'second.md': '# Second',
+        });
+
+        const restoreExit = patchProcessExit();
+        const { lines: logLines, restore: restoreStdout } = captureStdout();
+
+        try {
+            let caughtExit: ProcessExitError | null = null;
+            try {
+                await docsPushWithConfig(dir, { onConflict: 'skip' }, stubConfig());
+            } catch (e) {
+                if (e instanceof ProcessExitError) caughtExit = e;
+                else throw e;
+            }
+
+            expect(caughtExit?.code).toBe(0);
+            const out = logLines.join('\n');
+            expect(out.toLowerCase()).not.toMatch(/properties pending/);
+        } finally {
+            restoreExit();
+            restoreStdout();
+            cleanup();
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: --json flag
+// ---------------------------------------------------------------------------
+
+describe('docsPushWithConfig — --json flag', () => {
+    it('outputs a single JSON object with summary, pending, and results fields', async () => {
+        responseQueue = [makeMcpSuccess({
+            results: [
+                {
+                    index: 0,
+                    status: 'created',
+                    id: 'doc-1',
+                    property_validation: {
+                        status: 'pending',
+                        missing: ['author'],
+                        invalid: [],
+                        schema: [],
+                    },
+                },
+                { index: 1, status: 'skipped', id: 'doc-2' },
+            ],
+            summary: { created: 1, overwritten: 0, skipped: 1, renamed: 0, errors: 0, folders_created: 0 },
+        })];
+
+        const { dir, cleanup } = makeTmpDocsDir({
+            'alpha.md': '# Alpha',
+            'beta.md': '# Beta',
+        });
+
+        const restoreExit = patchProcessExit();
+        const { lines: logLines, restore: restoreStdout } = captureStdout();
+
+        try {
+            let caughtExit: ProcessExitError | null = null;
+            try {
+                await docsPushWithConfig(dir, { onConflict: 'skip', json: true }, stubConfig());
+            } catch (e) {
+                if (e instanceof ProcessExitError) caughtExit = e;
+                else throw e;
+            }
+
+            expect(caughtExit?.code).toBe(0);
+
+            // Should have printed exactly one JSON line
+            const jsonLine = logLines.find((l) => l.trim().startsWith('{'));
+            expect(jsonLine).toBeDefined();
+
+            const parsed = JSON.parse(jsonLine!);
+            expect(parsed).toHaveProperty('summary');
+            expect(parsed).toHaveProperty('pending');
+            expect(parsed).toHaveProperty('results');
+
+            // pending should include the file that had property_validation
+            expect(parsed.pending.length).toBe(1);
+            expect(parsed.pending[0]).toHaveProperty('file');
+            expect(parsed.pending[0]).toHaveProperty('missing');
+            expect(parsed.pending[0].missing).toContain('author');
+
+            // results should have file names attached
+            expect(parsed.results.length).toBe(2);
+            expect(parsed.results[0]).toHaveProperty('file');
+        } finally {
+            restoreExit();
+            restoreStdout();
+            cleanup();
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: report totals output
+// ---------------------------------------------------------------------------
+
+describe('docsPushWithConfig — report totals', () => {
+    it('prints totals from aggregated summaries across multiple chunks', async () => {
+        // 57 files: 50 + 7
+        const files: Record<string, string> = {};
+        for (let i = 0; i < 57; i++) {
+            files[`doc-${i}.md`] = `# Doc ${i}`;
+        }
+
+        // Chunk 1: 40 created, 10 skipped
+        responseQueue.push(makeMcpSuccess({
+            results: Array.from({ length: 50 }, (_, i) => ({
+                index: i,
+                status: i < 40 ? 'created' : 'skipped',
+                id: `doc-${i}`,
+            })),
+            summary: { created: 40, overwritten: 0, skipped: 10, renamed: 0, errors: 0, folders_created: 2 },
+        }));
+
+        // Chunk 2: 5 created, 2 skipped
+        responseQueue.push(makeMcpSuccess({
+            results: Array.from({ length: 7 }, (_, i) => ({
+                index: i,
+                status: i < 5 ? 'created' : 'skipped',
+                id: `doc-${i + 50}`,
+            })),
+            summary: { created: 5, overwritten: 0, skipped: 2, renamed: 0, errors: 0, folders_created: 0 },
+        }));
+
+        const { dir, cleanup } = makeTmpDocsDir(files);
+        const restoreExit = patchProcessExit();
+        const { lines: logLines, restore: restoreStdout } = captureStdout();
+
+        try {
+            let caughtExit: ProcessExitError | null = null;
+            try {
+                await docsPushWithConfig(dir, { onConflict: 'skip' }, stubConfig());
+            } catch (e) {
+                if (e instanceof ProcessExitError) caughtExit = e;
+                else throw e;
+            }
+
+            expect(caughtExit?.code).toBe(0);
+            const out = logLines.join('\n');
+
+            // Total created: 45, skipped: 12
+            expect(out).toContain('45');
+            expect(out).toContain('12');
+        } finally {
+            restoreExit();
+            restoreStdout();
+            cleanup();
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: error handling
+// ---------------------------------------------------------------------------
+
+describe('docsPushWithConfig — error handling', () => {
+    it('exits non-zero with an error message when the directory does not exist', async () => {
+        const restoreExit = patchProcessExit();
+        const { lines: stderrLines, restore: restoreStderr } = captureStderr();
+
+        try {
+            let caughtExit: ProcessExitError | null = null;
+            try {
+                await docsPushWithConfig('/nonexistent/path/that/does/not/exist', { onConflict: 'skip' }, stubConfig());
+            } catch (e) {
+                if (e instanceof ProcessExitError) caughtExit = e;
+                else throw e;
+            }
+
+            expect(caughtExit).not.toBeNull();
+            expect(caughtExit!.code).not.toBe(0);
+            expect(stderrLines.join('')).toMatch(/not a directory|does not exist/i);
+        } finally {
+            restoreExit();
+            restoreStderr();
+        }
+    });
+
+    it('exits non-zero when the directory has no .md files', async () => {
+        const { dir, cleanup } = makeTmpDocsDir({ 'readme.txt': 'not a markdown file' });
+        const restoreExit = patchProcessExit();
+        const { lines: stderrLines, restore: restoreStderr } = captureStderr();
+
+        try {
+            let caughtExit: ProcessExitError | null = null;
+            try {
+                await docsPushWithConfig(dir, { onConflict: 'skip' }, stubConfig());
+            } catch (e) {
+                if (e instanceof ProcessExitError) caughtExit = e;
+                else throw e;
+            }
+
+            expect(caughtExit).not.toBeNull();
+            expect(caughtExit!.code).not.toBe(0);
+            expect(stderrLines.join('')).toMatch(/no .md files|nothing to push/i);
+        } finally {
+            restoreExit();
+            restoreStderr();
+            cleanup();
+        }
+    });
+});

--- a/tests/docs-tool.test.ts
+++ b/tests/docs-tool.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Tests for callDocsTool — verifies it POSTs to /mcp/docs with the correct
+ * JSON-RPC envelope, headers, and response unwrapping.
+ *
+ * Uses a real in-process HTTP server (Node's http.createServer) to stub the
+ * /mcp/docs endpoint.  No mock/spy/stub libraries.
+ */
+
+import * as http from 'http';
+import { describe, expect, it, beforeAll, afterAll, beforeEach } from 'vitest';
+import { callDocsTool } from '../src/utils/mcp';
+import type { Config } from '../src/utils/config';
+
+// ---------------------------------------------------------------------------
+// Stub MCP server — records the last request and returns a canned response
+// ---------------------------------------------------------------------------
+
+interface CapturedRequest {
+    method: string | undefined;
+    path: string | undefined;
+    headers: http.IncomingHttpHeaders;
+    body: any;
+}
+
+let stubServer: http.Server;
+let stubPort: number;
+let lastCapture: CapturedRequest | null = null;
+
+/** Canned MCP success response. */
+function makeMcpSuccess(toolData: object): string {
+    return JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        result: {
+            isError: false,
+            content: [{ type: 'text', text: JSON.stringify(toolData) }],
+        },
+    });
+}
+
+let nextResponse = makeMcpSuccess({ items: [] });
+
+beforeAll(async () => {
+    stubServer = http.createServer((req, res) => {
+        let rawBody = '';
+        req.on('data', (chunk) => { rawBody += chunk; });
+        req.on('end', () => {
+            let parsedBody: any = null;
+            try { parsedBody = JSON.parse(rawBody); } catch { /* ignore */ }
+
+            lastCapture = {
+                method: req.method,
+                path: req.url,
+                headers: req.headers,
+                body: parsedBody,
+            };
+
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(nextResponse);
+        });
+    });
+
+    await new Promise<void>((resolve) => {
+        stubServer.listen(0, '127.0.0.1', () => {
+            stubPort = (stubServer.address() as { port: number }).port;
+            resolve();
+        });
+    });
+});
+
+afterAll(() => {
+    return new Promise<void>((resolve, reject) => {
+        stubServer.close((err) => (err ? reject(err) : resolve()));
+    });
+});
+
+beforeEach(() => {
+    lastCapture = null;
+    nextResponse = makeMcpSuccess({ items: [] });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a Config that points at the stub server. */
+function stubConfig(workspaceId = 'ws-docs-test'): Config {
+    return {
+        host: `http://127.0.0.1:${stubPort}`,
+        apiKey: 'test-api-key',
+        workspaceId,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('callDocsTool', () => {
+    it('POSTs to /mcp/docs (not /mcp/crews)', async () => {
+        await callDocsTool(stubConfig(), 'docs_vault', { action: 'list' });
+
+        expect(lastCapture).not.toBeNull();
+        expect(lastCapture!.path).toBe('/mcp/docs');
+    });
+
+    it('sends the correct X-Workspace-Id header', async () => {
+        await callDocsTool(stubConfig('ws-abc-123'), 'docs_vault', { action: 'list' });
+
+        expect(lastCapture!.headers['x-workspace-id']).toBe('ws-abc-123');
+    });
+
+    it('sends Accept header that includes text/event-stream (streamable-HTTP transport)', async () => {
+        await callDocsTool(stubConfig(), 'docs_vault', { action: 'list' });
+
+        const accept = lastCapture!.headers['accept'] as string;
+        expect(accept).toContain('text/event-stream');
+    });
+
+    it('sends the correct JSON-RPC tools/call envelope with name and arguments', async () => {
+        await callDocsTool(stubConfig(), 'docs_vault', { action: 'list' });
+
+        const body = lastCapture!.body;
+        expect(body.jsonrpc).toBe('2.0');
+        expect(body.method).toBe('tools/call');
+        expect(body.params.name).toBe('docs_vault');
+        expect(body.params.arguments).toEqual({ action: 'list' });
+    });
+
+    it('uses POST method', async () => {
+        await callDocsTool(stubConfig(), 'docs_vault', { action: 'list' });
+
+        expect(lastCapture!.method).toBe('POST');
+    });
+
+    it('sends Authorization: Bearer header', async () => {
+        await callDocsTool(stubConfig(), 'docs_vault', { action: 'list' });
+
+        expect(lastCapture!.headers['authorization']).toBe('Bearer test-api-key');
+    });
+
+    it('unwraps response content[0].text and returns {ok:true, data} on success', async () => {
+        const toolData = { items: [{ id: 'doc-1', title: 'My Doc' }] };
+        nextResponse = makeMcpSuccess(toolData);
+
+        const result = await callDocsTool(stubConfig(), 'docs_vault', { action: 'list' });
+
+        expect(result.ok).toBe(true);
+        expect(result.data).toEqual(toolData);
+    });
+
+    it('returns {ok:false, data:{code,message}} when isError:true in response', async () => {
+        nextResponse = JSON.stringify({
+            jsonrpc: '2.0',
+            id: 1,
+            result: {
+                isError: true,
+                content: [{ type: 'text', text: JSON.stringify({ code: 'not_found', message: 'Vault not found.' }) }],
+            },
+        });
+
+        const result = await callDocsTool(stubConfig(), 'docs_vault', { action: 'list' });
+
+        expect(result.ok).toBe(false);
+        expect(result.data).toEqual({ code: 'not_found', message: 'Vault not found.' });
+    });
+});


### PR DESCRIPTION
## Summary

The CLI half of SolidActions/solidactions-app#255 — the headline `solidactions docs push` command.

- **`solidactions docs push <dir>`** — recursively uploads a local markdown tree into SA-Docs via the docs MCP `docs_vault bulk_create` tool: mirrors folder structure (auto-created server-side), chunks items ≤50/call, and prints a report that **separates fully-published docs from "properties pending"** ones (missing/invalid keys per file).
- Flags: `--on-conflict skip|overwrite|rename` (default `skip`), `--type <slug>`, `--dry-run`, `--json`.
- **`callDocsTool`** (`/mcp/docs`) added via a DRY refactor of `callCrewsTool` (shared `callMcpTool`).

Out of scope for v1 (noted in the app-side spec): per-file frontmatter `type:` override, `docs pull`.

## Test Plan
- [x] vitest green — new `docs-tool` (8) + `docs-push` (17) tests; correlation, chunking (>50), folder mirroring, dry-run, report, error paths
- [x] `npm run build` clean
- [x] Live smoke against a local MCP: dry-run + real push of a fixture tree, folder mirroring + properties-pending report verified end-to-end
- [ ] Note: 4 pre-existing `dev.test.ts` failures on `main` (missing `@solidactions/sdk/testing`) are unrelated to this change

Pairs with **SolidActions/solidactions-app#258** which adds the property gating + `properties_pending` this report surfaces. Completes the CLI side of SolidActions/solidactions-app#255.

🤖 Generated with [Claude Code](https://claude.com/claude-code)