### PR TITLE
feat(cli): docs push --folder <base> (#255)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@solidactions/cli",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@solidactions/cli",
-      "version": "1.15.0",
+      "version": "1.16.0",
       "license": "MIT",
       "dependencies": {
         "archiver": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solidactions/cli",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "SolidActions CLI - Deploy and manage workflow automation",
   "main": "dist/index.js",
   "bin": {

--- a/src/commands/docs-push.ts
+++ b/src/commands/docs-push.ts
@@ -18,6 +18,8 @@ import { callDocsTool } from '../utils/mcp';
 export interface DocsPushOptions {
     onConflict?: 'skip' | 'overwrite' | 'rename';
     type?: string;
+    /** Nest the whole upload under this base folder path in SA-Docs. */
+    folder?: string;
     dryRun?: boolean;
     json?: boolean;
 }
@@ -198,6 +200,10 @@ export async function docsPushWithConfig(
 
         if (options.type) {
             callArgs.type = options.type;
+        }
+        if (options.folder) {
+            // Top-level base for every item; each item's relative_folder_path nests under it.
+            callArgs.folder_path = options.folder;
         }
         if (options.dryRun) {
             callArgs.dry_run = true;

--- a/src/index.ts
+++ b/src/index.ts
@@ -524,10 +524,11 @@ docs
     .argument('<dir>', 'Path to the directory containing markdown files')
     .option('--on-conflict <mode>', 'Conflict resolution: skip|overwrite|rename (default: skip)', 'skip')
     .option('--type <slug>', 'Doc-type slug to apply to all uploaded docs')
+    .option('--folder <base>', 'Nest the whole upload under this base folder path in SA-Docs')
     .option('--dry-run', 'Preview what would be created without writing')
     .option('--json', 'Output result as JSON')
     .action(async (dir, options) => {
-        await docsPush(dir, { onConflict: options.onConflict, type: options.type, dryRun: options.dryRun, json: options.json });
+        await docsPush(dir, { onConflict: options.onConflict, type: options.type, folder: options.folder, dryRun: options.dryRun, json: options.json });
     });
 
 program.parseAsync().catch((err) => {

--- a/tests/docs-push.test.ts
+++ b/tests/docs-push.test.ts
@@ -837,3 +837,58 @@ describe('docsPushWithConfig — error handling', () => {
         }
     });
 });
+
+// ---------------------------------------------------------------------------
+// Tests: --folder <base> nests the whole upload under a base folder path
+// ---------------------------------------------------------------------------
+
+describe('docsPushWithConfig — --folder base', () => {
+    it('forwards --folder as the top-level folder_path on every bulk_create call', async () => {
+        const { dir, cleanup } = makeTmpDocsDir({
+            'root.md': '# Root',
+            'sub/nested.md': '# Nested',
+        });
+        const restoreExit = patchProcessExit();
+        const { restore: restoreStdout } = captureStdout();
+
+        try {
+            try {
+                await docsPushWithConfig(dir, { onConflict: 'skip', folder: '4 MomentFactory' }, stubConfig());
+            } catch (e) {
+                if (!(e instanceof ProcessExitError)) throw e;
+            }
+
+            expect(allCaptures.length).toBe(1);
+            const args = allCaptures[0].body.params.arguments;
+            expect(args.folder_path).toBe('4 MomentFactory');
+            // relative_folder_path on nested item is still relative to <dir> (server appends under base)
+            const nested = args.items.find((i: any) => i.title === 'nested');
+            expect(nested.relative_folder_path).toBe('sub');
+        } finally {
+            restoreExit();
+            restoreStdout();
+            cleanup();
+        }
+    });
+
+    it('omits folder_path when --folder is not given', async () => {
+        const { dir, cleanup } = makeTmpDocsDir({ 'root.md': '# Root' });
+        const restoreExit = patchProcessExit();
+        const { restore: restoreStdout } = captureStdout();
+
+        try {
+            try {
+                await docsPushWithConfig(dir, { onConflict: 'skip' }, stubConfig());
+            } catch (e) {
+                if (!(e instanceof ProcessExitError)) throw e;
+            }
+
+            expect(allCaptures.length).toBe(1);
+            expect(allCaptures[0].body.params.arguments).not.toHaveProperty('folder_path');
+        } finally {
+            restoreExit();
+            restoreStdout();
+            cleanup();
+        }
+    });
+});


### PR DESCRIPTION
## Summary

Adds `--folder <base>` to `solidactions docs push` — nests the entire upload under a chosen base folder in SA-Docs instead of mirroring onto the vault root. The docs analog of `skill push --role`.

```
solidactions docs push ~/wiki/momentfactory --folder "4 MomentFactory"
# → everything lands under "4 MomentFactory/…" (each file's relative path nests beneath it)
```

CLI-only: forwards to the existing `bulk_create` top-level `folder_path` param (server already combines base + each item's `relative_folder_path`). No MCP change.

Also bumps the package to **1.16.0**.

## Test Plan
- [x] vitest green — 19 docs-push tests incl. 2 new `--folder` cases (forwards `folder_path`; omitted when absent)
- [x] `npm run build` clean
- [x] Live-verified against local MCP: `--folder "QA Run"` lands docs under `QA Run/…` and nested under `QA Run/sub`
- [x] tmux QA agent ran the full `docs push` surface (dry-run, real, --folder, idempotent skip, fix-and-overwrite-clears-pending, --json, error path) against the live dev stack — all PASS

Follow-up to #255 (docs push). 

🤖 Generated with [Claude Code](https://claude.com/claude-code)