### PR TITLE
fix(deploy): anchor dist/ and vendor/ default excludes to project root

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@solidactions/cli",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@solidactions/cli",
-      "version": "1.17.0",
+      "version": "1.17.1",
       "license": "MIT",
       "dependencies": {
         "archiver": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solidactions/cli",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "description": "SolidActions CLI - Deploy and manage workflow automation",
   "main": "dist/index.js",
   "bin": {

--- a/src/utils/deploy-ignore.ts
+++ b/src/utils/deploy-ignore.ts
@@ -6,12 +6,19 @@ import { SolidActionsConfig } from './env';
 /**
  * Layer-2 matcher defaults (gitignore syntax). These are excluded unless a later
  * pattern (deploy.exclude or .gitignore) re-includes them via a `!` negation.
+ *
+ * `dist/` and `vendor/` are anchored to the project root (`/dist/`, `/vendor/`)
+ * so they only strip the project's own build output. An unanchored `dist/` /
+ * `vendor/` matches at any depth and wrongly excludes a vendored dependency's
+ * own build output — e.g. a `"@solidactions/sdk": "file:./sdk"` dep whose code
+ * lives in `sdk/dist/`, which then fails to resolve at build time.
+ * `node_modules/` and `.git/` stay unanchored: those are never wanted at any depth.
  */
 export const DEFAULT_DEPLOY_IGNORES: string[] = [
     'node_modules/',
     '.git/',
-    'dist/',
-    'vendor/',
+    '/dist/',
+    '/vendor/',
 ];
 
 /**

--- a/tests/deploy-ignore.test.ts
+++ b/tests/deploy-ignore.test.ts
@@ -52,6 +52,22 @@ describe('buildDeployMatcher (Layer 2)', () => {
         expect(matcher.ignores('vendor/x')).toBe(true);
     });
 
+    it('anchors dist/ and vendor/ to the project root (keeps a vendored dep\'s dist/)', () => {
+        const { matcher } = buildDeployMatcher('/nonexistent', null);
+        // Root build output is still excluded.
+        expect(matcher.ignores('dist/a.js')).toBe(true);
+        expect(matcher.ignores('vendor/x')).toBe(true);
+        // But a vendored dependency that ships its own dist/ or vendor/ is kept.
+        // Regression: a `file:./sdk` dependency resolves through sdk/dist, which a
+        // bare (unanchored) `dist/` default would wrongly strip — breaking the build.
+        expect(matcher.ignores('sdk/dist/index.js')).toBe(false);
+        expect(matcher.ignores('packages/foo/vendor/autoload.php')).toBe(false);
+        // node_modules and .git stay excluded at ANY depth.
+        expect(matcher.ignores('node_modules/x')).toBe(true);
+        expect(matcher.ignores('packages/foo/node_modules/y')).toBe(true);
+        expect(matcher.ignores('sub/.git/HEAD')).toBe(true);
+    });
+
     it('does NOT exclude a normal source file', () => {
         const { matcher } = buildDeployMatcher('/nonexistent', null);
         expect(matcher.ignores('src/index.ts')).toBe(false);
@@ -218,6 +234,23 @@ describe('planDeployFiles (walker)', () => {
         expect(files).toContain('src/index.ts');
         expect(files.some(f => f.startsWith('node_modules/'))).toBe(false);
         expect(files).not.toContain('node_modules/pkg/deep/nested/decoy.js');
+    });
+
+    it('keeps a vendored dependency\'s nested dist/ (regression: file:./sdk -> sdk/dist)', () => {
+        writeFile(root, 'package.json', '{}');
+        writeFile(root, 'src/index.ts', '');
+        writeFile(root, 'sdk/package.json', '{}');
+        writeFile(root, 'sdk/dist/index.js', 'SDK');
+        writeFile(root, 'sdk/dist/schemas/a.json', '{}');
+        // Root build output and node_modules must still be pruned.
+        writeFile(root, 'dist/out.js', 'ROOT_BUILD');
+        writeFile(root, 'node_modules/pkg/index.js', 'DEP');
+
+        const { files } = planDeployFiles(root, { workflows: [] });
+        expect(files).toContain('sdk/dist/index.js');
+        expect(files).toContain('sdk/dist/schemas/a.json');
+        expect(files).not.toContain('dist/out.js');
+        expect(files.some(f => f.startsWith('node_modules/'))).toBe(false);
     });
 
     it('excludes .env at root even with no deploy config', () => {


### PR DESCRIPTION
## The bug

#44 set the default deploy excludes as **bare** gitignore patterns:

```
node_modules/  .git/  dist/  vendor/
```

`dist/` and `vendor/` (bare) match at **any depth**, so they strip a vendored dependency's own build output. sdk-test declares `"@solidactions/sdk": "file:./sdk"` and the SDK's code lives in `sdk/dist/` — which got stripped from the bundle. The sandbox then can't resolve the SDK and the build dies:

```
error TS2307: Cannot find module '@solidactions/sdk' or its corresponding type declarations.
```

This broke **every** `examples/sdk-test` deploy — and therefore the entire solidactions-app e2e suite — on `@solidactions/cli` ≥ 1.17.0.

## The fix

Anchor the two build-output defaults to the project root:

```diff
-    'dist/',
-    'vendor/',
+    '/dist/',
+    '/vendor/',
```

Root build output is still excluded; a vendored dep's nested `dist/`/`vendor/` is kept. `node_modules/` and `.git/` stay unanchored (never wanted at any depth).

## Verification

- New regression tests (matcher + walker level) for the `file:./sdk → sdk/dist` case; **25/25** deploy-ignore tests pass (23 existing + 2 new).
- Live repro against a local stack: with this build, deploying sdk-test now ships **189** `sdk/dist/**` files while root `dist/` and `node_modules/` stay excluded (was **0** `sdk/dist/` before the fix).

Bumps `1.17.0 → 1.17.1`. Unblocks solidactions-app#299 (whose e2e fails today purely because of this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)