### PR TITLE
feat(cli): project create — create an empty project without deploying (#47)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Use `solidactions <command> --help` for full flag details on any command.
 
 | Command | Key Flags | Description |
 |---------|-----------|-------------|
+| `project create <name>` | `-e` | Create an empty project (no source/build); `-e` defaults to `production` |
 | `project deploy <name> [path]` | `-e`, `--create`, `--config-only` | Deploy or sync config only |
 | `project pull <name> [path]` | `-y` | Pull source (warns before overwriting) |
 | `project logs <name>` | | View build logs |

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -8,6 +8,7 @@ import yaml from 'js-yaml';
 import { SolidActionsConfig, parseYamlEnvVars } from '../utils/env';
 import { getApiHeaders, requireConfigWithWorkspace } from '../utils/api';
 import { planDeployFiles } from '../utils/deploy-ignore';
+import { buildProjectSlug } from '../utils/slug';
 
 /**
  * Validate project structure before deployment.
@@ -278,7 +279,7 @@ export async function deploy(projectName: string, sourcePath?: string, options: 
             }
 
             console.log(chalk.yellow(`Project "${projectName}"${envLabel} not found. Creating...`));
-            const requestedSlug = projectName.toLowerCase().replace(/[^a-z0-9-]/g, '-') + (environment !== 'production' ? `-${environment}` : '');
+            const requestedSlug = buildProjectSlug(projectName, environment);
             try {
                 const createResponse = await axios.post(`${config.host}/api/v1/projects`, {
                     name: projectName,

--- a/src/commands/project-create.ts
+++ b/src/commands/project-create.ts
@@ -1,0 +1,75 @@
+/**
+ * solidactions project create <name> [-e <environment>]
+ *
+ * Creates a project + environment via POST /api/v1/projects WITHOUT uploading
+ * any source or triggering a build. This is the empty-project path that the web
+ * UI already offers; `project deploy` creates-on-demand but always builds.
+ *
+ * When -e is omitted we default to `production`: a project needs a production
+ * root before dev/staging children can attach to it, so creating the root is
+ * the sensible default (mirrors the guidance in `project deploy`).
+ */
+
+import axios from 'axios';
+import chalk from 'chalk';
+import { Config } from '../utils/config';
+import { getApiHeaders, requireConfigWithWorkspace } from '../utils/api';
+import { buildProjectSlug, slugifyName } from '../utils/slug';
+
+export interface ProjectCreateOptions {
+    env?: string;
+}
+
+/**
+ * Core implementation — accepts an injected config so tests can point at a
+ * stub server without touching the filesystem config.
+ */
+export async function projectCreateWithConfig(
+    name: string,
+    options: ProjectCreateOptions,
+    config: Config,
+): Promise<void> {
+    const environment = options.env ?? 'production';
+
+    // Reject names that produce no usable slug (e.g. "!!!" or non-Latin scripts)
+    // up front, with a clear client-side message instead of an opaque 422.
+    // Name/slug length is left to the server, which owns those limits.
+    if (slugifyName(name) === '') {
+        console.error(chalk.red(`Invalid project name "${name}": it must contain letters or numbers (a-z, 0-9).`));
+        process.exit(1);
+    }
+
+    const slug = buildProjectSlug(name, environment);
+
+    const envLabel = environment !== 'production' ? ` (${environment})` : '';
+    console.log(chalk.blue(`Creating project "${name}"${envLabel}...`));
+
+    try {
+        const response = await axios.post(
+            `${config.host}/api/v1/projects`,
+            { name, slug, environment },
+            { headers: getApiHeaders(config, 'application/json') },
+        );
+
+        const createdSlug = response.data?.slug || slug;
+        console.log(chalk.green(`✓ Project "${name}"${envLabel} created.`));
+        console.log(chalk.gray(`  slug: ${createdSlug}`));
+    } catch (error: any) {
+        if (error.response) {
+            if (error.response.status === 401) {
+                console.error(chalk.red('Authentication failed. Run "solidactions login <api-key>" to re-configure.'));
+            } else {
+                console.error(chalk.red('Failed to create project:'), error.response.data?.message || error.message);
+            }
+        } else {
+            console.error(chalk.red('Connection failed:'), error.message);
+        }
+        process.exit(1);
+    }
+}
+
+/** Entry point wired into the CLI — resolves config, then delegates. */
+export async function projectCreate(name: string, options: ProjectCreateOptions): Promise<void> {
+    const config = await requireConfigWithWorkspace();
+    await projectCreateWithConfig(name, options, config);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { login, logout, whoami } from './commands/login';
 import { init } from './commands/init';
 import { pull } from './commands/pull';
 import { projectList } from './commands/project-list';
+import { projectCreate } from './commands/project-create';
 import { logsBuild } from './commands/project-logs';
 import { run } from './commands/run-start';
 import { runs } from './commands/run-list';
@@ -149,6 +150,15 @@ program
 // =============================================================================
 
 const project = program.command('project').description('Manage projects');
+
+project
+    .command('create')
+    .description('Create an empty project (and environment) without deploying source')
+    .argument('<name>', 'Project name')
+    .option('-e, --env <environment>', 'Target environment (production/staging/dev). Defaults to production.')
+    .action(async (name, options) => {
+        await projectCreate(name, options);
+    });
 
 project
     .command('deploy')

--- a/src/utils/slug.ts
+++ b/src/utils/slug.ts
@@ -1,0 +1,32 @@
+/**
+ * Project slug generation — shared by `project create` and `project deploy`
+ * so the two commands always produce identical slugs for the same input.
+ *
+ * The server is the authority on slugs (it re-derives/validates on write); this
+ * client-side slug is what we send in the POST body and use for follow-up
+ * lookups. Keeping it normalized avoids odd values like `foo--bar` or `-foo-`.
+ */
+
+/**
+ * Normalize a free-text project name into a slug fragment:
+ * lowercase, collapse every run of non-alphanumerics to a single hyphen, and
+ * trim leading/trailing hyphens. Returns '' when the name has no usable
+ * alphanumeric characters (e.g. "!!!" or "你好") — callers should treat an
+ * empty result as invalid input.
+ */
+export function slugifyName(name: string): string {
+    return name
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+}
+
+/**
+ * Build the full project slug for an environment. Non-production environments
+ * get a `-<environment>` suffix (matching the deploy create flow); production
+ * is the bare root slug.
+ */
+export function buildProjectSlug(name: string, environment: string): string {
+    const base = slugifyName(name);
+    return environment !== 'production' ? `${base}-${environment}` : base;
+}

--- a/tests/project-create.test.ts
+++ b/tests/project-create.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Tests for `solidactions project create`
+ *
+ * Uses a real in-process HTTP server to stub the /api/v1/projects endpoint.
+ * No mocks/stubs/spies — follows the pattern from skill-list.test.ts.
+ */
+
+import * as http from 'http';
+import { describe, expect, it, beforeAll, afterAll, beforeEach } from 'vitest';
+import { projectCreateWithConfig } from '../src/commands/project-create';
+import type { Config } from '../src/utils/config';
+
+// ---------------------------------------------------------------------------
+// Stub API server
+// ---------------------------------------------------------------------------
+
+interface CapturedRequest {
+    method: string | undefined;
+    path: string | undefined;
+    headers: http.IncomingHttpHeaders;
+    body: any;
+}
+
+let stubServer: http.Server;
+let stubPort: number;
+let lastCapture: CapturedRequest | null = null;
+let allCaptures: CapturedRequest[] = [];
+
+// Each entry: { status, body }. Dequeued per request; defaults to 201 success.
+let responseQueue: Array<{ status: number; body: object }> = [];
+
+function nextResponse(req: CapturedRequest): { status: number; body: object } {
+    if (responseQueue.length > 0) return responseQueue.shift()!;
+    // Default: echo back a created project.
+    const slug = req.body?.slug ?? 'echo-slug';
+    return { status: 201, body: { slug, name: req.body?.name, environment: req.body?.environment } };
+}
+
+beforeAll(async () => {
+    stubServer = http.createServer((req, res) => {
+        let rawBody = '';
+        req.on('data', (chunk) => { rawBody += chunk; });
+        req.on('end', () => {
+            let parsedBody: any = null;
+            try { parsedBody = JSON.parse(rawBody); } catch { /* ignore */ }
+
+            const capture: CapturedRequest = {
+                method: req.method,
+                path: req.url,
+                headers: req.headers,
+                body: parsedBody,
+            };
+            lastCapture = capture;
+            allCaptures.push(capture);
+
+            const { status, body } = nextResponse(capture);
+            res.writeHead(status, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify(body));
+        });
+    });
+
+    await new Promise<void>((resolve) => {
+        stubServer.listen(0, '127.0.0.1', () => {
+            stubPort = (stubServer.address() as { port: number }).port;
+            resolve();
+        });
+    });
+});
+
+afterAll(() => {
+    return new Promise<void>((resolve, reject) => {
+        stubServer.close((err) => (err ? reject(err) : resolve()));
+    });
+});
+
+beforeEach(() => {
+    lastCapture = null;
+    allCaptures = [];
+    responseQueue = [];
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function stubConfig(workspaceId = 'ws-test-uuid'): Config {
+    return {
+        host: `http://127.0.0.1:${stubPort}`,
+        apiKey: 'test-api-key',
+        workspaceId,
+    };
+}
+
+class ProcessExitError extends Error {
+    constructor(public readonly code: number | undefined) {
+        super(`process.exit(${code})`);
+    }
+}
+
+function patchProcessExit(): () => void {
+    const orig = process.exit.bind(process);
+    (process as any).exit = (code?: number) => { throw new ProcessExitError(code); };
+    return () => { (process as any).exit = orig; };
+}
+
+function captureStderr(): { lines: string[]; restore: () => void } {
+    const lines: string[] = [];
+    const orig = console.error;
+    console.error = (...args: any[]) => { lines.push(args.map(String).join(' ')); };
+    return { lines, restore: () => { console.error = orig; } };
+}
+
+function captureStdout(): { lines: string[]; restore: () => void } {
+    const lines: string[] = [];
+    const orig = console.log;
+    console.log = (...args: any[]) => { lines.push(args.map(String).join(' ')); };
+    return { lines, restore: () => { console.log = orig; } };
+}
+
+/** Run the command, swallowing the process.exit throw and returning its code. */
+async function runCreate(name: string, options: any, config: Config = stubConfig()): Promise<{ code: number | undefined; stdout: string[]; stderr: string[] }> {
+    const restoreExit = patchProcessExit();
+    const out = captureStdout();
+    const err = captureStderr();
+    let code: number | undefined = 0;
+    try {
+        try {
+            await projectCreateWithConfig(name, options, config);
+        } catch (e) {
+            if (e instanceof ProcessExitError) code = e.code;
+            else throw e;
+        }
+    } finally {
+        restoreExit();
+        out.restore();
+        err.restore();
+    }
+    return { code, stdout: out.lines, stderr: err.lines };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('projectCreateWithConfig', () => {
+    it('POSTs to /api/v1/projects with name, slug and default production environment', async () => {
+        const { code } = await runCreate('My Project', {});
+
+        expect(code).toBe(0);
+        expect(lastCapture).not.toBeNull();
+        expect(lastCapture!.method).toBe('POST');
+        expect(lastCapture!.path).toBe('/api/v1/projects');
+        expect(lastCapture!.body.name).toBe('My Project');
+        // production root → no environment suffix on the slug
+        expect(lastCapture!.body.slug).toBe('my-project');
+        expect(lastCapture!.body.environment).toBe('production');
+    });
+
+    it('sends Authorization and X-Workspace-Id headers', async () => {
+        await runCreate('foo', {});
+        expect(lastCapture!.headers['authorization']).toBe('Bearer test-api-key');
+        expect(lastCapture!.headers['x-workspace-id']).toBe('ws-test-uuid');
+    });
+
+    it('appends the environment suffix to the slug for non-production envs', async () => {
+        await runCreate('My Project', { env: 'dev' });
+        expect(lastCapture!.body.environment).toBe('dev');
+        expect(lastCapture!.body.slug).toBe('my-project-dev');
+    });
+
+    it('normalizes the slug: trims and collapses separators', async () => {
+        await runCreate('  My  Project!  ', {});
+        expect(lastCapture!.body.slug).toBe('my-project');
+    });
+
+    it('collapses existing repeated hyphens in the slug', async () => {
+        await runCreate('my--project', {});
+        expect(lastCapture!.body.slug).toBe('my-project');
+    });
+
+    it('rejects an all-punctuation name without sending a request', async () => {
+        const { code, stderr } = await runCreate('!!!', {});
+        expect(code).not.toBe(0);
+        expect(stderr.join('\n').toLowerCase()).toContain('invalid project name');
+        expect(allCaptures).toHaveLength(0);
+    });
+
+    it('rejects a name with no Latin alphanumerics (e.g. non-Latin script)', async () => {
+        const { code, stderr } = await runCreate('你好', {});
+        expect(code).not.toBe(0);
+        expect(stderr.join('\n').toLowerCase()).toContain('invalid project name');
+        expect(allCaptures).toHaveLength(0);
+    });
+
+    it('does NOT upload any source / does not call the deploy endpoint', async () => {
+        await runCreate('foo', {});
+        // Exactly one request, and it is the create POST (never .../deploy)
+        expect(allCaptures).toHaveLength(1);
+        expect(allCaptures[0].path).toBe('/api/v1/projects');
+    });
+
+    it('prints a success message including the project name', async () => {
+        const { stdout } = await runCreate('foo', {});
+        expect(stdout.join('\n').toLowerCase()).toContain('created');
+        expect(stdout.join('\n')).toContain('foo');
+    });
+
+    it('on 401 prints an auth error and exits non-zero', async () => {
+        responseQueue = [{ status: 401, body: { message: 'Unauthenticated.' } }];
+        const { code, stderr } = await runCreate('foo', {});
+        expect(code).not.toBe(0);
+        expect(stderr.join('\n').toLowerCase()).toContain('auth');
+    });
+
+    it('on 422 (already exists) prints the server message and exits non-zero', async () => {
+        responseQueue = [{ status: 422, body: { message: 'A project with this slug already exists.' } }];
+        const { code, stderr } = await runCreate('foo', {});
+        expect(code).not.toBe(0);
+        expect(stderr.join('\n')).toContain('already exists');
+    });
+
+    it('on a 500 with no message body still fails cleanly (falls back to axios error text)', async () => {
+        responseQueue = [{ status: 500, body: {} }];
+        const { code, stderr } = await runCreate('foo', {});
+        expect(code).not.toBe(0);
+        const text = stderr.join('\n');
+        expect(text).toContain('Failed to create project');
+        // No "undefined" leaking into the message when the body has no `message`.
+        expect(text.toLowerCase()).not.toContain('undefined');
+    });
+
+    it('on a network/connection failure prints "Connection failed" and exits non-zero', async () => {
+        // Port 1 is unbound → ECONNREFUSED, no response object on the error.
+        const badConfig: Config = { host: 'http://127.0.0.1:1', apiKey: 'k', workspaceId: 'ws' };
+        const { code, stderr } = await runCreate('foo', {}, badConfig);
+        expect(code).not.toBe(0);
+        expect(stderr.join('\n')).toContain('Connection failed');
+        expect(allCaptures).toHaveLength(0);
+    });
+});

--- a/tests/slug.test.ts
+++ b/tests/slug.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Tests for the shared project-slug helper used by `project create` and
+ * `project deploy`.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { slugifyName, buildProjectSlug } from '../src/utils/slug';
+
+describe('slugifyName', () => {
+    it('lowercases and hyphenates spaces', () => {
+        expect(slugifyName('My Project')).toBe('my-project');
+    });
+
+    it('trims leading/trailing separators', () => {
+        expect(slugifyName('  My Project!  ')).toBe('my-project');
+        expect(slugifyName('-foo-')).toBe('foo');
+    });
+
+    it('collapses runs of non-alphanumerics to a single hyphen', () => {
+        expect(slugifyName('a  b')).toBe('a-b');
+        expect(slugifyName('my--project')).toBe('my-project');
+        expect(slugifyName('foo!!!bar')).toBe('foo-bar');
+    });
+
+    it('drops non-Latin / accented characters, keeping the alphanumeric remainder', () => {
+        expect(slugifyName('Café')).toBe('caf');
+    });
+
+    it('returns empty string when there is nothing usable', () => {
+        expect(slugifyName('!!!')).toBe('');
+        expect(slugifyName('你好')).toBe('');
+        expect(slugifyName('')).toBe('');
+    });
+});
+
+describe('buildProjectSlug', () => {
+    it('returns the bare slug for production', () => {
+        expect(buildProjectSlug('My Project', 'production')).toBe('my-project');
+    });
+
+    it('appends the environment suffix for non-production', () => {
+        expect(buildProjectSlug('My Project', 'dev')).toBe('my-project-dev');
+        expect(buildProjectSlug('My Project', 'staging')).toBe('my-project-staging');
+    });
+});


### PR DESCRIPTION
## What

Adds `solidactions project create <name> [-e <environment>]` — creates a project + environment via `POST /api/v1/projects` **without uploading source or triggering a build** (UI parity for empty-project creation). Closes #47.

- `-e` defaults to `production` (the root a project needs before dev/staging children can attach).
- The `--backend` flag from #47 is **intentionally deferred** to a follow-up.

## Notes

- Slug generation is extracted into a shared `src/utils/slug.ts` used by **both** `project create` and `project deploy`, so the two produce identical, normalized slugs (collapsed/trimmed hyphens). Names with no usable alphanumerics (e.g. `!!!`, non-Latin script) are rejected client-side with a clear error.
- Error handling mirrors `project deploy` (`error.response.data?.message || error.message`).

## Tests

20 new tests (`tests/project-create.test.ts`, `tests/slug.test.ts`) — all green. Covers default-production, env suffixes, slug normalization, invalid-name rejection (no request sent), 401 / 422 / 500-no-body / network-failure paths.

> Note: 4 pre-existing `dev.test.ts` failures in this environment are unrelated — they fail on a missing `@solidactions/sdk/testing` package; this diff touches no `dev`/`sdk`/`fixtures` code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)