### PR TITLE
docs(#312): project create no longer implies a production root

### DIFF
--- a/src/commands/project-create.ts
+++ b/src/commands/project-create.ts
@@ -2,12 +2,12 @@
  * solidactions project create <name> [-e <environment>]
  *
  * Creates a project + environment via POST /api/v1/projects WITHOUT uploading
- * any source or triggering a build. This is the empty-project path that the web
- * UI already offers; `project deploy` creates-on-demand but always builds.
+ * any source or triggering a build. This is the empty-project path the web UI
+ * already offers; `project deploy` creates-on-demand but always builds.
  *
- * When -e is omitted we default to `production`: a project needs a production
- * root before dev/staging children can attach to it, so creating the root is
- * the sensible default (mirrors the guidance in `project deploy`).
+ * `-e` defaults to `production`. Non-production environments are created
+ * standalone — the server links to an existing production root if one exists
+ * but no longer auto-creates one (#312).
  */
 
 import axios from 'axios';

--- a/tests/project-create.test.ts
+++ b/tests/project-create.test.ts
@@ -237,4 +237,21 @@ describe('projectCreateWithConfig', () => {
         expect(stderr.join('\n')).toContain('Connection failed');
         expect(allCaptures).toHaveLength(0);
     });
+
+    it('creates exactly one project for -e dev (no production shell)', async () => {
+        const { code, stdout } = await runCreate('foo', { env: 'dev' });
+
+        // Exactly one POST — no implicit production root created alongside it.
+        expect(allCaptures).toHaveLength(1);
+        expect(allCaptures[0].method).toBe('POST');
+        expect(allCaptures[0].path).toBe('/api/v1/projects');
+        expect(allCaptures[0].body.name).toBe('foo');
+        expect(allCaptures[0].body.environment).toBe('dev');
+
+        expect(code).toBe(0);
+        // Success message mentions the created project.
+        const text = stdout.join('\n');
+        expect(text.toLowerCase()).toContain('created');
+        expect(text).toContain('foo');
+    });
 });


### PR DESCRIPTION
Companion to **solidactions-app#372** / app issue #312.

The server no longer auto-creates a production root when you create a non-production environment (`project create foo -e dev` now yields exactly one standalone dev project). This PR:

- Fixes the stale doc comment in `project create` that claimed "a project needs a production root before dev/staging children can attach" — no longer true.
- Adds a test asserting `project create foo -e dev` issues exactly one `POST /api/v1/projects` (environment `dev`) and creates one project, with no production shell.

No behavioral change to the CLI itself — the standalone-create behavior is delivered by the server change; this aligns the docs/tests with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
