### PR TITLE
Tee-time DX: dev multi-file fix + -e/family resolution + env-set non-TTY + deploy warning + webhook secret

### DIFF
--- a/fixtures/multi-file/entry.ts
+++ b/fixtures/multi-file/entry.ts
@@ -1,0 +1,15 @@
+/**
+ * Multi-file fixture workflow: imports a sibling module using the NodeNext
+ * .js-extension convention. This is the pattern that breaks under tsx's CJS
+ * hook (require('./lib/double.js') cannot find the real double.ts file).
+ */
+import { defineWorkflow } from '@solidactions/sdk';
+import { double } from './lib/double.js';
+
+export default defineWorkflow({
+    name: 'multi-file-echo',
+    run: async (ctx) => {
+        const input = ctx.input as { n?: number };
+        return double(input.n ?? 0);
+    },
+});

--- a/fixtures/multi-file/lib/double.ts
+++ b/fixtures/multi-file/lib/double.ts
@@ -1,0 +1,4 @@
+/** Returns n * 2. Used by the multi-file fixture to exercise .js-extension imports. */
+export function double(n: number): number {
+    return n * 2;
+}

--- a/fixtures/multi-file/package.json
+++ b/fixtures/multi-file/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "multi-file-test",
+  "type": "module"
+}

--- a/fixtures/multi-file/solidactions.yaml
+++ b/fixtures/multi-file/solidactions.yaml
@@ -1,0 +1,1 @@
+project: multi-file-test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@solidactions/cli",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@solidactions/cli",
-      "version": "1.20.0",
+      "version": "1.21.0",
       "license": "MIT",
       "dependencies": {
         "archiver": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solidactions/cli",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "description": "SolidActions CLI - Deploy and manage workflow automation",
   "main": "dist/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "deploy"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && cp src/commands/dev-shim.mjs dist/commands/dev-shim.mjs",
     "prepublishOnly": "npm run build",
     "test": "vitest run",
     "test:watch": "vitest"

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -136,6 +136,16 @@ async function pushYamlDeclarations(
     }
 }
 
+/**
+ * Returns true only when a 404 on the environment-specific project lookup
+ * will cause the deploy command to abort (non-production environment and
+ * --create was not passed). On these paths the workspace-mismatch warning
+ * should print. On all success/create paths it must be suppressed.
+ */
+export function shouldPrintWorkspaceMismatch(environment: string, willCreate: boolean): boolean {
+    return environment !== 'production' && !willCreate;
+}
+
 export async function deploy(projectName: string, sourcePath?: string, options: DeployOptions = {}) {
     const config = await requireConfigWithWorkspace();
 
@@ -179,11 +189,8 @@ export async function deploy(projectName: string, sourcePath?: string, options: 
     } catch (error: any) {
         if (error.response?.status === 404) {
             productionExists = false;
-            // App PR #128 returns "Project '<slug>' not found in your active workspace '<ws>'." on 404.
-            // The axios interceptor (utils/api.ts) already appended the "Did you mean to switch workspaces?"
-            // hint. Surface that augmented message so the user sees the hint before falling through to
-            // the first-deploy flow.
-            printWorkspaceMismatchOnce(error);
+            // Project doesn't exist yet — this is the normal first-deploy path.
+            // Do NOT print a warning here; the deploy proceeds to create/deploy successfully.
         } else {
             // 5xx, network error, auth failure, etc. — fail conservatively rather
             // than treating the project as non-existent and potentially creating it.
@@ -264,13 +271,11 @@ export async function deploy(projectName: string, sourcePath?: string, options: 
         }
     } catch (error: any) {
         if (error.response?.status === 404) {
-            // App PR #128 returns "Project '<slug>' not found in your active workspace '<ws>'." on 404.
-            // Surface the augmented message (axios interceptor already appended the hint) before
-            // falling through to the --create / first-deploy flow.
-            printWorkspaceMismatchOnce(error);
-
-            // For non-production environments, require --create or give a clear hint
-            if (environment !== 'production' && !options.create) {
+            // For non-production environments, require --create or give a clear hint.
+            // Only print the workspace-mismatch warning on this abort path — not on
+            // the success/create path (shouldPrintWorkspaceMismatch guards this).
+            if (shouldPrintWorkspaceMismatch(environment, options.create ?? false)) {
+                printWorkspaceMismatchOnce(error);
                 console.error(chalk.red(`\nProject "${projectName}" doesn't have a ${environment} environment.\n`));
                 console.error(`  If production is the intended target:`);
                 console.error(`    solidactions project deploy ${projectName} <path> -e production`);

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import { randomUUID } from 'crypto';
 import archiver from 'archiver';
 import axios from 'axios';
 import FormData from 'form-data';
@@ -94,10 +95,27 @@ function validateProject(sourceDir: string): { valid: boolean; errors: string[];
 }
 
 
+/**
+ * When `noCache` is true, returns an archive entry with a unique name and
+ * random content that busts the build-layer content hash (Blaxel/Daytona S3
+ * MD5 and BuildKit COPY . layer). Returns null when noCache is false/undefined.
+ */
+export function cacheBusterEntry(noCache: boolean): { name: string; content: string } | null {
+    if (!noCache) {
+        return null;
+    }
+    const uuid = randomUUID();
+    return {
+        name: `tenantcode/sa-nocache-${uuid}`,
+        content: `force-rebuild ${uuid} ${Date.now()}`,
+    };
+}
+
 interface DeployOptions {
     env?: string;
     create?: boolean;
     configOnly?: boolean;
+    noCache?: boolean;
 }
 
 /**
@@ -491,6 +509,15 @@ export async function deploy(projectName: string, sourcePath?: string, options: 
     ].join('\n') + '\n';
 
     archive.append(universalDockerfile, { name: 'Dockerfile' });
+
+    // --no-cache / --force-rebuild: inject a unique random-content file so all
+    // cache layers (Blaxel content hash, S3 context.tar MD5, BuildKit COPY .)
+    // see a new directory fingerprint and are forced to rebuild from scratch.
+    const buster = cacheBusterEntry(options.noCache ?? false);
+    if (buster) {
+        console.log(chalk.yellow('🔄 --no-cache: injecting cache-buster, forcing a fresh build'));
+        archive.append(buster.content, { name: buster.name });
+    }
 
     await archive.finalize();
 }

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -422,8 +422,9 @@ export async function deploy(projectName: string, sourcePath?: string, options: 
                         }
 
                         if (yamlConfig && shouldPrintWebhookSecretNotice(yamlConfig.workflows ?? [])) {
+                            const envFlag = environment !== 'dev' ? ` -e ${environment}` : '';
                             console.log('');
-                            console.log(chalk.blue(`ℹ  Webhook secret: run \`solidactions webhook secret ${projectName}\` to retrieve the generated secret.`));
+                            console.log(chalk.blue(`ℹ  Webhook secret: run \`solidactions webhook secret ${projectName}${envFlag}\` to retrieve the generated secret.`));
                             console.log(chalk.gray(`   Set the same value in your sender (e.g. Telegram setWebhook secret_token).`));
                         }
 

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -421,6 +421,12 @@ export async function deploy(projectName: string, sourcePath?: string, options: 
                             await pushYamlDeclarations(config, projectSlug, yamlConfig);
                         }
 
+                        if (yamlConfig && shouldPrintWebhookSecretNotice(yamlConfig.workflows ?? [])) {
+                            console.log('');
+                            console.log(chalk.blue(`ℹ  Webhook secret: run \`solidactions webhook secret ${projectName}\` to retrieve the generated secret.`));
+                            console.log(chalk.gray(`   Set the same value in your sender (e.g. Telegram setWebhook secret_token).`));
+                        }
+
                         fs.unlinkSync(archivePath);
                         process.exit(0);
                     } else if (status === 'error') {
@@ -486,4 +492,21 @@ export async function deploy(projectName: string, sourcePath?: string, options: 
     archive.append(universalDockerfile, { name: 'Dockerfile' });
 
     await archive.finalize();
+}
+
+/**
+ * Returns true if any workflow in the project has a webhook trigger that
+ * uses HMAC or header authentication (i.e. requires a shared secret).
+ * Used to gate the post-deploy notice pointing authors to `webhook secret`.
+ */
+export function shouldPrintWebhookSecretNotice(
+    workflows: { trigger?: string; webhook?: { auth?: string } }[]
+): boolean {
+    return workflows.some(wf => {
+        if (wf.trigger !== 'webhook') {
+            return false;
+        }
+        const auth = wf.webhook?.auth ?? 'hmac';
+        return auth === 'hmac' || auth === 'header';
+    });
 }

--- a/src/commands/dev-shim.mjs
+++ b/src/commands/dev-shim.mjs
@@ -1,0 +1,194 @@
+/**
+ * dev-shim.mjs — ESM subprocess entrypoint for `solidactions dev`.
+ *
+ * WHY THIS FILE IS .mjs (NOT .ts):
+ *   The CLI tsconfig compiles "module": "commonjs". tsc rewrites await import(x)
+ *   to Promise.resolve(x).then(s => require(s)) in CJS output (confirmed in
+ *   dist/commands/dev.js:217). A .ts shim compiled by this tsconfig would also
+ *   produce require(), which runs under tsx's CJS hook — the CJS hook does NOT
+ *   remap .js→.ts. A hand-written .mjs file bypasses tsc entirely, so its
+ *   await import() stays a real ESM dynamic import. tsx loads .mjs files under
+ *   the ESM loader, which DOES remap .js→.ts for all transitive imports.
+ *
+ * HOW IT IS SPAWNED:
+ *   npx tsx dist/commands/dev-shim.mjs <userEntry.ts>
+ *
+ * CONTEXT (from parent, via env var — no secrets to disk):
+ *   SOLIDACTIONS_DEV_SHIM_CONTEXT: JSON-encoded DevShimContext object (see below).
+ *
+ * RESULT (written to temp file, path in context):
+ *   The result file path is passed in context.resultPath. A private temp file
+ *   (mode 0o600, random UUID name) is written by the parent before spawn; the
+ *   shim writes its result JSON there; the parent reads it and unlinks it.
+ *
+ * This file is copied to dist/commands/dev-shim.mjs by the build script.
+ */
+
+import path from 'path';
+import fs from 'fs';
+import { createRequire } from 'module';
+import { randomUUID } from 'crypto';
+
+/**
+ * Serialize an unknown error value to a plain JSON-serialisable object.
+ * JSON.stringify(new Error('x')) produces {} — this ensures the message
+ * is preserved so the CLI's r.error?.message reads correctly.
+ *
+ * @param {unknown} e
+ * @returns {{ message: string; name: string; stack?: string }}
+ */
+function serializeError(e) {
+    if (e instanceof Error) {
+        return { message: e.message, name: e.name, stack: e.stack };
+    }
+    return { message: String(e), name: 'Error' };
+}
+
+async function main() {
+    const contextJson = process.env['SOLIDACTIONS_DEV_SHIM_CONTEXT'];
+
+    if (!contextJson) {
+        process.stderr.write('dev-shim: missing SOLIDACTIONS_DEV_SHIM_CONTEXT env var\n');
+        process.exit(1);
+    }
+
+    let ctx;
+    try {
+        ctx = JSON.parse(contextJson);
+    } catch (e) {
+        process.stderr.write(`dev-shim: failed to parse context JSON: ${e?.message ?? e}\n`);
+        process.exit(1);
+    }
+
+    const { entryPath, input, vars, mockBaseUrl, mockApiKey, runUuid, workerSessionId, resultPath } = ctx;
+
+    // Resolve SDK from the user entry's directory — ensures we hit the same SDK
+    // registry instance the workflow populated, not the CLI's own linked copy.
+    const _require = createRequire(entryPath);
+
+    let shimResult;
+
+    try {
+        // Import the user entry file. Under tsx's ESM loader (active because this
+        // file is .mjs), dynamic import() correctly remaps .js-extension imports
+        // to .ts files for all transitive requires in the user project.
+        const mod = await import(entryPath);
+
+        let descriptor;
+
+        if (mod?.default && typeof mod.default?.run === 'function') {
+            descriptor = mod.default;
+        } else {
+            const sdkMain = _require.resolve('@solidactions/sdk');
+            const registryPath = path.resolve(sdkMain, '..', 'invoke', 'registry.js');
+            const registry = _require(registryPath);
+            descriptor = registry.__getRegisteredWorkflows()[0];
+        }
+
+        if (!descriptor) {
+            shimResult = {
+                result: {
+                    status: 'failed',
+                    error: serializeError(new Error('no workflow registered after importing the entry file')),
+                    phase: 'run',
+                },
+            };
+            fs.writeFileSync(resultPath, JSON.stringify(shimResult), { mode: 0o600 });
+            process.exit(1);
+            return;
+        }
+
+        // Create the run-row BEFORE invoking (descriptor is now available for
+        // workflowName — preserves current behaviour where descriptor.name is
+        // used at src/commands/dev.ts:319).
+        const sdkMainForInvoke = _require.resolve('@solidactions/sdk');
+        const httpClientPath = path.resolve(sdkMainForInvoke, '..', 'http_client.js');
+        const { HttpClient } = _require(httpClientPath);
+        try {
+            const client = new HttpClient({ baseUrl: mockBaseUrl, apiKey: mockApiKey });
+            await client.post('/runs/status', {
+                workflowUUID: runUuid,
+                status: 'PENDING',
+                workflowName: descriptor.name ?? '',
+                workflowClassName: '',
+                workflowConfigName: '',
+                output: null,
+                error: null,
+                authenticatedUser: '',
+                assumedRole: '',
+                authenticatedRoles: [],
+                request: {},
+                executorId: 'local-dev',
+                applicationVersion: '0',
+                applicationID: 'local-dev',
+                createdAt: Date.now(),
+                priority: 0,
+                ownerXid: randomUUID(),
+                options: {},
+            });
+        } catch (_e) {
+            // Best-effort, symmetric with the parent's swallow.
+        }
+
+        // Build InvokeCtx using the context passed from the parent.
+        const invokeCtx = {
+            input: JSON.parse(input || '{}'),
+            vars: Object.freeze(vars),
+            run: {
+                triggerId: 'local-dev',
+                runUuid,
+                runSecret: 'local-dev',
+                workerSessionId,
+            },
+            app: {
+                appVersion: '0',
+                appId: 'local-dev',
+                tenantId: 'local-dev',
+            },
+            api: {
+                url: mockBaseUrl,
+                key: mockApiKey,
+            },
+            mode: 'local',
+        };
+
+        // Invoke via internal SDK path (same resolution as runDev).
+        const invokePath = path.resolve(sdkMainForInvoke, '..', 'invoke', 'invoke.js');
+        const { invoke } = _require(invokePath);
+        const result = await invoke(descriptor, invokeCtx);
+
+        // Serialize Error objects before JSON.stringify (Error → {} otherwise).
+        const serializedResult = {
+            ...result,
+            ...(result?.error ? { error: serializeError(result.error) } : {}),
+        };
+
+        shimResult = { result: serializedResult };
+    } catch (e) {
+        // Surface module-resolution failures with an actionable message.
+        let errorObj = serializeError(e);
+        if (e?.code === 'MODULE_NOT_FOUND' || /Cannot find module/i.test(errorObj.message)) {
+            const attempted = e?.requireStack?.[0] ?? entryPath;
+            errorObj = {
+                ...errorObj,
+                message:
+                    `Cannot find module: ${errorObj.message}\n` +
+                    `\nThis usually means a TypeScript file uses a .js-extension import (e.g. './lib/foo.js')\n` +
+                    `but the real file is foo.ts and could not be found by the loader.\n` +
+                    `\nVerify that your project's tsconfig.json sets "moduleResolution": "NodeNext" or "Bundler"\n` +
+                    `and that all imported files exist as .ts sources in: ${path.dirname(attempted)}`,
+            };
+        }
+        shimResult = {
+            result: { status: 'failed', error: errorObj, phase: 'run' },
+        };
+    }
+
+    fs.writeFileSync(resultPath, JSON.stringify(shimResult), { mode: 0o600 });
+    process.exit(shimResult.result?.status === 'failed' ? 1 : 0);
+}
+
+main().catch((e) => {
+    process.stderr.write(`dev-shim: unexpected top-level error: ${e?.message ?? e}\n`);
+    process.exit(1);
+});

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -197,6 +197,7 @@ async function runDevViaShim(
         // (run-row creation, step/sleep/recv routes). spawnSync would block the
         // parent's event loop, deadlocking the mock server — so we await an
         // async child and pump its stdout/stderr while the loop stays live.
+        let timedOut = false;
         const spawnError = await new Promise<NodeJS.ErrnoException | undefined>((resolve) => {
             const child = spawn(
                 'npx',
@@ -218,6 +219,7 @@ async function runDevViaShim(
             child.stderr.on('data', (chunk: string) => { stderrBuf += chunk; });
 
             const timer = setTimeout(() => {
+                timedOut = true;
                 child.kill('SIGKILL');
             }, 120_000);
 
@@ -261,10 +263,13 @@ async function runDevViaShim(
         }
 
         if (!resultContent.trim()) {
+            const msg = timedOut
+                ? 'dev-shim timed out after 120s'
+                : 'dev-shim wrote an empty result file (check stderr above)';
             return {
                 result: {
                     status: 'failed',
-                    error: { message: 'dev-shim wrote an empty result file (check stderr above)', name: 'Error' },
+                    error: { message: msg, name: 'Error' },
                     phase: 'run',
                 },
             };

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -1,6 +1,7 @@
-import { spawnSync } from 'child_process';
+import { spawn, spawnSync } from 'child_process';
 import path from 'path';
 import fs from 'fs';
+import os from 'os';
 import chalk from 'chalk';
 import yaml from 'js-yaml';
 import { randomUUID } from 'crypto';
@@ -48,6 +49,35 @@ export interface RunDevResult {
     stderr: string;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     result: any; // InvokeResult from @solidactions/sdk
+}
+
+/**
+ * Context passed to dev-shim.mjs via SOLIDACTIONS_DEV_SHIM_CONTEXT env var
+ * as a JSON string. Every field must be JSON-serialisable.
+ */
+export interface DevShimContext {
+    /** Absolute path to the user's workflow entry file (.ts). */
+    entryPath: string;
+    /** JSON-serialised workflow input (e.g. '{"n":2}'). */
+    input: string;
+    /** ctx.vars built from platform vars + overrides. */
+    vars: Record<string, string | { key: string; proxyUrl: string; proxyToken: string }>;
+    /** baseUrl of the mock server started by the parent. */
+    mockBaseUrl: string;
+    /** API key for the mock server. */
+    mockApiKey: string;
+    /** Pre-generated run UUID. */
+    runUuid: string;
+    /** workerSessionId for ctx.run. */
+    workerSessionId: string;
+    /** Path to the private temp file the shim writes its result JSON to. */
+    resultPath: string;
+}
+
+/** Result the shim writes to the result temp file. */
+export interface DevShimResult {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    result: any;
 }
 
 export interface RunDevOptions {
@@ -117,6 +147,135 @@ function findSolidActionsRoot(startPath: string): string | null {
         dir = parent;
     }
     return null;
+}
+
+/**
+ * Run the user workflow entry by spawning `npx tsx dist/commands/dev-shim.mjs`.
+ *
+ * WHY THE CHILD PROCESS (not in-process import):
+ *   The CLI tsconfig compiles "module": "commonjs", so tsc rewrites await import(x)
+ *   to require(x) in every .ts file it compiles. tsx's CJS hook does NOT remap
+ *   .js→.ts in require() calls. A hand-written .mjs shim bypasses tsc entirely,
+ *   so its import() stays a real ESM dynamic import. When tsx loads .mjs, it uses
+ *   the ESM loader, which DOES remap .js→.ts for all transitive imports.
+ *
+ * SECRETS: context is passed as a JSON env var — OAuth proxyToken values never
+ * touch disk. The result uses a private temp file (mode 0o600, UUID name).
+ */
+async function runDevViaShim(
+    entryPath: string,
+    input: string,
+    vars: Record<string, string | { key: string; proxyUrl: string; proxyToken: string }>,
+    mockBaseUrl: string,
+    runUuid: string,
+    workerSessionId: string,
+    stdoutLines: string[],
+    stderrLines: string[],
+): Promise<{ result: any }> {
+    const shimPath = path.resolve(__dirname, 'dev-shim.mjs');
+
+    // Private temp file for the result (mode 0o600, UUID name).
+    const resultPath = path.join(os.tmpdir(), `sa-dev-result-${runUuid}-${randomUUID()}.json`);
+
+    // Write placeholder so the shim can overwrite it.
+    fs.writeFileSync(resultPath, '', { mode: 0o600 });
+
+    const shimCtx: DevShimContext = {
+        entryPath,
+        input,
+        vars,
+        mockBaseUrl,
+        mockApiKey: 'local-dev',
+        runUuid,
+        workerSessionId,
+        resultPath,
+    };
+
+    try {
+        // Use async spawn (NOT spawnSync): the SDK mock backend runs in THIS
+        // process's event loop, and the shim makes HTTP calls back to it
+        // (run-row creation, step/sleep/recv routes). spawnSync would block the
+        // parent's event loop, deadlocking the mock server — so we await an
+        // async child and pump its stdout/stderr while the loop stays live.
+        const spawnError = await new Promise<NodeJS.ErrnoException | undefined>((resolve) => {
+            const child = spawn(
+                'npx',
+                ['tsx', shimPath],
+                {
+                    stdio: ['ignore', 'pipe', 'pipe'],
+                    env: {
+                        ...process.env,
+                        SOLIDACTIONS_DEV_SHIM_CONTEXT: JSON.stringify(shimCtx),
+                    },
+                },
+            );
+
+            let stdoutBuf = '';
+            let stderrBuf = '';
+            child.stdout.setEncoding('utf8');
+            child.stderr.setEncoding('utf8');
+            child.stdout.on('data', (chunk: string) => { stdoutBuf += chunk; });
+            child.stderr.on('data', (chunk: string) => { stderrBuf += chunk; });
+
+            const timer = setTimeout(() => {
+                child.kill('SIGKILL');
+            }, 120_000);
+
+            child.on('error', (e: NodeJS.ErrnoException) => {
+                clearTimeout(timer);
+                if (stdoutBuf.trim()) { stdoutLines.push(stdoutBuf.trimEnd()); }
+                if (stderrBuf.trim()) { stderrLines.push(stderrBuf.trimEnd()); }
+                resolve(e);
+            });
+
+            child.on('close', () => {
+                clearTimeout(timer);
+                if (stdoutBuf.trim()) { stdoutLines.push(stdoutBuf.trimEnd()); }
+                if (stderrBuf.trim()) { stderrLines.push(stderrBuf.trimEnd()); }
+                resolve(undefined);
+            });
+        });
+
+        if (spawnError) {
+            const code = spawnError.code;
+            const msg = code === 'ENOENT'
+                ? 'npx not found. Make sure Node.js is installed.'
+                : `Failed to spawn tsx shim: ${spawnError.message}`;
+            return {
+                result: { status: 'failed', error: { message: msg, name: 'Error' }, phase: 'run' },
+            };
+        }
+
+        let resultContent = '';
+        try {
+            resultContent = fs.readFileSync(resultPath, 'utf8');
+        } catch {
+            // shim crashed before writing — stderr already captured above
+            return {
+                result: {
+                    status: 'failed',
+                    error: { message: 'dev-shim did not write a result file (check stderr above)', name: 'Error' },
+                    phase: 'run',
+                },
+            };
+        }
+
+        if (!resultContent.trim()) {
+            return {
+                result: {
+                    status: 'failed',
+                    error: { message: 'dev-shim wrote an empty result file (check stderr above)', name: 'Error' },
+                    phase: 'run',
+                },
+            };
+        }
+
+        const shimResult: DevShimResult = JSON.parse(resultContent);
+        return { result: shimResult.result };
+    } finally {
+        // Clean up result temp file on all exit paths.
+        try { fs.unlinkSync(resultPath); } catch { /* ignore */ }
+    }
 }
 
 /**
@@ -245,8 +404,45 @@ export async function runDev(opts: RunDevOptions): Promise<RunDevResult> {
 
     const mockServer = await createMockServer();
 
+    // Pre-generate run IDs so they can be passed to the shim (for .ts entries)
+    // or used in-process (for .js/.mjs entries).
+    const runUuid = randomUUID();
+    const workerSessionId = randomUUID();
+
     try {
-        // 7. Import the workflow entry file. Prefer the module's default export
+        // 7. Load and invoke the workflow.
+        //
+        // For .ts entries: spawn `npx tsx dist/commands/dev-shim.mjs`. The .mjs shim
+        // is NOT compiled by tsc, so its import() stays a real ESM dynamic import.
+        // tsx's ESM loader remaps .js-extension imports to .ts files, fixing the
+        // Cannot-find-module bug on multi-file NodeNext projects.
+        //
+        // The shim creates the run-row (it has the descriptor name) and invokes.
+        // stdio: pipe — child stdout/stderr are captured into stdoutLines/stderrLines.
+        //
+        // For .js/.mjs entries: original in-process import path (no change).
+        const isTs = /\.(ts|tsx|mts|cts)$/.test(entryPath);
+
+        if (isTs) {
+            const shimInvokeResult = await runDevViaShim(
+                entryPath,
+                opts.input,
+                vars,
+                mockServer.baseUrl,
+                runUuid,
+                workerSessionId,
+                stdoutLines,
+                stderrLines,
+            );
+            return {
+                stdout: stdoutLines.join('\n'),
+                stderr: stderrLines.join('\n'),
+                result: shimInvokeResult.result,
+            };
+        }
+
+        // JS/MJS path: in-process import (original behaviour, no change).
+        // 8. Import the workflow entry file. Prefer the module's default export
         //    (a WorkflowDescriptor returned by defineWorkflow) so that repeated
         //    runDev() calls in the same test process don't need to clear and
         //    re-register from a cached module (cached CJS modules don't re-run
@@ -277,8 +473,7 @@ export async function runDev(opts: RunDevOptions): Promise<RunDevResult> {
             };
         }
 
-        // 8. Build InvokeCtx.
-        const runUuid = randomUUID();
+        // 9. Build InvokeCtx.
         const ctx = {
             input: JSON.parse(opts.input || '{}'),
             vars: Object.freeze(vars),
@@ -286,7 +481,7 @@ export async function runDev(opts: RunDevOptions): Promise<RunDevResult> {
                 triggerId: 'local-dev',
                 runUuid,
                 runSecret: 'local-dev',
-                workerSessionId: randomUUID(),
+                workerSessionId,
             },
             app: {
                 appVersion: '0',
@@ -300,7 +495,7 @@ export async function runDev(opts: RunDevOptions): Promise<RunDevResult> {
             mode: 'local' as const,
         };
 
-        // 9. Create the run-row BEFORE invoking. invoke() itself never creates
+        // 10. Create the run-row BEFORE invoking. invoke() itself never creates
         //    the durable run record — the production launcher (SolidActions.run
         //    → #initOneShotStatusRow) does that first, and step/sleep/recv
         //    sub-routes (`/runs/status/<id>/...`) 404 ("Workflow not found")
@@ -338,7 +533,7 @@ export async function runDev(opts: RunDevOptions): Promise<RunDevResult> {
             err(`failed to create local run-row: ${e?.message ?? e}`);
         }
 
-        // 10. Invoke via internal SDK path (invoke() is not in the public index).
+        // 11. Invoke via internal SDK path (invoke() is not in the public index).
         const invokePath = path.resolve(sdkMainForInvoke, '..', 'invoke', 'invoke.js');
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const { invoke } = _require(invokePath) as { invoke: (wf: any, ctx: any) => Promise<any> };
@@ -369,13 +564,25 @@ const TSX_REEXEC_GUARD = 'SOLIDACTIONS_DEV_TSX_REEXEC';
  * Detect whether the current Node process already has a TypeScript loader
  * registered (tsx / ts-node). When true, `await import('<file>.ts')` works
  * in-process and we can run `runDev` directly without re-exec.
+ *
+ * NOTE: Boolean(process._preload_modules) is intentionally NOT used here —
+ * an empty array is truthy, causing a false positive that always skips the
+ * re-exec path even when no TypeScript loader is active.
  */
 function hasTsLoader(): boolean {
     if (process.env[TSX_REEXEC_GUARD] === '1') {
         return true;
     }
     const execArgv = process.execArgv.join(' ');
-    return /tsx|ts-node/.test(execArgv) || Boolean((process as { _preload_modules?: unknown })._preload_modules);
+    if (/tsx|ts-node/.test(execArgv)) {
+        return true;
+    }
+    // Check _preload_modules for tsx/ts-node entries (non-empty array check).
+    const preload = (process as { _preload_modules?: unknown[] })._preload_modules;
+    if (Array.isArray(preload) && preload.length > 0) {
+        return preload.some((m) => typeof m === 'string' && /tsx|ts-node/i.test(m));
+    }
+    return false;
 }
 
 /**

--- a/src/commands/env-set.ts
+++ b/src/commands/env-set.ts
@@ -3,6 +3,11 @@ import chalk from 'chalk';
 import prompts from 'prompts';
 import { getApiHeaders, requireConfigWithWorkspace } from '../utils/api';
 
+/** Returns true when stdin is not an interactive terminal (CI, pipes, scripts). */
+export function isNonTty(): boolean {
+    return !process.stdin.isTTY;
+}
+
 interface EnvSetOptions {
     secret?: boolean;
     env?: string;
@@ -46,6 +51,13 @@ export async function envSet(keyOrProject: string, valueOrKey?: string, valueIfP
                 const existing = mappings.find((m: any) => m.env_name === key);
 
                 if (existing && existing.has_value) {
+                    if (isNonTty()) {
+                        console.error(chalk.red(
+                            `Variable "${key}" already has a value in "${projectName}" (${environment}). ` +
+                            `Pass -y / --yes to overwrite without confirmation.`
+                        ));
+                        process.exit(1);
+                    }
                     console.log(chalk.yellow(`Variable "${key}" already has a value in "${projectName}" (${environment}).`));
                     const confirm = await prompts({
                         type: 'confirm',
@@ -138,6 +150,13 @@ export async function envSet(keyOrProject: string, valueOrKey?: string, valueIfP
 
             if (existing) {
                 if (!options.yes) {
+                    if (isNonTty()) {
+                        console.error(chalk.red(
+                            `Global variable "${key}" already exists. ` +
+                            `Pass -y / --yes to overwrite without confirmation.`
+                        ));
+                        process.exit(1);
+                    }
                     console.log(chalk.yellow(`Global variable "${key}" already exists.`));
                     const confirm = await prompts({
                         type: 'confirm',

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -79,9 +79,10 @@ export async function init(directory: string | undefined, options: InitOptions =
         if (directory) {
             console.log(chalk.gray(`  cd ${directory}`));
         }
-        console.log(chalk.gray(`  # Fill in WEBHOOK_SECRET and any other env vars in solidactions.yaml:`));
-        console.log(chalk.gray(`  solidactions env set ${projectName} WEBHOOK_SECRET <your-secret> -e production`));
         console.log(chalk.gray(`  solidactions project deploy ${projectName} -e production`));
+        console.log(chalk.gray(`  # If your workflow uses a webhook, retrieve its auto-generated secret`));
+        console.log(chalk.gray(`  # and set that value in your sender (e.g. Telegram secret_token):`));
+        console.log(chalk.gray(`  solidactions webhook secret ${projectName} -e production`));
     } catch (err: any) {
         if (err.message?.includes('rate limit')) {
             console.error(chalk.red(err.message));

--- a/src/commands/project-logs.ts
+++ b/src/commands/project-logs.ts
@@ -2,14 +2,38 @@ import axios from 'axios';
 import chalk from 'chalk';
 import { getApiHeaders, requireConfigWithWorkspace } from '../utils/api';
 
-export async function logsBuild(projectName: string) {
+export function buildBuildLogUrl(host: string, projectName: string, environment?: string): string {
+    if (environment) {
+        return `${host}/api/v1/projects/resolve/build-log`;
+    }
+    return `${host}/api/v1/projects/${projectName}/build-log`;
+}
+
+export function buildBuildLogRequest(
+    host: string,
+    projectName: string,
+    environment?: string,
+): { url: string; params?: Record<string, string> } {
+    if (environment) {
+        return {
+            url: `${host}/api/v1/projects/resolve/build-log`,
+            params: { name: projectName, environment },
+        };
+    }
+    return { url: `${host}/api/v1/projects/${projectName}/build-log` };
+}
+
+export async function logsBuild(projectName: string, environment?: string): Promise<void> {
     const config = await requireConfigWithWorkspace();
 
     console.log(chalk.blue(`Fetching build logs for project "${projectName}"...`));
 
+    const { url, params } = buildBuildLogRequest(config.host, projectName, environment);
+
     try {
-        const response = await axios.get(`${config.host}/api/v1/projects/${projectName}/build-log`, {
+        const response = await axios.get(url, {
             headers: getApiHeaders(config),
+            params,
         });
 
         const buildLog = response.data.build_log || response.data;
@@ -27,7 +51,11 @@ export async function logsBuild(projectName: string) {
             if (error.response.status === 401) {
                 console.error(chalk.red('Authentication failed. Run "solidactions login <api-key>" to re-configure.'));
             } else if (error.response.status === 404) {
-                console.error(chalk.red(`Project "${projectName}" not found.`));
+                console.error(chalk.red(error.response.data?.message ?? `Project "${projectName}" not found.`));
+                const envs: string[] | undefined = error.response.data?.available_environments;
+                if (envs && envs.length > 0) {
+                    console.error(chalk.yellow(`Available environments: ${envs.join(', ')}. Pass -e <env> to select one.`));
+                }
             } else {
                 console.error(chalk.red(`Failed: ${error.response.status}`), error.response.data);
             }

--- a/src/commands/run-list.ts
+++ b/src/commands/run-list.ts
@@ -80,7 +80,7 @@ export async function runs(projectName?: string, options: RunListOptions = {}) {
         if (error.response) {
             // ambiguous_project is 422 — axios throws, so handle here
             if (error.response.status === 422 && error.response.data?.error === 'ambiguous_project') {
-                const envs = (error.response.data.environments as string[]).join(', ');
+                const envs = ((error.response.data.environments ?? []) as string[]).join(', ');
                 console.error(chalk.yellow(`Ambiguous project '${projectName}': found in environments: ${envs}.`));
                 console.error(chalk.yellow(`Pass -e <env> to disambiguate, e.g.: solidactions run list ${projectName} -e dev`));
             } else if (error.response.status === 401) {

--- a/src/commands/run-list.ts
+++ b/src/commands/run-list.ts
@@ -11,25 +11,36 @@ interface RunListOptions {
     detailed?: boolean;
     hasErrors?: boolean;
     json?: boolean;
+    environment?: string;
+}
+
+/**
+ * Build the params object for GET /api/v1/runs.
+ * Extracted as a pure function so it can be unit-tested without mocking axios.
+ */
+export function buildRunListParams(projectName?: string, options: RunListOptions = {}): Record<string, any> {
+    const defaultLimit = options.detailed ? 5 : 20;
+    const limit = options.limit || defaultLimit;
+
+    const params: Record<string, any> = { limit };
+
+    if (projectName) params.project = projectName;
+    if (options.environment) params.environment = options.environment;
+    if (options.offset) params.offset = options.offset;
+    if (options.status) params.status = options.status;
+    if (options.since) params.since = parseSince(options.since);
+    if (options.workflow) params.workflow = options.workflow;
+    if (options.detailed) params.detailed = '1';
+    if (options.hasErrors) params.has_errors = '1';
+
+    return params;
 }
 
 export async function runs(projectName?: string, options: RunListOptions = {}) {
     const config = await requireConfigWithWorkspace();
 
-    // Default limit is lower for --detailed (more data per run)
-    const defaultLimit = options.detailed ? 5 : 20;
-    const limit = options.limit || defaultLimit;
-
     try {
-        const params: Record<string, any> = { limit };
-
-        if (projectName) params.project = projectName;
-        if (options.offset) params.offset = options.offset;
-        if (options.status) params.status = options.status;
-        if (options.since) params.since = parseSince(options.since);
-        if (options.workflow) params.workflow = options.workflow;
-        if (options.detailed) params.detailed = '1';
-        if (options.hasErrors) params.has_errors = '1';
+        const params = buildRunListParams(projectName, options);
 
         const response = await axios.get(`${config.host}/api/v1/runs`, {
             headers: getApiHeaders(config),
@@ -37,6 +48,13 @@ export async function runs(projectName?: string, options: RunListOptions = {}) {
         });
 
         const runsList = response.data.data || response.data;
+
+        // Check server-side error fields FIRST (project_not_found comes back as 200 with data:[])
+        const serverError = response.data.error;
+        if (serverError === 'project_not_found') {
+            console.error(chalk.red(response.data.message || `Project '${projectName}' not found.`));
+            process.exit(1);
+        }
 
         if (!runsList || runsList.length === 0) {
             if (options.json) {
@@ -60,7 +78,12 @@ export async function runs(projectName?: string, options: RunListOptions = {}) {
         }
     } catch (error: any) {
         if (error.response) {
-            if (error.response.status === 401) {
+            // ambiguous_project is 422 — axios throws, so handle here
+            if (error.response.status === 422 && error.response.data?.error === 'ambiguous_project') {
+                const envs = (error.response.data.environments as string[]).join(', ');
+                console.error(chalk.yellow(`Ambiguous project '${projectName}': found in environments: ${envs}.`));
+                console.error(chalk.yellow(`Pass -e <env> to disambiguate, e.g.: solidactions run list ${projectName} -e dev`));
+            } else if (error.response.status === 401) {
                 console.error(chalk.red('Authentication failed. Run "solidactions login <api-key>" to re-configure.'));
             } else {
                 console.error(chalk.red(`Failed: ${error.response.status}`), error.response.data);

--- a/src/commands/webhook-secret.ts
+++ b/src/commands/webhook-secret.ts
@@ -1,0 +1,87 @@
+import axios from 'axios';
+import chalk from 'chalk';
+import { getApiHeaders, requireConfigWithWorkspace } from '../utils/api';
+
+interface SecretRow {
+    workflow_name?: string;
+    webhook_secret?: string;
+}
+
+export function formatSecretOutput(rows: SecretRow[], workflowFilter?: string): string {
+    if (workflowFilter) {
+        const match = rows.find((r) => r.workflow_name === workflowFilter);
+        if (!match) return `No webhook named "${workflowFilter}" found.`;
+        return match.webhook_secret ?? '(secret not returned — check your access level)';
+    }
+    if (rows.length === 1) {
+        return rows[0].webhook_secret ?? '(secret not returned — check your access level)';
+    }
+    const lines = rows.map(
+        (r) => `${(r.workflow_name ?? '?').padEnd(32)}${r.webhook_secret ?? '(none)'}`
+    );
+    return ['WORKFLOW'.padEnd(32) + 'SECRET', '-'.repeat(80), ...lines].join('\n');
+}
+
+interface WebhookSecretOptions {
+    env?: string;
+    workflow?: string;
+    format?: string;
+}
+
+export async function webhookSecret(projectName: string, options: WebhookSecretOptions = {}) {
+    const format = options.format ?? 'text';
+    if (format !== 'text' && format !== 'json') {
+        console.error(chalk.red(`Invalid --format: ${format}. Expected 'text' or 'json'.`));
+        process.exit(1);
+    }
+
+    const config = await requireConfigWithWorkspace();
+
+    const environment = options.env ?? 'production';
+    const projectSlug = environment === 'production' ? projectName : `${projectName}-${environment}`;
+
+    try {
+        const response = await axios.get(`${config.host}/api/v1/projects/${projectSlug}/webhooks`, {
+            headers: getApiHeaders(config),
+            params: { show_secrets: 'true' },
+        });
+
+        const rows: SecretRow[] = response.data.data ?? [];
+
+        if (rows.length === 0) {
+            console.error(
+                chalk.yellow(
+                    `No webhook workflows found for project "${projectName}"${environment !== 'production' ? ` (${environment})` : ''}.`
+                )
+            );
+            process.exit(1);
+        }
+
+        if (format === 'json') {
+            const out = options.workflow
+                ? rows
+                      .filter((r) => r.workflow_name === options.workflow)
+                      .map((r) => ({ workflow: r.workflow_name, secret: r.webhook_secret }))
+                : rows.map((r) => ({ workflow: r.workflow_name, secret: r.webhook_secret }));
+            console.log(JSON.stringify(out, null, 2));
+            return;
+        }
+
+        console.log(formatSecretOutput(rows, options.workflow));
+    } catch (error: any) {
+        if (error.response) {
+            if (error.response.status === 401) {
+                console.error(
+                    chalk.red('Authentication failed. Run "solidactions login <api-key>" to re-configure.')
+                );
+            } else if (error.response.status === 404) {
+                console.error(chalk.red(`Project "${projectName}" not found.`));
+            } else {
+                console.error(chalk.red(`Failed: ${error.response.status}`), error.response.data);
+            }
+        } else {
+            console.error(chalk.red('Connection failed:'), error.message);
+        }
+        process.exit(1);
+    }
+}

--- a/src/commands/webhook-secret.ts
+++ b/src/commands/webhook-secret.ts
@@ -37,7 +37,7 @@ export async function webhookSecret(projectName: string, options: WebhookSecretO
 
     const config = await requireConfigWithWorkspace();
 
-    const environment = options.env ?? 'production';
+    const environment = options.env || 'dev';
     const projectSlug = environment === 'production' ? projectName : `${projectName}-${environment}`;
 
     if (format === 'text') {

--- a/src/commands/webhook-secret.ts
+++ b/src/commands/webhook-secret.ts
@@ -40,6 +40,12 @@ export async function webhookSecret(projectName: string, options: WebhookSecretO
     const environment = options.env ?? 'production';
     const projectSlug = environment === 'production' ? projectName : `${projectName}-${environment}`;
 
+    if (format === 'text') {
+        process.stderr.write(
+            chalk.dim(`(environment: ${environment} — pass -e <env> to change)\n`)
+        );
+    }
+
     try {
         const response = await axios.get(`${config.host}/api/v1/projects/${projectSlug}/webhooks`, {
             headers: getApiHeaders(config),

--- a/src/index.ts
+++ b/src/index.ts
@@ -382,7 +382,7 @@ webhook
     .command('secret')
     .description('Print the webhook secret for a project (set this value in your sender)')
     .argument('<project>', 'Project name')
-    .option('-e, --env <environment>', 'Environment (production/staging/dev)', 'production')
+    .option('-e, --env <environment>', 'Environment (production/staging/dev)')
     .option('--workflow <name>', 'Filter to a specific workflow by name')
     .option('--format <format>', 'Output format: text or json', 'text')
     .action((projectName, options) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -227,6 +227,7 @@ runCmd
     .option('--detailed', 'Include timeline, steps, and logs per run (default limit: 5)')
     .option('--has-errors', 'Show only runs with errors (step errors, retries, or degraded results)')
     .option('--json', 'Output as JSON')
+    .option('-e, --environment <environment>', 'Environment to filter by (production/staging/dev)')
     .action((projectName, options) => {
         runs(projectName, options);
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -185,9 +185,10 @@ project
 project
     .command('logs')
     .description('View build/deployment logs for a project')
-    .argument('<project>', 'Project name')
-    .action((projectName) => {
-        logsBuild(projectName);
+    .argument('<project>', 'Project name (or family name with -e)')
+    .option('-e, --environment <environment>', 'Environment to resolve (production/staging/dev)')
+    .action((projectName, options) => {
+        logsBuild(projectName, options.environment);
     });
 
 project

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import { scheduleSet } from './commands/schedule-set';
 import { scheduleList } from './commands/schedule-list';
 import { scheduleDelete } from './commands/schedule-delete';
 import { webhookList } from './commands/webhook-list';
+import { webhookSecret } from './commands/webhook-secret';
 import { dev } from './commands/dev';
 import { aiInit } from './commands/ai-init';
 import { aiExamples } from './commands/ai-examples';
@@ -375,6 +376,17 @@ webhook
     .option('--format <format>', 'Output format: table or json', 'table')
     .action((projectName, options) => {
         webhookList(projectName, options);
+    });
+
+webhook
+    .command('secret')
+    .description('Print the webhook secret for a project (set this value in your sender)')
+    .argument('<project>', 'Project name')
+    .option('-e, --env <environment>', 'Environment (production/staging/dev)', 'production')
+    .option('--workflow <name>', 'Filter to a specific workflow by name')
+    .option('--format <format>', 'Output format: text or json', 'text')
+    .action((projectName, options) => {
+        webhookSecret(projectName, options);
     });
 
 // =============================================================================

--- a/src/index.ts
+++ b/src/index.ts
@@ -169,8 +169,13 @@ project
     .option('-e, --env <environment>', 'Target environment (production/staging/dev). Required on first deploy of a new project.')
     .option('--create', 'Create environment project if it doesn\'t exist')
     .option('--config-only', 'Sync YAML env declarations without building/deploying')
+    .option('--no-cache', 'Force a fresh build, bypassing all build caches')
+    .option('--force-rebuild', 'Force a fresh build, bypassing all build caches (alias for --no-cache)')
     .action((projectName, path, options) => {
-        deploy(projectName, path, options);
+        // Commander's negation convention maps --no-cache to options.cache === false
+        // (NOT options.noCache). Normalize both flags to a single boolean.
+        const noCache = options.cache === false || options.forceRebuild === true;
+        deploy(projectName, path, { ...options, noCache });
     });
 
 project

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -17,7 +17,7 @@ export interface ParsedEnvVar {
 export interface SolidActionsConfig {
     /** Project name declared at the top of solidactions.yaml (e.g. "sdk-test"). */
     project?: string;
-    workflows: { id?: string; name: string; command?: string; file?: string; enabled?: boolean }[];
+    workflows: { id?: string; name: string; command?: string; file?: string; enabled?: boolean; trigger?: string; webhook?: { auth?: string; method?: string | string[]; mode?: string; timeout?: number } }[];
     env?: (string | { [key: string]: string | { oauth: string } })[];
     deploy?: {
         exclude?: string[];

--- a/tests/deploy-no-cache.test.ts
+++ b/tests/deploy-no-cache.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import { Command } from 'commander';
+import { cacheBusterEntry } from '../src/commands/deploy';
+
+// ---------------------------------------------------------------------------
+// cacheBusterEntry helper — pure unit tests
+// ---------------------------------------------------------------------------
+
+describe('cacheBusterEntry', () => {
+    it('returns null when noCache is false', () => {
+        expect(cacheBusterEntry(false)).toBeNull();
+    });
+
+    it('returns a non-null entry when noCache is true', () => {
+        const entry = cacheBusterEntry(true);
+        expect(entry).not.toBeNull();
+    });
+
+    it('entry name starts with tenantcode/sa-nocache-', () => {
+        const entry = cacheBusterEntry(true)!;
+        expect(entry.name).toMatch(/^tenantcode\/sa-nocache-/);
+    });
+
+    it('entry content contains the uuid from the name', () => {
+        const entry = cacheBusterEntry(true)!;
+        // The uuid is the suffix after "tenantcode/sa-nocache-"
+        const uuid = entry.name.replace('tenantcode/sa-nocache-', '');
+        expect(entry.content).toContain(uuid);
+    });
+
+    it('two consecutive calls produce different names and different content', () => {
+        const a = cacheBusterEntry(true)!;
+        const b = cacheBusterEntry(true)!;
+        expect(a.name).not.toBe(b.name);
+        expect(a.content).not.toBe(b.content);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Commander flag parsing — verify the --no-cache negation gotcha
+// ---------------------------------------------------------------------------
+
+describe('--no-cache / --force-rebuild flag parsing', () => {
+    function parseDeployOpts(args: string[]): { cache?: boolean; forceRebuild?: boolean } {
+        const cmd = new Command();
+        cmd.option('--no-cache', 'Force fresh build');
+        cmd.option('--force-rebuild', 'Force fresh build alias');
+        // parseCommand sets exitOverride so errors throw instead of process.exit
+        cmd.exitOverride();
+        cmd.parse(['node', 'deploy', ...args]);
+        return cmd.opts() as { cache?: boolean; forceRebuild?: boolean };
+    }
+
+    it('--no-cache sets cache === false (Commander negation convention, NOT noCache)', () => {
+        const opts = parseDeployOpts(['--no-cache']);
+        expect(opts.cache).toBe(false);
+        // Confirm there is no "noCache" property — the gotcha we guard against
+        expect((opts as any).noCache).toBeUndefined();
+    });
+
+    it('--force-rebuild sets forceRebuild === true', () => {
+        const opts = parseDeployOpts(['--force-rebuild']);
+        expect(opts.forceRebuild).toBe(true);
+    });
+
+    it('neither flag: cache defaults to true, forceRebuild is undefined', () => {
+        const opts = parseDeployOpts([]);
+        // Commander initializes --no-X pairs with the positive side as true by default
+        expect(opts.cache).toBe(true);
+        expect(opts.forceRebuild).toBeUndefined();
+    });
+
+    it('normalization: cache===false resolves to noCache=true', () => {
+        const opts = parseDeployOpts(['--no-cache']);
+        const noCache = opts.cache === false || opts.forceRebuild === true;
+        expect(noCache).toBe(true);
+    });
+
+    it('normalization: forceRebuild===true resolves to noCache=true', () => {
+        const opts = parseDeployOpts(['--force-rebuild']);
+        const noCache = opts.cache === false || opts.forceRebuild === true;
+        expect(noCache).toBe(true);
+    });
+
+    it('normalization: no flags resolves to noCache=false', () => {
+        const opts = parseDeployOpts([]);
+        const noCache = opts.cache === false || opts.forceRebuild === true;
+        expect(noCache).toBe(false);
+    });
+});

--- a/tests/deploy-webhook-notice.test.ts
+++ b/tests/deploy-webhook-notice.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { shouldPrintWebhookSecretNotice } from '../src/commands/deploy';
+
+describe('shouldPrintWebhookSecretNotice', () => {
+    it('returns true for a webhook workflow with hmac auth (default)', () => {
+        expect(shouldPrintWebhookSecretNotice([{ name: 'hello', trigger: 'webhook' }])).toBe(true);
+    });
+
+    it('returns true for explicit hmac', () => {
+        expect(shouldPrintWebhookSecretNotice([
+            { name: 'hello', trigger: 'webhook', webhook: { auth: 'hmac' } },
+        ])).toBe(true);
+    });
+
+    it('returns true for header auth', () => {
+        expect(shouldPrintWebhookSecretNotice([
+            { name: 'hello', trigger: 'webhook', webhook: { auth: 'header' } },
+        ])).toBe(true);
+    });
+
+    it('returns false for auth: none', () => {
+        expect(shouldPrintWebhookSecretNotice([
+            { name: 'hello', trigger: 'webhook', webhook: { auth: 'none' } },
+        ])).toBe(false);
+    });
+
+    it('returns false when there are no webhook workflows', () => {
+        expect(shouldPrintWebhookSecretNotice([{ name: 'scheduled' }])).toBe(false);
+    });
+
+    it('returns true when any workflow in a multi-workflow project uses a secret', () => {
+        expect(shouldPrintWebhookSecretNotice([
+            { name: 'public', trigger: 'webhook', webhook: { auth: 'none' } },
+            { name: 'private', trigger: 'webhook', webhook: { auth: 'hmac' } },
+        ])).toBe(true);
+    });
+});

--- a/tests/deploy-workspace-warning.test.ts
+++ b/tests/deploy-workspace-warning.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+// shouldPrintWorkspaceMismatch does not exist yet — this import will fail (RED).
+// After the fix it is exported from deploy.ts.
+import { shouldPrintWorkspaceMismatch } from '../src/commands/deploy';
+
+// These tests fail before the fix because:
+// (a) shouldPrintWorkspaceMismatch is not exported yet (import error → RED), and
+// (b) the decision logic doesn't exist as a pure function — it's embedded inline.
+//
+// After the fix they document the invariant: the warning must ONLY fire on paths
+// that actually abort. A 404 on the production-existence check (first deploy) and
+// a 404 on the env lookup with --create should both produce shouldPrint === false.
+
+describe('shouldPrintWorkspaceMismatch — warning only on abort paths', () => {
+    it('returns false for production environment (404 → create, not abort)', () => {
+        // Production 404 at site 1 (existence check) or site 2 — always falls through
+        // to create. The warning must not fire.
+        expect(shouldPrintWorkspaceMismatch('production', false)).toBe(false);
+        expect(shouldPrintWorkspaceMismatch('production', true)).toBe(false);
+    });
+
+    it('returns false for non-production with --create (404 → create, not abort)', () => {
+        // Non-production 404 with --create proceeds to create the env. No abort → no warning.
+        expect(shouldPrintWorkspaceMismatch('dev', true)).toBe(false);
+        expect(shouldPrintWorkspaceMismatch('staging', true)).toBe(false);
+    });
+
+    it('returns true for non-production without --create (404 → abort)', () => {
+        // Non-production 404 without --create exits 1. This is a real abort → warn.
+        expect(shouldPrintWorkspaceMismatch('dev', false)).toBe(true);
+        expect(shouldPrintWorkspaceMismatch('staging', false)).toBe(true);
+    });
+});

--- a/tests/dev.test.ts
+++ b/tests/dev.test.ts
@@ -6,6 +6,7 @@
  * Matches the pattern used in proxy-contract.test.ts (Task 5.1).
  */
 
+import * as fs from 'fs';
 import * as http from 'http';
 import * as path from 'path';
 import * as childProcess from 'child_process';
@@ -176,6 +177,14 @@ const MULTI_FILE_FIXTURE = path.resolve(__dirname, '../fixtures/multi-file/entry
 const CLI_BINARY = path.resolve(__dirname, '../dist/index.js');
 
 describe('solidactions dev — multi-file NodeNext project', () => {
+    beforeAll(() => {
+        if (!fs.existsSync(CLI_BINARY)) {
+            throw new Error(
+                `CLI not built — run \`npm run build\` first (expected: ${CLI_BINARY})`,
+            );
+        }
+    });
+
     it('resolves .js-extension imports, exits 0, and prints correct output', () => {
         // Spawn the built CLI binary under plain `node` (NOT tsx) to exercise the
         // real code path. The bug manifests because hasTsLoader() returns true due

--- a/tests/dev.test.ts
+++ b/tests/dev.test.ts
@@ -8,6 +8,7 @@
 
 import * as http from 'http';
 import * as path from 'path';
+import * as childProcess from 'child_process';
 import { describe, expect, it, beforeAll, afterAll } from 'vitest';
 import { runDev, type SaApiClient, type PlatformVar } from '../src/commands/dev';
 
@@ -165,4 +166,48 @@ describe('runDev', () => {
         expect(out.result.status).not.toBe('completed');
         expect(out.result.status).toBe('failed');
     }, 20_000);
+});
+
+// ---------------------------------------------------------------------------
+// Multi-file NodeNext fixture — .js-extension relative imports
+// ---------------------------------------------------------------------------
+
+const MULTI_FILE_FIXTURE = path.resolve(__dirname, '../fixtures/multi-file/entry.ts');
+const CLI_BINARY = path.resolve(__dirname, '../dist/index.js');
+
+describe('solidactions dev — multi-file NodeNext project', () => {
+    it('resolves .js-extension imports, exits 0, and prints correct output', () => {
+        // Spawn the built CLI binary under plain `node` (NOT tsx) to exercise the
+        // real code path. The bug manifests because hasTsLoader() returns true due
+        // to Boolean(process._preload_modules) being truthy for an empty array,
+        // so the re-exec under tsx is skipped and runDev() runs in-process in a
+        // plain CJS node process. When it calls await import(entry.ts), Node.js
+        // uses native ESM (because the fixture has "type":"module") and cannot
+        // remap the .js extension import to the real double.ts file.
+        //
+        // Spawning with `npx tsx` would mask the bug (tsx ESM loader remaps .js).
+        const result = childProcess.spawnSync(
+            process.execPath,
+            [CLI_BINARY, 'dev', MULTI_FILE_FIXTURE, '--input', '{"n":3}'],
+            {
+                encoding: 'utf8',
+                env: { ...process.env },
+                timeout: 30_000,
+            },
+        );
+
+        // Must NOT contain the module-resolution error.
+        expect(result.stderr ?? '').not.toMatch(/Cannot find module/);
+        expect(result.stderr ?? '').not.toMatch(/MODULE_NOT_FOUND/);
+
+        // Must exit 0 (workflow completed).
+        expect(result.status).toBe(0);
+
+        // Must print the completion line.
+        expect(result.stdout ?? '').toMatch(/completed/);
+
+        // Must print the correct output: double(3) = 6.
+        // The CLI prints: Output: <json>
+        expect(result.stdout ?? '').toMatch(/Output:.*6/);
+    }, 35_000);
 });

--- a/tests/env-set-non-tty.test.ts
+++ b/tests/env-set-non-tty.test.ts
@@ -59,16 +59,10 @@ describe('envSet non-TTY fast-fail', () => {
                 throw new Error('unexpected GET: ' + url);
             };
 
-            let thrownFromExit = false;
             try {
                 await envSet('my-project', 'MY_KEY', 'new-value', { yes: false, env: 'dev' });
-            } catch (err: any) {
-                // The guard calls process.exit(1) which throws from our mock
-                if (err.message.includes('process.exit')) {
-                    thrownFromExit = true;
-                }
-                // The catch block in envSet also catches this and calls process.exit(1) again,
-                // so the outer try-catch may re-throw. Any path that sets exitCode to 1 is correct.
+            } catch {
+                // process.exit mock throws; any path that sets exitCode to 1 is correct.
             }
 
             expect(exitCode).toBe(1);

--- a/tests/env-set-non-tty.test.ts
+++ b/tests/env-set-non-tty.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import axios from 'axios';
+import { envSet, isNonTty } from '../src/commands/env-set';
+import { makeTmpEnv, writeGlobal } from './helpers';
+
+describe('envSet non-TTY fast-fail', () => {
+    let originalIsTTY: boolean | undefined;
+    let exitCode: number | undefined;
+    let originalExit: typeof process.exit;
+    let originalAxiosGet: typeof axios.get;
+
+    beforeEach(() => {
+        originalIsTTY = process.stdin.isTTY;
+        // Simulate non-TTY (CI / pipe) — isTTY is undefined in a pipe
+        Object.defineProperty(process.stdin, 'isTTY', { value: undefined, configurable: true });
+
+        exitCode = undefined;
+        originalExit = process.exit;
+        (process as any).exit = (code?: number) => {
+            exitCode = code ?? 0;
+            throw new Error(`process.exit(${code})`);
+        };
+
+        originalAxiosGet = axios.get;
+    });
+
+    afterEach(() => {
+        Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true });
+        (process as any).exit = originalExit;
+        axios.get = originalAxiosGet;
+    });
+
+    it('isNonTty() returns true when stdin.isTTY is undefined', () => {
+        // process.stdin.isTTY is set to undefined in beforeEach
+        expect(isNonTty()).toBe(true);
+    });
+
+    it('isNonTty() returns false when stdin.isTTY is true', () => {
+        Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
+        expect(isNonTty()).toBe(false);
+    });
+
+    it('project-mode: exits with code 1 (no hang) when non-TTY and variable already has a value', async () => {
+        const { cleanup } = makeTmpEnv();
+        try {
+            // Write a real config file so requireConfigWithWorkspace resolves without a server call
+            const tmpHome = process.env.HOME!;
+            writeGlobal(tmpHome, {
+                host: 'http://localhost',
+                apiKey: 'test-key',
+                workspaceId: 'ws-1',
+            });
+
+            // Stub axios.get to return an existing variable mapping
+            axios.get = async (url: string) => {
+                if (url.includes('variable-mappings')) {
+                    return { data: [{ env_name: 'MY_KEY', has_value: true }] };
+                }
+                throw new Error('unexpected GET: ' + url);
+            };
+
+            let thrownFromExit = false;
+            try {
+                await envSet('my-project', 'MY_KEY', 'new-value', { yes: false, env: 'dev' });
+            } catch (err: any) {
+                // The guard calls process.exit(1) which throws from our mock
+                if (err.message.includes('process.exit')) {
+                    thrownFromExit = true;
+                }
+                // The catch block in envSet also catches this and calls process.exit(1) again,
+                // so the outer try-catch may re-throw. Any path that sets exitCode to 1 is correct.
+            }
+
+            expect(exitCode).toBe(1);
+        } finally {
+            cleanup();
+        }
+    });
+
+    it('global-mode: exits with code 1 (no hang) when non-TTY and global variable already exists', async () => {
+        const { cleanup } = makeTmpEnv();
+        try {
+            const tmpHome = process.env.HOME!;
+            writeGlobal(tmpHome, {
+                host: 'http://localhost',
+                apiKey: 'test-key',
+                workspaceId: 'ws-1',
+            });
+
+            // Stub axios.get to return an existing global variable
+            axios.get = async (url: string) => {
+                if (url.includes('/api/v1/variables')) {
+                    return { data: { data: [{ id: 42, key: 'GLOBAL_KEY' }] } };
+                }
+                throw new Error('unexpected GET: ' + url);
+            };
+
+            try {
+                // Global mode: only two positional args (key, value), no third arg
+                await envSet('GLOBAL_KEY', 'new-value', undefined, { yes: false });
+            } catch (err: any) {
+                // Expected: process.exit mock throws, then caught by envSet's outer catch, may throw again
+            }
+
+            expect(exitCode).toBe(1);
+        } finally {
+            cleanup();
+        }
+    });
+});

--- a/tests/project-logs-env.test.ts
+++ b/tests/project-logs-env.test.ts
@@ -14,11 +14,11 @@ describe('buildBuildLogUrl', () => {
 
 describe('buildBuildLogParams', () => {
     it('returns name+environment params when environment provided', () => {
-        const { url, params } = buildBuildLogRequest('http://localhost:8001', 'my-flow', 'dev');
+        const { params } = buildBuildLogRequest('http://localhost:8001', 'my-flow', 'dev');
         expect(params).toEqual({ name: 'my-flow', environment: 'dev' });
     });
     it('returns no params when slug route is used', () => {
-        const { url, params } = buildBuildLogRequest('http://localhost:8001', 'my-flow-dev', undefined);
+        const { params } = buildBuildLogRequest('http://localhost:8001', 'my-flow-dev', undefined);
         expect(params).toBeUndefined();
     });
 });

--- a/tests/project-logs-env.test.ts
+++ b/tests/project-logs-env.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { buildBuildLogUrl, buildBuildLogRequest } from '../src/commands/project-logs';
+
+describe('buildBuildLogUrl', () => {
+    it('uses resolve route when environment is provided', () => {
+        const url = buildBuildLogUrl('http://localhost:8001', 'my-flow', 'dev');
+        expect(url).toBe('http://localhost:8001/api/v1/projects/resolve/build-log');
+    });
+    it('uses slug route when environment is omitted', () => {
+        const url = buildBuildLogUrl('http://localhost:8001', 'my-flow-dev', undefined);
+        expect(url).toBe('http://localhost:8001/api/v1/projects/my-flow-dev/build-log');
+    });
+});
+
+describe('buildBuildLogParams', () => {
+    it('returns name+environment params when environment provided', () => {
+        const { url, params } = buildBuildLogRequest('http://localhost:8001', 'my-flow', 'dev');
+        expect(params).toEqual({ name: 'my-flow', environment: 'dev' });
+    });
+    it('returns no params when slug route is used', () => {
+        const { url, params } = buildBuildLogRequest('http://localhost:8001', 'my-flow-dev', undefined);
+        expect(params).toBeUndefined();
+    });
+});

--- a/tests/run-list-env.test.ts
+++ b/tests/run-list-env.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { buildRunListParams } from '../src/commands/run-list';
+
+describe('buildRunListParams', () => {
+    it('includes environment when -e is passed', () => {
+        const params = buildRunListParams('my-flow', { environment: 'dev', limit: 20 });
+        expect(params.project).toBe('my-flow');
+        expect(params.environment).toBe('dev');
+    });
+
+    it('omits environment when not passed', () => {
+        const params = buildRunListParams('my-flow', { limit: 20 });
+        expect(params).not.toHaveProperty('environment');
+    });
+
+    it('omits project when projectName is undefined', () => {
+        const params = buildRunListParams(undefined, { limit: 20 });
+        expect(params).not.toHaveProperty('project');
+    });
+
+    it('uses provided limit', () => {
+        const params = buildRunListParams('my-flow', { limit: 50 });
+        expect(params.limit).toBe(50);
+    });
+
+    it('defaults limit to 20 when not detailed', () => {
+        const params = buildRunListParams('my-flow', {});
+        expect(params.limit).toBe(20);
+    });
+
+    it('defaults limit to 5 when detailed is set', () => {
+        const params = buildRunListParams('my-flow', { detailed: true });
+        expect(params.limit).toBe(5);
+    });
+
+    it('includes status when set', () => {
+        const params = buildRunListParams('my-flow', { status: 'failed' });
+        expect(params.status).toBe('failed');
+    });
+
+    it('includes has_errors when hasErrors is set', () => {
+        const params = buildRunListParams('my-flow', { hasErrors: true });
+        expect(params.has_errors).toBe('1');
+    });
+
+    it('includes workflow when set', () => {
+        const params = buildRunListParams('my-flow', { workflow: 'my-workflow' });
+        expect(params.workflow).toBe('my-workflow');
+    });
+});

--- a/tests/webhook-secret-formatter.test.ts
+++ b/tests/webhook-secret-formatter.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { formatSecretOutput } from '../src/commands/webhook-secret';
+
+describe('formatSecretOutput', () => {
+    it('returns the raw secret when there is exactly one webhook', () => {
+        const result = formatSecretOutput([{ workflow_name: 'hello', webhook_secret: 'abc123' }]);
+        expect(result).toBe('abc123');
+    });
+
+    it('returns a table when there are multiple webhooks', () => {
+        const result = formatSecretOutput([
+            { workflow_name: 'alpha', webhook_secret: 'secret-a' },
+            { workflow_name: 'beta', webhook_secret: 'secret-b' },
+        ]);
+        expect(result).toContain('WORKFLOW');
+        expect(result).toContain('alpha');
+        expect(result).toContain('secret-a');
+        expect(result).toContain('beta');
+        expect(result).toContain('secret-b');
+    });
+
+    it('filters to a single workflow by name when --workflow is given', () => {
+        const result = formatSecretOutput(
+            [
+                { workflow_name: 'alpha', webhook_secret: 'secret-a' },
+                { workflow_name: 'beta', webhook_secret: 'secret-b' },
+            ],
+            'beta'
+        );
+        expect(result).toBe('secret-b');
+    });
+
+    it('returns a not-found message when --workflow filter matches nothing', () => {
+        const result = formatSecretOutput(
+            [{ workflow_name: 'alpha', webhook_secret: 'secret-a' }],
+            'nope'
+        );
+        expect(result).toContain('No webhook named "nope" found.');
+    });
+
+    it('returns a placeholder when secret is absent (access denied)', () => {
+        const result = formatSecretOutput([{ workflow_name: 'hello', webhook_secret: undefined }]);
+        expect(result).toContain('secret not returned');
+    });
+});


### PR DESCRIPTION
Fixes `solidactions dev` multi-file NodeNext resolution (hand-written `.mjs` shim under tsx + `hasTsLoader` false-positive fix). Adds `-e/--environment` to `run list`/`project logs` threading server-side family+env resolution. `env set` fast-fails in non-TTY instead of hanging. Deploy warn-then-succeed suppressed (warning only on genuine abort). New `webhook secret <project>` command + deploy-time secret notice; `init` next-step points to it.

---
Part of a 4-repo tee-time DX effort (app · sdk · cli · examples). Verified: per-task + final whole-branch reviews (Opus) all clean; clean-room smoke confirmed the authoring DX. **Do not merge/release yet** — pending your review + E2E CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)