### PR TITLE
fix(examples): migrate hello-world to defineWorkflow/ctx (SDK 0.5+)

### DIFF
--- a/examples/hello-world/src/hello.ts
+++ b/examples/hello-world/src/hello.ts
@@ -1,19 +1,20 @@
-import { SolidActions } from "@solidactions/sdk";
+import { SolidActions, defineWorkflow } from "@solidactions/sdk";
 
-async function greet() {
+async function greet(): Promise<{ message: string }> {
   SolidActions.logger.info("Hello from SolidActions!");
   return { message: "Hello, world!" };
 }
 
-async function farewell() {
+async function farewell(): Promise<{ message: string }> {
   SolidActions.logger.info("Goodbye from SolidActions!");
   return { message: "Goodbye!" };
 }
 
-async function helloWorkflow() {
-  const greeting = await SolidActions.runStep(() => greet());
-  const goodbye = await SolidActions.runStep(() => farewell());
-  return { greeting, goodbye };
-}
-
-export default SolidActions.registerWorkflow(helloWorkflow);
+export default defineWorkflow({
+  name: "hello",
+  async run(ctx) {
+    const greeting = await SolidActions.runStep(() => greet(), { name: "greet" });
+    const goodbye = await SolidActions.runStep(() => farewell(), { name: "farewell" });
+    return { greeting, goodbye };
+  },
+});


### PR DESCRIPTION
## Problem

The `hello-world` example still used the **pre-0.5 static-entry API** (`SolidActions.registerWorkflow(...)` + a bare workflow function). Since `examples/hello-world/package.json` pins `"@solidactions/sdk": "latest"` — now **0.7.0** — an engineer who copies the example and installs the SDK gets code that no longer matches the API. Workflows must be exported as a `defineWorkflow` descriptor with a `ctx`-based `run()`. This file hadn't been touched since the initial CLI extraction, so it missed the 0.5 → 0.6 → 0.7 migration entirely.

## Fix

Rewrote `examples/hello-world/src/hello.ts` to the current `defineWorkflow`/`ctx` contract. `SolidActions.runStep`/`logger` are unchanged (still valid); only the legacy wiring was replaced.

## Verification

Installed `@solidactions/sdk@latest` (→ 0.7.0) and ran the example locally:

```
$ solidactions dev src/hello.ts
Hello from SolidActions!
Goodbye from SolidActions!
✓ completed
Output: {"greeting":{"message":"Hello, world!"},"goodbye":{"message":"Goodbye!"}}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)