### PR TITLE
feat: Sweep B — reserved-env guards, login/env UX, run-view error display, schedule --timezone, scaffold lockfile

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -12,6 +12,13 @@ import { planDeployFiles } from '../utils/deploy-ignore';
 import { buildProjectSlug } from '../utils/slug';
 import { hasSolidActionsSkills } from '../utils/skills';
 
+/** Printed when a deploy target has no SolidActions skill files installed. */
+export const SKILLS_TIP_LINES = [
+    'Tip: no SolidActions skill files found (.claude/skills/solidactions-*). Your AI assistant',
+    'works much better with them — run `solidactions ai init --claude` (or --agents) in this',
+    'directory to add them.',
+];
+
 /**
  * Validate project structure before deployment.
  * Checks for required files and SDK dependency.
@@ -193,9 +200,9 @@ export async function deploy(projectName: string, sourcePath?: string, options: 
     // Non-blocking: AI assistants work measurably better with the skill files
     // (field report: a 600-line skill file cracked the env-scope bug).
     if (!hasSolidActionsSkills(sourceDir)) {
-        console.log(chalk.yellow('Tip: no SolidActions skill files found (.claude/skills/solidactions-*). Your AI assistant'));
-        console.log(chalk.yellow('works much better with them — run `solidactions init --claude` in this directory, or'));
-        console.log(chalk.yellow('`solidactions skill push`.'));
+        for (const line of SKILLS_TIP_LINES) {
+            console.log(chalk.yellow(line));
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -10,6 +10,7 @@ import { SolidActionsConfig, parseYamlEnvVars } from '../utils/env';
 import { getApiHeaders, requireConfigWithWorkspace } from '../utils/api';
 import { planDeployFiles } from '../utils/deploy-ignore';
 import { buildProjectSlug } from '../utils/slug';
+import { hasSolidActionsSkills } from '../utils/skills';
 
 /**
  * Validate project structure before deployment.
@@ -187,6 +188,14 @@ export async function deploy(projectName: string, sourcePath?: string, options: 
     if (!fs.existsSync(sourceDir)) {
         console.error(chalk.red(`Source directory not found: ${sourceDir}`));
         process.exit(1);
+    }
+
+    // Non-blocking: AI assistants work measurably better with the skill files
+    // (field report: a 600-line skill file cracked the env-scope bug).
+    if (!hasSolidActionsSkills(sourceDir)) {
+        console.log(chalk.yellow('Tip: no SolidActions skill files found (.claude/skills/solidactions-*). Your AI assistant'));
+        console.log(chalk.yellow('works much better with them — run `solidactions init --claude` in this directory, or'));
+        console.log(chalk.yellow('`solidactions skill push`.'));
     }
 
     // -------------------------------------------------------------------------

--- a/src/commands/env-map.ts
+++ b/src/commands/env-map.ts
@@ -2,9 +2,15 @@ import axios from 'axios';
 import chalk from 'chalk';
 import prompts from 'prompts';
 import { getApiHeaders, requireConfigWithWorkspace } from '../utils/api';
+import { isReservedEnvName, reservedEnvNameError } from '../utils/env';
 
 export async function envMap(projectName: string, projectKey: string, globalKey: string, options: { yes?: boolean } = {}) {
     const config = await requireConfigWithWorkspace();
+
+    if (isReservedEnvName(projectKey)) {
+        console.error(chalk.red(reservedEnvNameError(projectKey)));
+        process.exit(1);
+    }
 
     console.log(chalk.blue(`Mapping global variable "${globalKey}" to project key "${projectKey}" in "${projectName}"...`));
 

--- a/src/commands/env-push.ts
+++ b/src/commands/env-push.ts
@@ -4,7 +4,7 @@ import axios from 'axios';
 import chalk from 'chalk';
 import prompts from 'prompts';
 import { getApiHeaders, requireConfigWithWorkspace } from '../utils/api';
-import { SolidActionsConfig, parseEnvFile, getYamlDeclaredVars, loadSolidActionsConfig } from '../utils/env';
+import { SolidActionsConfig, parseEnvFile, getYamlDeclaredVars, loadSolidActionsConfig, isReservedEnvName, RESERVED_ENV_PREFIX } from '../utils/env';
 
 interface EnvPushOptions {
     env?: string;
@@ -82,6 +82,18 @@ export async function envPush(projectName: string, sourcePath: string, options: 
             console.log(chalk.gray('Your .env has variables not declared in solidactions.yaml. Use --include-undeclared to push them.'));
         }
         process.exit(0);
+    }
+
+    // Hard-reject reserved names among the keys that would actually be pushed
+    // (the server rejects them too — fail here, before any network call).
+    const reservedKeys = keysToProcess.filter(isReservedEnvName);
+    if (reservedKeys.length > 0) {
+        console.error(chalk.red(`Refusing to push — reserved ${RESERVED_ENV_PREFIX} names found: ${reservedKeys.join(', ')}`));
+        console.error(chalk.red(
+            'These names are set by the platform at runtime (API credentials, run context) and a custom variable would clobber them, causing authentication failures. ' +
+            `Rename them (e.g. "${reservedKeys[0].replace(/^SOLIDACTIONS_/, 'MY_')}") and retry. Nothing was pushed.`
+        ));
+        process.exit(1);
     }
 
     // Build project slug

--- a/src/commands/env-set.ts
+++ b/src/commands/env-set.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import chalk from 'chalk';
 import prompts from 'prompts';
 import { getApiHeaders, requireConfigWithWorkspace } from '../utils/api';
+import { isReservedEnvName, reservedEnvNameError } from '../utils/env';
 
 /** Returns true when stdin is not an interactive terminal (CI, pipes, scripts). */
 export function isNonTty(): boolean {
@@ -30,6 +31,12 @@ export async function envSet(keyOrProject: string, valueOrKey?: string, valueIfP
         const projectName = keyOrProject;
         const key = valueOrKey!;
         const value = valueIfProject;
+
+        if (isReservedEnvName(key)) {
+            console.error(chalk.red(reservedEnvNameError(key)));
+            process.exit(1);
+        }
+
         const environment = options.env || 'dev';
 
         // Build project slug
@@ -110,6 +117,12 @@ export async function envSet(keyOrProject: string, valueOrKey?: string, valueIfP
         // Global mode: solidactions env set <key> <value>
         const key = keyOrProject;
         const value = valueOrKey!;
+
+        if (isReservedEnvName(key)) {
+            console.error(chalk.red(reservedEnvNameError(key)));
+            process.exit(1);
+        }
+
         const isSecret = options.secret || false;
 
         // Build the request body with per-environment values

--- a/src/commands/env-set.ts
+++ b/src/commands/env-set.ts
@@ -9,6 +9,14 @@ export function isNonTty(): boolean {
     return !process.stdin.isTTY;
 }
 
+/** Printed before a 2-arg (global-scope) write — Jordan's runs 3-7 footgun. */
+export const GLOBAL_ENV_SCOPE_NOTE = [
+    'Note: no project specified — creating a GLOBAL variable.',
+    "  Global variables are NOT visible to a project's plain `env:` YAML declarations",
+    '  unless you map them (`solidactions env map …`).',
+    '  For a project variable, use: solidactions env set <project> KEY value',
+].join('\n');
+
 interface EnvSetOptions {
     secret?: boolean;
     env?: string;
@@ -122,6 +130,8 @@ export async function envSet(keyOrProject: string, valueOrKey?: string, valueIfP
             console.error(chalk.red(reservedEnvNameError(key)));
             process.exit(1);
         }
+
+        console.log(chalk.yellow(GLOBAL_ENV_SCOPE_NOTE));
 
         const isSecret = options.secret || false;
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -16,8 +16,9 @@ const EXAMPLES_REPO = 'solidactions-examples';
 const TEMPLATE_PREFIX = 'templates/minimal';
 
 // Tuples of [remote-path-suffix-under-template-prefix, local-path-relative-to-target].
-const TEMPLATE_FILES: Array<[string, string]> = [
+export const TEMPLATE_FILES: Array<[string, string]> = [
     ['package.json', 'package.json'],
+    ['package-lock.json', 'package-lock.json'],
     ['tsconfig.json', 'tsconfig.json'],
     ['solidactions.yaml', 'solidactions.yaml'],
     ['.env.example', '.env.example'],

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -31,18 +31,32 @@ export function clearConfig(): void {
 }
 
 
+export function resolveLoginHost(options: { dev?: boolean; host?: string }): { host: string; isDefault: boolean } {
+    if (options.host) {
+        return { host: options.host, isDefault: false };
+    }
+    if (options.dev) {
+        return { host: 'http://localhost:8000', isDefault: false };
+    }
+    return { host: 'https://app.solidactions.com', isDefault: true };
+}
+
+export function loginHostLines(resolved: { host: string; isDefault: boolean }): string[] {
+    if (resolved.isDefault) {
+        return [
+            `Logging into ${resolved.host} (SolidActions Cloud)`,
+            '  Self-hosted or local dev? Pass --host <url> (or --dev for http://localhost:8000)',
+        ];
+    }
+    return [`Host: ${resolved.host}`];
+}
+
 export async function login(
     apiKey: string,
     options: { dev?: boolean; host?: string; workspace?: string; local?: boolean; global?: boolean; gitignore?: boolean },
 ) {
-    let host: string;
-    if (options.host) {
-        host = options.host;
-    } else if (options.dev) {
-        host = 'http://localhost:8000';
-    } else {
-        host = 'https://app.solidactions.com';
-    }
+    const resolved = resolveLoginHost(options);
+    const host = resolved.host;
 
     if (!apiKey || apiKey.trim().length === 0) {
         console.error(chalk.red('Error: API key is required.'));
@@ -55,7 +69,9 @@ export async function login(
     const targetPath = pathForTarget(target);
 
     console.log(chalk.blue(`Initializing SolidActions CLI...`));
-    console.log(chalk.gray(`Host: ${host}`));
+    for (const line of loginHostLines(resolved)) {
+        console.log(resolved.isDefault ? chalk.yellow(line) : chalk.gray(line));
+    }
 
     if (readConfigFile(targetPath)) {
         console.log(chalk.yellow(`Existing config at ${targetPath} will be overwritten.`));

--- a/src/commands/run-view.ts
+++ b/src/commands/run-view.ts
@@ -209,7 +209,7 @@ function displayTimeline(runData: any, timeline: any, steps: any[] = []) {
     console.log(`  Duration:  ${chalk.gray(timeline.durationMs ? formatDuration(timeline.durationMs) : '-')}`);
 }
 
-function displayStepsTable(steps: any[], indent: string = '  ') {
+export function displayStepsTable(steps: any[], indent: string = '  ') {
     if (steps.length === 0) {
         console.log(chalk.gray(`${indent}(no steps)`));
         return;
@@ -220,20 +220,32 @@ function displayStepsTable(steps: any[], indent: string = '  ') {
 
     for (const step of steps) {
         const name = (step.name || '?').padEnd(24);
-        const status = step.completedAt ? 'completed' : step.startedAt ? 'running' : 'pending';
+        const status = stepDisplayStatus(step);
         const statusColor = getStatusColor(status);
         const duration = formatDuration(step.durationMs);
-        const output = step.output ? truncate(JSON.stringify(unwrapOutput(step.output)), 40) : '-';
+        // A failed step's error is more useful than its (null) output — show it, red.
+        const output = step.error
+            ? chalk.red(truncate(String(step.error), 40))
+            : chalk.gray(step.output ? truncate(JSON.stringify(unwrapOutput(step.output)), 40) : '-');
 
         console.log(
-            `${indent}${name}${statusColor(status.padEnd(12))}${chalk.gray(duration.padEnd(12))}${chalk.gray(output)}`
+            `${indent}${name}${statusColor(status.padEnd(12))}${chalk.gray(duration.padEnd(12))}${output}`
         );
+    }
+
+    // Untruncated first failure below the table: `run view` alone must be
+    // enough to diagnose (Wall #5 — failed steps used to render "completed").
+    const firstFailed = steps.find((s) => stepDisplayStatus(s).toLowerCase() === 'failed' && s.error);
+    if (firstFailed) {
+        console.log('');
+        console.log(chalk.bold.red(`${indent}Step "${firstFailed.name}" failed:`));
+        console.log(chalk.red(`${indent}  ${String(firstFailed.error)}`));
     }
 }
 
 // ─── Utility ───────────────────────────────────────────────────────────────
 
-function flattenSteps(workers: any[]): any[] {
+export function flattenSteps(workers: any[]): any[] {
     const steps: any[] = [];
     for (const worker of workers) {
         for (const step of worker.steps || []) {
@@ -243,10 +255,17 @@ function flattenSteps(workers: any[]): any[] {
                 completedAt: step.completed_at || null,
                 durationMs: step.duration_ms ?? null,
                 output: step.output ?? null,
+                status: step.status ?? null,
+                error: step.error ?? null,
             });
         }
     }
     return steps;
+}
+
+/** Server-derived status wins; timestamp heuristic only for pre-status API responses. */
+export function stepDisplayStatus(step: { status?: string | null; startedAt?: string | null; completedAt?: string | null }): string {
+    return step.status ?? (step.completedAt ? 'completed' : step.startedAt ? 'running' : 'pending');
 }
 
 function unwrapOutput(output: any): any {

--- a/src/commands/run-view.ts
+++ b/src/commands/run-view.ts
@@ -225,7 +225,7 @@ export function displayStepsTable(steps: any[], indent: string = '  ') {
         const duration = formatDuration(step.durationMs);
         // A failed step's error is more useful than its (null) output — show it, red.
         const output = step.error
-            ? chalk.red(truncate(String(step.error), 40))
+            ? chalk.red(truncate(String(step.error).replace(/\s+/g, ' ').trim(), 40))
             : chalk.gray(step.output ? truncate(JSON.stringify(unwrapOutput(step.output)), 40) : '-');
 
         console.log(

--- a/src/commands/run-view.ts
+++ b/src/commands/run-view.ts
@@ -158,7 +158,7 @@ function displayFullView(runData: any, timeline: any, steps: any[], logsData: an
     if (runData.error) {
         console.log('');
         console.log(chalk.bold.red('  Error:'));
-        console.log(chalk.red(`    ${runData.error}`));
+        console.log(chalk.red(`    ${errorMessage(runData.error)}`));
     }
 
     // Logs snippet
@@ -225,7 +225,7 @@ export function displayStepsTable(steps: any[], indent: string = '  ') {
         const duration = formatDuration(step.durationMs);
         // A failed step's error is more useful than its (null) output — show it, red.
         const output = step.error
-            ? chalk.red(truncate(String(step.error).replace(/\s+/g, ' ').trim(), 40))
+            ? chalk.red(truncate(errorMessage(step.error).replace(/\s+/g, ' ').trim(), 40))
             : chalk.gray(step.output ? truncate(JSON.stringify(unwrapOutput(step.output)), 40) : '-');
 
         console.log(
@@ -239,7 +239,7 @@ export function displayStepsTable(steps: any[], indent: string = '  ') {
     if (firstFailed) {
         console.log('');
         console.log(chalk.bold.red(`${indent}Step "${firstFailed.name}" failed:`));
-        console.log(chalk.red(`${indent}  ${String(firstFailed.error)}`));
+        console.log(chalk.red(`${indent}  ${errorMessage(firstFailed.error)}`));
     }
 }
 
@@ -273,6 +273,37 @@ function unwrapOutput(output: any): any {
         return output.json;
     }
     return output;
+}
+
+/**
+ * Normalize a step/run `error` field to a readable string. Errors arrive in
+ * one of three shapes: a plain string (legacy servers), a superjson-wrapped
+ * `{ json: { name, message, stack }, __solidactions_serializer: 'superjson' }`
+ * object (steps endpoint), or that same shape JSON.stringified into a string
+ * (run-level `error` field) — confirmed live via GET /api/v1/runs/{id} and
+ * .../steps. Without this, a thrown Error renders as "[object Object]".
+ */
+export function errorMessage(error: unknown): string {
+    if (error === null || error === undefined) return '';
+
+    let value: any = error;
+    if (typeof value === 'string') {
+        try {
+            value = JSON.parse(value);
+        } catch {
+            return value;
+        }
+    }
+
+    if (value && typeof value === 'object' && value.__solidactions_serializer === 'superjson' && value.json) {
+        const inner = value.json;
+        if (inner && typeof inner === 'object' && (inner.name || inner.message)) {
+            return inner.name && inner.message ? `${inner.name}: ${inner.message}` : String(inner.name || inner.message);
+        }
+        return JSON.stringify(inner);
+    }
+
+    return typeof value === 'object' ? JSON.stringify(value) : String(value);
 }
 
 function formatDuration(ms: number | null): string {

--- a/src/commands/schedule-list.ts
+++ b/src/commands/schedule-list.ts
@@ -20,13 +20,14 @@ export async function scheduleList(projectName: string) {
         }
 
         console.log('');
-        console.log(chalk.gray('ID'.padEnd(8) + 'WORKFLOW'.padEnd(25) + 'CRON'.padEnd(18) + 'ENABLED'.padEnd(10) + 'NEXT RUN'));
-        console.log(chalk.gray('-'.repeat(95)));
+        console.log(chalk.gray('ID'.padEnd(8) + 'WORKFLOW'.padEnd(25) + 'CRON'.padEnd(18) + 'TIMEZONE'.padEnd(20) + 'ENABLED'.padEnd(10) + 'NEXT RUN'));
+        console.log(chalk.gray('-'.repeat(105)));
 
         for (const schedule of schedules) {
             const id = schedule.id?.toString() || '?';
             const workflow = schedule.workflow_name || schedule.workflow_slug || '?';
             const cron = schedule.cron_expression || '?';
+            const timezone = schedule.timezone || 'UTC';
             const enabled = schedule.enabled;
             const nextRun = schedule.next_run_at ? formatRelativeTime(schedule.next_run_at) : '-';
 
@@ -36,6 +37,7 @@ export async function scheduleList(projectName: string) {
                 chalk.gray(id.padEnd(8)) +
                 workflow.padEnd(25) +
                 chalk.cyan(cron.padEnd(18)) +
+                chalk.gray(timezone.padEnd(20)) +
                 enabledColor((enabled ? 'yes' : 'no').padEnd(10)) +
                 chalk.gray(nextRun)
             );

--- a/src/commands/schedule-set.ts
+++ b/src/commands/schedule-set.ts
@@ -94,11 +94,13 @@ export async function scheduleSet(projectName: string, cron: string, options: { 
         });
 
         // Verify, don't trust: a server predating timezone support silently
-        // strips the field and runs the schedule in UTC. Fail loudly instead.
+        // strips the field, but the schedule is already persisted by this point —
+        // it's live and running in the wrong timezone. Report the persisted fact
+        // and the remedy, not a hypothetical.
         const returnedTz: string | undefined = response.data?.schedule?.timezone;
         if (timezoneMismatch(options.timezone, returnedTz)) {
-            console.error(chalk.red(`Server did not apply the requested timezone: sent "${options.timezone}", got "${returnedTz ?? 'none'}".`));
-            console.error(chalk.red('The schedule would silently run in UTC. This server likely predates --timezone support — upgrade it, or omit --timezone.'));
+            console.error(chalk.red(`A schedule was created but is running in ${returnedTz ?? 'UTC'} — not ${options.timezone} as requested.`));
+            console.error(chalk.red(`Your server may not support schedule timezones yet; update the server or delete the schedule with: solidactions schedule delete ${projectName} ${options.workflow ?? '<workflow>'}`));
             process.exit(1);
         }
 

--- a/src/commands/schedule-set.ts
+++ b/src/commands/schedule-set.ts
@@ -26,6 +26,14 @@ export function timezoneMismatch(requested: string | undefined, returned: string
     return requested !== undefined && returned !== requested;
 }
 
+/**
+ * Remediation text for a timezoneMismatch. `schedule delete` takes a numeric
+ * <schedule-id>, not a workflow name — point at `schedule list` first to find it.
+ */
+export function timezoneMismatchRemedy(projectName: string): string {
+    return `Your server may not support schedule timezones yet; update the server, or run 'solidactions schedule list ${projectName}' to find the schedule ID and remove it with: solidactions schedule delete ${projectName} <schedule-id>`;
+}
+
 export async function scheduleSet(projectName: string, cron: string, options: { workflow?: string; input?: string; timezone?: string; yes?: boolean }) {
     const config = await requireConfigWithWorkspace();
 
@@ -100,7 +108,7 @@ export async function scheduleSet(projectName: string, cron: string, options: { 
         const returnedTz: string | undefined = response.data?.schedule?.timezone;
         if (timezoneMismatch(options.timezone, returnedTz)) {
             console.error(chalk.red(`A schedule was created but is running in ${returnedTz ?? 'UTC'} — not ${options.timezone} as requested.`));
-            console.error(chalk.red(`Your server may not support schedule timezones yet; update the server or delete the schedule with: solidactions schedule delete ${projectName} ${options.workflow ?? '<workflow>'}`));
+            console.error(chalk.red(timezoneMismatchRemedy(projectName)));
             process.exit(1);
         }
 

--- a/src/commands/schedule-set.ts
+++ b/src/commands/schedule-set.ts
@@ -3,7 +3,30 @@ import chalk from 'chalk';
 import prompts from 'prompts';
 import { getApiHeaders, requireConfigWithWorkspace } from '../utils/api';
 
-export async function scheduleSet(projectName: string, cron: string, options: { workflow?: string; input?: string; yes?: boolean }) {
+export function buildSchedulePayload(
+    cron: string,
+    options: { workflow?: string; input?: string; timezone?: string },
+    inputData?: Record<string, any>,
+): Record<string, any> {
+    const payload: Record<string, any> = { cron };
+    if (options.workflow) {
+        payload.workflow = options.workflow;
+    }
+    if (inputData) {
+        payload.input = inputData;
+    }
+    if (options.timezone) {
+        payload.timezone = options.timezone;
+    }
+    return payload;
+}
+
+/** True when the user asked for a timezone the server did not apply (pre-item-5-App server). */
+export function timezoneMismatch(requested: string | undefined, returned: string | undefined): boolean {
+    return requested !== undefined && returned !== requested;
+}
+
+export async function scheduleSet(projectName: string, cron: string, options: { workflow?: string; input?: string; timezone?: string; yes?: boolean }) {
     const config = await requireConfigWithWorkspace();
 
     // Parse input JSON if provided
@@ -64,24 +87,26 @@ export async function scheduleSet(projectName: string, cron: string, options: { 
     console.log(chalk.blue(`Setting schedule for project "${projectName}"...`));
 
     try {
-        const payload: Record<string, any> = {
-            cron,
-        };
+        const payload = buildSchedulePayload(cron, options, inputData);
 
-        if (options.workflow) {
-            payload.workflow = options.workflow;
-        }
-
-        if (inputData) {
-            payload.input = inputData;
-        }
-
-        await axios.post(`${config.host}/api/v1/projects/${projectName}/schedules`, payload, {
+        const response = await axios.post(`${config.host}/api/v1/projects/${projectName}/schedules`, payload, {
             headers: getApiHeaders(config, 'application/json'),
         });
 
+        // Verify, don't trust: a server predating timezone support silently
+        // strips the field and runs the schedule in UTC. Fail loudly instead.
+        const returnedTz: string | undefined = response.data?.schedule?.timezone;
+        if (timezoneMismatch(options.timezone, returnedTz)) {
+            console.error(chalk.red(`Server did not apply the requested timezone: sent "${options.timezone}", got "${returnedTz ?? 'none'}".`));
+            console.error(chalk.red('The schedule would silently run in UTC. This server likely predates --timezone support — upgrade it, or omit --timezone.'));
+            process.exit(1);
+        }
+
         console.log(chalk.green(`Schedule set successfully!`));
         console.log(chalk.gray(`  Cron: ${cron}`));
+        if (options.timezone) {
+            console.log(chalk.gray(`  Timezone: ${options.timezone}`));
+        }
         if (options.workflow) {
             console.log(chalk.gray(`  Workflow: ${options.workflow}`));
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -343,6 +343,7 @@ schedule
     .argument('<cron>', 'Cron expression (e.g., "0 9 * * *" for daily at 9am)')
     .option('-w, --workflow <name>', 'Workflow name (if project has multiple)')
     .option('-i, --input <json>', 'JSON input to pass to scheduled runs')
+    .option('-z, --timezone <iana>', 'IANA timezone the cron is evaluated in (e.g. America/Chicago); defaults to UTC')
     .option('-y, --yes', 'Skip confirmation if schedule already exists')
     .action((projectName, cron, options) => {
         scheduleSet(projectName, cron, options);

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -138,9 +138,3 @@ export function reservedEnvNameError(key: string): string {
     const suggestion = key.replace(/^SOLIDACTIONS_/, 'MY_');
     return `"${key}" uses the reserved ${RESERVED_ENV_PREFIX} prefix. These names are set by the platform at runtime (API credentials, run context) and a custom variable would clobber them, causing authentication failures. Choose a different name (e.g. "${suggestion}").`;
 }
-
-export function assertNotReservedEnvName(key: string): void {
-    if (isReservedEnvName(key)) {
-        throw new Error(reservedEnvNameError(key));
-    }
-}

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -119,3 +119,28 @@ export function loadSolidActionsConfig(yamlPath: string): SolidActionsConfig {
     const content = fs.readFileSync(yamlPath, 'utf8');
     return yaml.load(content) as SolidActionsConfig;
 }
+
+/**
+ * Reserved runtime env-name prefix. SOLIDACTIONS_* names are set by the
+ * platform at dispatch time (SOLIDACTIONS_API_KEY, SOLIDACTIONS_API_URL, run
+ * context); a custom variable with such a name clobbers the platform
+ * credential — the field failure mode is a bare 401 out of
+ * InvokeSystemDatabase.init before any workflow code runs. Case-sensitive,
+ * matching the server-side rule (App\Support\ReservedEnvNames).
+ */
+export const RESERVED_ENV_PREFIX = 'SOLIDACTIONS_';
+
+export function isReservedEnvName(key: string): boolean {
+    return key.startsWith(RESERVED_ENV_PREFIX);
+}
+
+export function reservedEnvNameError(key: string): string {
+    const suggestion = key.replace(/^SOLIDACTIONS_/, 'MY_');
+    return `"${key}" uses the reserved ${RESERVED_ENV_PREFIX} prefix. These names are set by the platform at runtime (API credentials, run context) and a custom variable would clobber them, causing authentication failures. Choose a different name (e.g. "${suggestion}").`;
+}
+
+export function assertNotReservedEnvName(key: string): void {
+    if (isReservedEnvName(key)) {
+        throw new Error(reservedEnvNameError(key));
+    }
+}

--- a/src/utils/skills.ts
+++ b/src/utils/skills.ts
@@ -61,3 +61,22 @@ export async function installSkills(targetDir: string): Promise<{ written: strin
 export async function fetchAiHelperContent(targetFile: AiHelperTarget): Promise<string> {
     return fetchRawFile(EXAMPLES_OWNER, EXAMPLES_REPO, targetFile);
 }
+
+/**
+ * True when the project dir already has SolidActions skill files installed
+ * (either AI-helper convention). Used by `deploy` for a non-blocking tip —
+ * these files are how AI assistants self-rescue on env-scope/deploy traps.
+ */
+export function hasSolidActionsSkills(projectDir: string): boolean {
+    for (const target of ['CLAUDE.md', 'AGENTS.md'] as AiHelperTarget[]) {
+        const dir = skillTargetDir(target, projectDir);
+        if (!fs.existsSync(dir)) {
+            continue;
+        }
+        const entries = fs.readdirSync(dir);
+        if (entries.some((f) => f.startsWith('solidactions-') && f.endsWith('.md'))) {
+            return true;
+        }
+    }
+    return false;
+}

--- a/tests/deploy-skills-tip.test.ts
+++ b/tests/deploy-skills-tip.test.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { hasSolidActionsSkills } from '../src/utils/skills';
+import { SKILLS_TIP_LINES } from '../src/commands/deploy';
 
 function tmpProject(): string {
     return fs.mkdtempSync(path.join(os.tmpdir(), 'sa-skills-test-'));
@@ -36,5 +37,13 @@ describe('hasSolidActionsSkills', () => {
         fs.mkdirSync(skills, { recursive: true });
         fs.writeFileSync(path.join(skills, 'my-notes.md'), '# not ours');
         expect(hasSolidActionsSkills(dir)).toBe(false);
+    });
+});
+
+describe('SKILLS_TIP_LINES — remedy printed when skills are missing', () => {
+    it('points at `ai init`, not the non-empty-dir `init` or the unrelated `skill push`', () => {
+        const tip = SKILLS_TIP_LINES.join(' ');
+        expect(tip).toContain('ai init');
+        expect(tip).not.toContain('skill push');
     });
 });

--- a/tests/deploy-skills-tip.test.ts
+++ b/tests/deploy-skills-tip.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { hasSolidActionsSkills } from '../src/utils/skills';
+
+function tmpProject(): string {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'sa-skills-test-'));
+}
+
+describe('hasSolidActionsSkills', () => {
+    it('is false for a bare project directory', () => {
+        const dir = tmpProject();
+        expect(hasSolidActionsSkills(dir)).toBe(false);
+    });
+
+    it('is true when .claude/skills contains a solidactions-*.md file', () => {
+        const dir = tmpProject();
+        const skills = path.join(dir, '.claude', 'skills');
+        fs.mkdirSync(skills, { recursive: true });
+        fs.writeFileSync(path.join(skills, 'solidactions-getting-started.md'), '# skill');
+        expect(hasSolidActionsSkills(dir)).toBe(true);
+    });
+
+    it('is true for the .agents/skills variant', () => {
+        const dir = tmpProject();
+        const skills = path.join(dir, '.agents', 'skills');
+        fs.mkdirSync(skills, { recursive: true });
+        fs.writeFileSync(path.join(skills, 'solidactions-workflow-coding.md'), '# skill');
+        expect(hasSolidActionsSkills(dir)).toBe(true);
+    });
+
+    it('ignores unrelated markdown in the skills dir', () => {
+        const dir = tmpProject();
+        const skills = path.join(dir, '.claude', 'skills');
+        fs.mkdirSync(skills, { recursive: true });
+        fs.writeFileSync(path.join(skills, 'my-notes.md'), '# not ours');
+        expect(hasSolidActionsSkills(dir)).toBe(false);
+    });
+});

--- a/tests/env-set-global-note.test.ts
+++ b/tests/env-set-global-note.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import axios from 'axios';
+import { GLOBAL_ENV_SCOPE_NOTE, envSet } from '../src/commands/env-set';
+import { makeTmpEnv, writeGlobal } from './helpers';
+
+describe('GLOBAL_ENV_SCOPE_NOTE content', () => {
+    it('explains the scope, the YAML invisibility, and both remedies', () => {
+        expect(GLOBAL_ENV_SCOPE_NOTE).toContain('creating a GLOBAL variable');
+        expect(GLOBAL_ENV_SCOPE_NOTE).toContain('NOT visible');
+        expect(GLOBAL_ENV_SCOPE_NOTE).toContain('solidactions env map');
+        expect(GLOBAL_ENV_SCOPE_NOTE).toContain('solidactions env set <project> KEY value');
+    });
+});
+
+describe('envSet prints the note in global mode only, before the API call', () => {
+    let lines: string[];
+    const originalLog = console.log;
+    let originalGet: typeof axios.get;
+    let originalPost: typeof axios.post;
+    let env: ReturnType<typeof makeTmpEnv>;
+    let firstHttpAfterNoteIndex: number;
+
+    beforeEach(() => {
+        env = makeTmpEnv();
+        writeGlobal(process.env.HOME!, { host: 'http://localhost', apiKey: 'k', workspaceId: 'ws-1' });
+
+        lines = [];
+        firstHttpAfterNoteIndex = -1;
+        console.log = (...args: unknown[]) => { lines.push(args.map(String).join(' ')); };
+
+        originalGet = axios.get;
+        originalPost = axios.post;
+        // Global-mode calls: GET /api/v1/variables (existence check), then POST create.
+        axios.get = (async (url: string) => {
+            if (url.includes('/api/v1/variables')) {
+                if (firstHttpAfterNoteIndex === -1) firstHttpAfterNoteIndex = lines.length;
+                return { data: { data: [] } };
+            }
+            if (url.includes('variable-mappings')) {
+                return { data: [] };
+            }
+            throw new Error('unexpected GET ' + url);
+        }) as any;
+        axios.post = (async () => ({ data: { created: 1, updated: 0 } })) as any;
+    });
+
+    afterEach(() => {
+        console.log = originalLog;
+        axios.get = originalGet;
+        axios.post = originalPost;
+        env.cleanup();
+    });
+
+    it('2-arg global form prints the note before any HTTP call and still succeeds', async () => {
+        await envSet('MY_GLOBAL', 'value', undefined, { yes: true });
+
+        const noteIndex = lines.findIndex((l) => l.includes('creating a GLOBAL variable'));
+        expect(noteIndex).toBeGreaterThanOrEqual(0);
+        expect(firstHttpAfterNoteIndex).toBeGreaterThan(noteIndex);
+        expect(lines.some((l) => l.includes('created successfully'))).toBe(true);
+    });
+
+    it('3-arg project form prints no note', async () => {
+        await envSet('my-project', 'MY_KEY', 'value', { yes: true });
+        expect(lines.some((l) => l.includes('creating a GLOBAL variable'))).toBe(false);
+    });
+});

--- a/tests/init-template-files.test.ts
+++ b/tests/init-template-files.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { TEMPLATE_FILES } from '../src/commands/init';
+
+describe('TEMPLATE_FILES', () => {
+    it('includes package-lock.json so scaffolds get SDK pin protection', () => {
+        expect(TEMPLATE_FILES.map(([remote]) => remote)).toContain('package-lock.json');
+    });
+
+    it('still includes the core scaffold files', () => {
+        const remotes = TEMPLATE_FILES.map(([remote]) => remote);
+        for (const f of ['package.json', 'tsconfig.json', 'solidactions.yaml', '.env.example', 'src/hello.ts']) {
+            expect(remotes).toContain(f);
+        }
+    });
+});

--- a/tests/login-host-hint.test.ts
+++ b/tests/login-host-hint.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { loginHostLines, resolveLoginHost } from '../src/commands/login';
+
+describe('resolveLoginHost', () => {
+    it('defaults to SolidActions Cloud and marks it as a default', () => {
+        expect(resolveLoginHost({})).toEqual({ host: 'https://app.solidactions.com', isDefault: true });
+    });
+
+    it('--host wins and is not a default', () => {
+        expect(resolveLoginHost({ host: 'http://localhost:8002' }))
+            .toEqual({ host: 'http://localhost:8002', isDefault: false });
+    });
+
+    it('--dev resolves localhost:8000 and is not a default', () => {
+        expect(resolveLoginHost({ dev: true })).toEqual({ host: 'http://localhost:8000', isDefault: false });
+    });
+
+    it('--host beats --dev', () => {
+        expect(resolveLoginHost({ dev: true, host: 'https://self.hosted' }).host).toBe('https://self.hosted');
+    });
+});
+
+describe('loginHostLines', () => {
+    it('default host prints the cloud callout and the --host/--dev hint', () => {
+        const lines = loginHostLines(resolveLoginHost({}));
+        expect(lines[0]).toBe('Logging into https://app.solidactions.com (SolidActions Cloud)');
+        expect(lines[1]).toContain('--host <url>');
+        expect(lines[1]).toContain('--dev');
+    });
+
+    it('explicit host prints the plain Host line with no hint', () => {
+        const lines = loginHostLines(resolveLoginHost({ host: 'http://localhost:8002' }));
+        expect(lines).toEqual(['Host: http://localhost:8002']);
+    });
+});

--- a/tests/reserved-env-names.test.ts
+++ b/tests/reserved-env-names.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import axios from 'axios';
+import fs from 'fs';
+import path from 'path';
+import {
+    RESERVED_ENV_PREFIX,
+    assertNotReservedEnvName,
+    isReservedEnvName,
+    reservedEnvNameError,
+} from '../src/utils/env';
+import { envSet } from '../src/commands/env-set';
+import { envMap } from '../src/commands/env-map';
+import { envPush } from '../src/commands/env-push';
+import { makeTmpEnv, writeGlobal } from './helpers';
+
+describe('reserved env-name guard (unit)', () => {
+    it('accepts ordinary names', () => {
+        expect(isReservedEnvName('MY_API_KEY')).toBe(false);
+        expect(() => assertNotReservedEnvName('MY_API_KEY')).not.toThrow();
+    });
+
+    it('rejects SOLIDACTIONS_-prefixed names', () => {
+        expect(isReservedEnvName('SOLIDACTIONS_API_KEY')).toBe(true);
+        expect(isReservedEnvName('SOLIDACTIONS_ANYTHING')).toBe(true);
+        expect(() => assertNotReservedEnvName('SOLIDACTIONS_API_KEY')).toThrow(/SOLIDACTIONS_API_KEY/);
+    });
+
+    it('message names the key, explains the clobber, and suggests a rename', () => {
+        const msg = reservedEnvNameError('SOLIDACTIONS_API_KEY');
+        expect(msg).toContain('SOLIDACTIONS_API_KEY');
+        expect(msg).toContain(`reserved ${RESERVED_ENV_PREFIX} prefix`);
+        expect(msg).toContain('authentication failures');
+        expect(msg).toContain('MY_API_KEY');
+    });
+});
+
+describe('commands hard-reject reserved names before any HTTP request', () => {
+    let exitCode: number | undefined;
+    let originalExit: typeof process.exit;
+    let originalGet: typeof axios.get;
+    let originalPost: typeof axios.post;
+    let httpCalls: string[];
+    let env: ReturnType<typeof makeTmpEnv>;
+
+    beforeEach(() => {
+        env = makeTmpEnv();
+        writeGlobal(process.env.HOME!, { host: 'http://localhost', apiKey: 'k', workspaceId: 'ws-1' });
+
+        exitCode = undefined;
+        originalExit = process.exit;
+        (process as any).exit = (code?: number) => {
+            exitCode = code ?? 0;
+            throw new Error(`process.exit(${code})`);
+        };
+
+        httpCalls = [];
+        originalGet = axios.get;
+        originalPost = axios.post;
+        axios.get = (async (url: string) => { httpCalls.push(`GET ${url}`); throw new Error('unexpected HTTP'); }) as any;
+        axios.post = (async (url: string) => { httpCalls.push(`POST ${url}`); throw new Error('unexpected HTTP'); }) as any;
+    });
+
+    afterEach(() => {
+        (process as any).exit = originalExit;
+        axios.get = originalGet;
+        axios.post = originalPost;
+        env.cleanup();
+    });
+
+    it('env set (global mode) exits 1 with no HTTP', async () => {
+        try { await envSet('SOLIDACTIONS_API_KEY', 'foo', undefined, {}); } catch { /* exit throws */ }
+        expect(exitCode).toBe(1);
+        expect(httpCalls).toEqual([]);
+    });
+
+    it('env set (project mode) exits 1 with no HTTP', async () => {
+        try { await envSet('my-project', 'SOLIDACTIONS_API_KEY', 'foo', { yes: true }); } catch { /* exit throws */ }
+        expect(exitCode).toBe(1);
+        expect(httpCalls).toEqual([]);
+    });
+
+    it('env map exits 1 with no HTTP when the project_key target is reserved', async () => {
+        try { await envMap('my-project', 'SOLIDACTIONS_API_KEY', 'GLOBAL_KEY', { yes: true }); } catch { /* exit throws */ }
+        expect(exitCode).toBe(1);
+        expect(httpCalls).toEqual([]);
+    });
+
+    it('env push lists offending keys, pushes nothing, exits 1', async () => {
+        const dir = path.join(env.cwd, 'proj');
+        fs.mkdirSync(dir, { recursive: true });
+        fs.writeFileSync(path.join(dir, 'solidactions.yaml'), [
+            'project: demo',
+            'workflows: []',
+            'env:',
+            '  - SOLIDACTIONS_API_KEY',
+            '  - MY_OK_VAR',
+        ].join('\n'));
+        fs.writeFileSync(path.join(dir, '.env.dev'), 'SOLIDACTIONS_API_KEY=evil\nMY_OK_VAR=fine\n');
+
+        try { await envPush('demo', dir, { yes: true }); } catch { /* exit throws */ }
+        expect(exitCode).toBe(1);
+        expect(httpCalls).toEqual([]);
+    });
+});

--- a/tests/reserved-env-names.test.ts
+++ b/tests/reserved-env-names.test.ts
@@ -4,7 +4,6 @@ import fs from 'fs';
 import path from 'path';
 import {
     RESERVED_ENV_PREFIX,
-    assertNotReservedEnvName,
     isReservedEnvName,
     reservedEnvNameError,
 } from '../src/utils/env';
@@ -16,13 +15,11 @@ import { makeTmpEnv, writeGlobal } from './helpers';
 describe('reserved env-name guard (unit)', () => {
     it('accepts ordinary names', () => {
         expect(isReservedEnvName('MY_API_KEY')).toBe(false);
-        expect(() => assertNotReservedEnvName('MY_API_KEY')).not.toThrow();
     });
 
     it('rejects SOLIDACTIONS_-prefixed names', () => {
         expect(isReservedEnvName('SOLIDACTIONS_API_KEY')).toBe(true);
         expect(isReservedEnvName('SOLIDACTIONS_ANYTHING')).toBe(true);
-        expect(() => assertNotReservedEnvName('SOLIDACTIONS_API_KEY')).toThrow(/SOLIDACTIONS_API_KEY/);
     });
 
     it('message names the key, explains the clobber, and suggests a rename', () => {

--- a/tests/run-view-failed-steps.test.ts
+++ b/tests/run-view-failed-steps.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { displayStepsTable, flattenSteps, stepDisplayStatus } from '../src/commands/run-view';
+
+// Fixture mirroring GET /api/v1/runs/{id}/steps (RunsApiController::deriveStepStatus
+// emits per-step status + error; timestamps are set on BOTH success and failure).
+const FAILED_ERROR = 'TypeError: fetch failed (GET http://localhost:3000/x, cause: Error: connect ECONNREFUSED 127.0.0.1:3000)';
+const failedRunPayload = {
+    workers: [
+        {
+            steps: [
+                { name: 'build-greeting', started_at: '2026-07-01T00:00:00Z', completed_at: '2026-07-01T00:00:01Z', duration_ms: 1000, output: { ok: true }, status: 'completed', error: null },
+                { name: 'fetch-data', started_at: '2026-07-01T00:00:01Z', completed_at: '2026-07-01T00:00:03Z', duration_ms: 2000, output: null, status: 'failed', error: FAILED_ERROR },
+            ],
+        },
+    ],
+};
+const successOnlyPayload = {
+    workers: [
+        { steps: [{ name: 'only-step', started_at: '2026-07-01T00:00:00Z', completed_at: '2026-07-01T00:00:01Z', duration_ms: 1000, output: { ok: true }, status: 'completed', error: null }] },
+    ],
+};
+// Older servers: no status/error fields at all.
+const legacyPayload = {
+    workers: [
+        { steps: [{ name: 'legacy-step', started_at: '2026-07-01T00:00:00Z', completed_at: '2026-07-01T00:00:01Z', duration_ms: 1000, output: null }] },
+    ],
+};
+
+describe('flattenSteps', () => {
+    it('carries the server status and error through', () => {
+        const steps = flattenSteps(failedRunPayload.workers);
+        expect(steps[1]).toMatchObject({ name: 'fetch-data', status: 'failed', error: FAILED_ERROR });
+        expect(steps[0]).toMatchObject({ name: 'build-greeting', status: 'completed', error: null });
+    });
+
+    it('defaults status/error to null for legacy payloads', () => {
+        const steps = flattenSteps(legacyPayload.workers);
+        expect(steps[0].status).toBeNull();
+        expect(steps[0].error).toBeNull();
+    });
+});
+
+describe('stepDisplayStatus', () => {
+    it('prefers the server status — a failed step with completedAt set renders failed', () => {
+        const [, failed] = flattenSteps(failedRunPayload.workers);
+        expect(stepDisplayStatus(failed)).toBe('failed');
+    });
+
+    it('falls back to the timestamp heuristic for legacy payloads', () => {
+        const [legacy] = flattenSteps(legacyPayload.workers);
+        expect(stepDisplayStatus(legacy)).toBe('completed');
+        expect(stepDisplayStatus({ status: null, startedAt: 'x', completedAt: null })).toBe('running');
+        expect(stepDisplayStatus({ status: null, startedAt: null, completedAt: null })).toBe('pending');
+    });
+});
+
+describe('displayStepsTable', () => {
+    let lines: string[];
+    const originalLog = console.log;
+
+    beforeEach(() => {
+        lines = [];
+        console.log = (...args: unknown[]) => { lines.push(args.map(String).join(' ')); };
+    });
+    afterEach(() => { console.log = originalLog; });
+
+    it('renders failed status, truncated error in the output column, and the full error below', () => {
+        displayStepsTable(flattenSteps(failedRunPayload.workers));
+        const table = lines.join('\n');
+
+        expect(table).toContain('failed');
+        // Truncated (40-char) error in the row…
+        expect(lines.some((l) => l.includes('fetch-data') && l.includes('TypeError: fetch failed'))).toBe(true);
+        // …and the FULL untruncated error below the table.
+        expect(lines.some((l) => l.includes(FAILED_ERROR))).toBe(true);
+    });
+
+    it('renders a success-only payload with no error block', () => {
+        displayStepsTable(flattenSteps(successOnlyPayload.workers));
+        const table = lines.join('\n');
+        expect(table).toContain('completed');
+        expect(table).not.toContain('failed:');
+        expect(lines.some((l) => l.includes('TypeError'))).toBe(false);
+    });
+});

--- a/tests/run-view-failed-steps.test.ts
+++ b/tests/run-view-failed-steps.test.ts
@@ -25,6 +25,13 @@ const legacyPayload = {
         { steps: [{ name: 'legacy-step', started_at: '2026-07-01T00:00:00Z', completed_at: '2026-07-01T00:00:01Z', duration_ms: 1000, output: null }] },
     ],
 };
+// Stack-trace-style error: a newline lands well within the ~37-char truncation window.
+const MULTILINE_ERROR = 'Error: boom\n    at fetchData (/app/src/fetch.ts:42:11)\n    at process (/app/src/process.ts:10:3)';
+const multilineErrorPayload = {
+    workers: [
+        { steps: [{ name: 'fetch-data', started_at: '2026-07-01T00:00:01Z', completed_at: '2026-07-01T00:00:03Z', duration_ms: 2000, output: null, status: 'failed', error: MULTILINE_ERROR }] },
+    ],
+};
 
 describe('flattenSteps', () => {
     it('carries the server status and error through', () => {
@@ -81,5 +88,20 @@ describe('displayStepsTable', () => {
         expect(table).toContain('completed');
         expect(table).not.toContain('failed:');
         expect(lines.some((l) => l.includes('TypeError'))).toBe(false);
+    });
+
+    it('collapses a multiline stack-trace error to a single-line truncated table cell, while the block below the table keeps the real newlines', () => {
+        displayStepsTable(flattenSteps(multilineErrorPayload.workers));
+
+        // The table row itself: no raw newline, so column alignment for subsequent rows can't break.
+        const rowLine = lines.find((l) => l.includes('fetch-data'));
+        expect(rowLine).toBeDefined();
+        expect(rowLine).not.toContain('\n');
+
+        // The untruncated block below the table preserves the real multiline text
+        // (search for text past the table row's truncation point, so this only matches the full block).
+        const fullBlockLine = lines.find((l) => l.includes('process.ts:10:3'));
+        expect(fullBlockLine).toBeDefined();
+        expect(fullBlockLine).toContain('\n');
     });
 });

--- a/tests/run-view-failed-steps.test.ts
+++ b/tests/run-view-failed-steps.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach, afterEach } from 'vitest';
-import { displayStepsTable, flattenSteps, stepDisplayStatus } from '../src/commands/run-view';
+import { displayStepsTable, errorMessage, flattenSteps, stepDisplayStatus } from '../src/commands/run-view';
 
 // Fixture mirroring GET /api/v1/runs/{id}/steps (RunsApiController::deriveStepStatus
 // emits per-step status + error; timestamps are set on BOTH success and failure).
@@ -30,6 +30,17 @@ const MULTILINE_ERROR = 'Error: boom\n    at fetchData (/app/src/fetch.ts:42:11)
 const multilineErrorPayload = {
     workers: [
         { steps: [{ name: 'fetch-data', started_at: '2026-07-01T00:00:01Z', completed_at: '2026-07-01T00:00:03Z', duration_ms: 2000, output: null, status: 'failed', error: MULTILINE_ERROR }] },
+    ],
+};
+// Real server shape (confirmed live, GET /api/v1/runs/{id}/steps): a thrown
+// native Error is superjson-wrapped as an OBJECT, not a plain string.
+const SUPERJSON_ERROR_OBJECT = {
+    json: { name: 'TypeError', message: 'fetch failed', stack: 'TypeError: fetch failed' },
+    __solidactions_serializer: 'superjson',
+};
+const superjsonErrorPayload = {
+    workers: [
+        { steps: [{ name: 'fetch-unreachable', started_at: '2026-07-01T00:00:01Z', completed_at: '2026-07-01T00:00:03Z', duration_ms: 3, output: null, status: 'failed', error: SUPERJSON_ERROR_OBJECT }] },
     ],
 };
 
@@ -103,5 +114,32 @@ describe('displayStepsTable', () => {
         const fullBlockLine = lines.find((l) => l.includes('process.ts:10:3'));
         expect(fullBlockLine).toBeDefined();
         expect(fullBlockLine).toContain('\n');
+    });
+
+    it('unwraps a superjson-wrapped error object to "Name: message" instead of "[object Object]"', () => {
+        displayStepsTable(flattenSteps(superjsonErrorPayload.workers));
+        const table = lines.join('\n');
+
+        expect(table).not.toContain('[object Object]');
+        expect(lines.some((l) => l.includes('fetch-unreachable') && l.includes('TypeError: fetch failed'))).toBe(true);
+    });
+});
+
+describe('errorMessage', () => {
+    it('returns a plain string error unchanged', () => {
+        expect(errorMessage(FAILED_ERROR)).toBe(FAILED_ERROR);
+    });
+
+    it('unwraps a superjson-wrapped error object to "Name: message"', () => {
+        expect(errorMessage(SUPERJSON_ERROR_OBJECT)).toBe('TypeError: fetch failed');
+    });
+
+    it('unwraps a superjson-wrapped error that arrives pre-JSON.stringified (the run-level `error` field shape)', () => {
+        expect(errorMessage(JSON.stringify(SUPERJSON_ERROR_OBJECT))).toBe('TypeError: fetch failed');
+    });
+
+    it('returns an empty string for null/undefined', () => {
+        expect(errorMessage(null)).toBe('');
+        expect(errorMessage(undefined)).toBe('');
     });
 });

--- a/tests/schedule-timezone.test.ts
+++ b/tests/schedule-timezone.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildSchedulePayload, timezoneMismatch } from '../src/commands/schedule-set';
+import { buildSchedulePayload, timezoneMismatch, timezoneMismatchRemedy } from '../src/commands/schedule-set';
 
 describe('buildSchedulePayload', () => {
     it('includes timezone only when passed', () => {
@@ -27,5 +27,13 @@ describe('timezoneMismatch (post-POST backstop for pre-timezone servers)', () =>
     it('flag dropped by an old server (UTC or missing) → mismatch', () => {
         expect(timezoneMismatch('America/Chicago', 'UTC')).toBe(true);
         expect(timezoneMismatch('America/Chicago', undefined)).toBe(true);
+    });
+});
+
+describe('timezoneMismatchRemedy — schedule delete takes a numeric ID, not a workflow name', () => {
+    it('points at `schedule list` to find the ID, then `schedule delete <project> <schedule-id>`', () => {
+        const remedy = timezoneMismatchRemedy('my-project');
+        expect(remedy).toContain('solidactions schedule list my-project');
+        expect(remedy).toContain('solidactions schedule delete my-project <schedule-id>');
     });
 });

--- a/tests/schedule-timezone.test.ts
+++ b/tests/schedule-timezone.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { buildSchedulePayload, timezoneMismatch } from '../src/commands/schedule-set';
+
+describe('buildSchedulePayload', () => {
+    it('includes timezone only when passed', () => {
+        expect(buildSchedulePayload('0 7 * * 1', { timezone: 'America/Chicago' }))
+            .toEqual({ cron: '0 7 * * 1', timezone: 'America/Chicago' });
+        expect(buildSchedulePayload('0 7 * * 1', {})).toEqual({ cron: '0 7 * * 1' });
+    });
+
+    it('keeps workflow and input alongside timezone', () => {
+        expect(buildSchedulePayload('0 7 * * 1', { workflow: 'report', timezone: 'UTC' }, { mode: 'weekly' }))
+            .toEqual({ cron: '0 7 * * 1', workflow: 'report', input: { mode: 'weekly' }, timezone: 'UTC' });
+    });
+});
+
+describe('timezoneMismatch (post-POST backstop for pre-timezone servers)', () => {
+    it('no flag → never a mismatch, whatever the server returns', () => {
+        expect(timezoneMismatch(undefined, 'UTC')).toBe(false);
+        expect(timezoneMismatch(undefined, undefined)).toBe(false);
+    });
+
+    it('flag echoed back → no mismatch', () => {
+        expect(timezoneMismatch('America/Chicago', 'America/Chicago')).toBe(false);
+    });
+
+    it('flag dropped by an old server (UTC or missing) → mismatch', () => {
+        expect(timezoneMismatch('America/Chicago', 'UTC')).toBe(true);
+        expect(timezoneMismatch('America/Chicago', undefined)).toBe(true);
+    });
+});


### PR DESCRIPTION
## What this is
CLI half of cross-repo Sweep B (companion: solidactions-app#395, sdk, examples). 7 tasks + gate, each adversarially reviewed; final branch review fixes applied.

## Changes
- **Reserved `SOLIDACTIONS_*` names hard-rejected** in `env set` (both modes), `env push` (lists all offenders, aborts whole push), `env map` — exit 1 before any HTTP, matching the server's new 422s
- **`login` host callout**: no-flag logins state the cloud target + `--host`/`--dev` hint (headless-safe, no prompt)
- **`env set` global-scope note**: 2-arg form warns it creates a GLOBAL var invisible to project YAML `env:`, with the project-scoped form hinted
- **`run view` failed steps finally look failed**: uses server `status`/`error` (was recomputing from timestamps — failed steps showed "completed"/"-"), unwraps superjson-shaped errors (was `[object Object]` against real servers — caught by live smoke), multiline stack traces collapse safely in the table with the full error below
- **`schedule set --timezone <IANA>`** + TIMEZONE column in `schedule list` + loud backstop when an older server ignores the field (states the schedule IS live in the returned tz + correct remediation)
- **Scaffolds ship `package-lock.json`** (TEMPLATE_FILES) — reproducible first deploys
- **`deploy` tips when SolidActions skills are missing** from the project (remedy: `solidactions ai init --claude`)

## Verification
Full vitest suite: 288 passed (5 pre-existing `dev.test.ts` environment failures, unrelated — missing `@solidactions/sdk/testing` link). Cross-cutting live smoke against a real dev stack: login callout, env rejects/warns, deploy tip, timezone round-trip + simulated-old-server backstop, run-view error display.

## Release
Publish as **1.22.0** — AFTER solidactions-app#395 deploys (timezone endpoint), BEFORE the examples-repo PR merges. npm publish is founder-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VRVMi2z12qcBqrPvvtB5Gg