### PR TITLE
feat: env set --global guard — no more silent global writes (Sweep C)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Use `solidactions <command> --help` for full flag details on any command.
 
 | Command | Key Flags | Description |
 |---------|-----------|-------------|
-| `env set <key> <value>` | `-s`, `-y`, `--staging-value`, `--dev-value` | Set global variable (warns before overwriting) |
+| `env set <key> <value> --global` | `-s`, `-y`, `--staging-value`, `--dev-value`, `--global` | Set global variable (warns before overwriting) |
 | `env set <project> <key> <value>` | `-e`, `-s`, `-y` | Set project variable (warns before overwriting) |
 | `env list [project]` | `-e` | List variables |
 | `env delete <key-or-project> [key]` | `-y` | Delete a variable |

--- a/src/commands/env-map.ts
+++ b/src/commands/env-map.ts
@@ -25,7 +25,7 @@ export async function envMap(projectName: string, projectKey: string, globalKey:
 
         if (!globalVar) {
             console.error(chalk.red(`Global variable "${globalKey}" not found.`));
-            console.log(chalk.gray('Create it with: solidactions env set ' + globalKey + ' <value>'));
+            console.log(chalk.gray('Create it with: solidactions env set ' + globalKey + ' <value> --global'));
             process.exit(1);
         }
 

--- a/src/commands/env-set.ts
+++ b/src/commands/env-set.ts
@@ -26,13 +26,38 @@ interface EnvSetOptions {
     stagingInherit?: boolean;
     devInherit?: boolean;
     devInheritStaging?: boolean;
+    global?: boolean;
 }
 
 export async function envSet(keyOrProject: string, valueOrKey?: string, valueIfProject?: string, options: EnvSetOptions = {}): Promise<void> {
-    const config = await requireConfigWithWorkspace();
-
     // Detect mode based on arguments
     const isProjectMode = valueIfProject !== undefined;
+
+    // Jordan Wall #4 (Sweep C, → 1.23.0): a 2-positional-arg call used to fall
+    // through to GLOBAL scope silently, so a typo'd `env set KEY VALUE` (meant
+    // for a project) wrote a global var the workflow never reads. Global
+    // writes now require an explicit --global. Runs before any
+    // config/network work so a plain argument mistake never needs a login.
+    if (!isProjectMode && !options.global) {
+        process.stderr.write(chalk.red(
+            'env set needs either a project or --global — pick one:\n' +
+            '  solidactions env set KEY VALUE --global      (global variable)\n' +
+            '  solidactions env set <project> KEY VALUE     (project variable)\n'
+        ));
+        process.exit(1);
+    }
+
+    // --global never takes a project positional — reject the ambiguous combo too.
+    if (isProjectMode && options.global) {
+        process.stderr.write(chalk.red(
+            'env set: --global does not take a project argument — pick one:\n' +
+            '  solidactions env set KEY VALUE --global      (global variable)\n' +
+            '  solidactions env set <project> KEY VALUE     (project variable)\n'
+        ));
+        process.exit(1);
+    }
+
+    const config = await requireConfigWithWorkspace();
 
     if (isProjectMode) {
         // Project mode: solidactions env set <project> <key> <value>

--- a/src/commands/env-set.ts
+++ b/src/commands/env-set.ts
@@ -11,7 +11,7 @@ export function isNonTty(): boolean {
 
 /** Printed before a 2-arg (global-scope) write — Jordan's runs 3-7 footgun. */
 export const GLOBAL_ENV_SCOPE_NOTE = [
-    'Note: no project specified — creating a GLOBAL variable.',
+    'Note: --global specified — creating a GLOBAL variable.',
     "  Global variables are NOT visible to a project's plain `env:` YAML declarations",
     '  unless you map them (`solidactions env map …`).',
     '  For a project variable, use: solidactions env set <project> KEY value',

--- a/src/index.ts
+++ b/src/index.ts
@@ -265,6 +265,7 @@ env
     .argument('[value]', 'Variable value (when first arg is project)')
     .option('-s, --secret', 'Mark as encrypted secret')
     .option('-e, --env <environment>', 'Target environment (production/staging/dev)', 'dev')
+    .option('--global', 'Set a global variable (no project) — required for the 2-arg form')
     .option('--staging-value <value>', 'Staging environment value (global only)')
     .option('--dev-value <value>', 'Dev environment value (global only)')
     .option('--staging-inherit', 'Staging inherits from production (global only)')

--- a/tests/env-set-global-guard.test.ts
+++ b/tests/env-set-global-guard.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Jordan Wall #4 (Sweep C, → 1.23.0): `env set` used to silently fall through
+ * to GLOBAL scope when no project arg was given, so a typo'd
+ * `env set KEY VALUE` (meant for a project) wrote a global var the workflow
+ * never reads. Global writes now require an explicit --global.
+ *
+ * Test-double policy: real in-process HTTP server (Node's http.createServer)
+ * for the "valid call" paths — no mock/spy/stub libraries. Matches the
+ * pattern in skill-push.test.ts / dev.test.ts. The guard-rejection paths need
+ * no server at all: they must fail before any config/network work.
+ */
+import * as http from 'http';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { envSet } from '../src/commands/env-set';
+import { makeTmpEnv, writeGlobal } from './helpers';
+
+class ProcessExitError extends Error {
+    constructor(public readonly code: number | undefined) {
+        super(`process.exit(${code})`);
+    }
+}
+
+function patchProcessExit(): () => void {
+    const orig = process.exit.bind(process);
+    (process as any).exit = (code?: number) => { throw new ProcessExitError(code); };
+    return () => { (process as any).exit = orig; };
+}
+
+function captureStderr(): { lines: string[]; restore: () => void } {
+    const lines: string[] = [];
+    const orig = process.stderr.write.bind(process.stderr);
+    (process.stderr as any).write = (chunk: string) => { lines.push(String(chunk)); return true; };
+    return { lines, restore: () => { (process.stderr as any).write = orig; } };
+}
+
+let server: http.Server;
+let port: number;
+let requests: Array<{ method: string; path: string; body: any }> = [];
+
+beforeAll(async () => {
+    server = http.createServer((req, res) => {
+        let raw = '';
+        req.on('data', (c) => { raw += c; });
+        req.on('end', () => {
+            let body: any = null;
+            try { body = raw ? JSON.parse(raw) : null; } catch { /* ignore */ }
+            requests.push({ method: req.method || '', path: req.url || '', body });
+
+            if (req.method === 'GET' && req.url?.startsWith('/api/v1/variables')) {
+                res.writeHead(200, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ data: [] }));
+                return;
+            }
+            if (req.method === 'POST' && req.url === '/api/v1/variables') {
+                res.writeHead(200, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({}));
+                return;
+            }
+            if (req.method === 'POST' && req.url?.match(/\/api\/v1\/projects\/.+\/variable-mappings\/bulk/)) {
+                res.writeHead(200, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ created: 1, updated: 0 }));
+                return;
+            }
+            res.writeHead(404, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ message: `unhandled ${req.method} ${req.url}` }));
+        });
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => {
+        port = (server.address() as any).port;
+        resolve();
+    }));
+});
+
+afterAll(() => new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve()))));
+
+beforeEach(() => { requests = []; });
+
+describe('envSet — --global guard (Jordan Wall #4)', () => {
+    it('2-arg call without --global hard-errors naming both correct forms, before any network call', async () => {
+        const restoreExit = patchProcessExit();
+        const { lines, restore: restoreErr } = captureStderr();
+        try {
+            let caught: ProcessExitError | null = null;
+            try { await envSet('KEY', 'value'); }
+            catch (e) { if (e instanceof ProcessExitError) caught = e; else throw e; }
+
+            expect(caught?.code).toBe(1);
+            expect(requests.length).toBe(0); // guard fires before requireConfigWithWorkspace/network
+            const out = lines.join('');
+            expect(out).toContain('solidactions env set KEY VALUE --global');
+            expect(out).toContain('solidactions env set <project> KEY VALUE');
+        } finally { restoreExit(); restoreErr(); }
+    });
+
+    it('2-arg call with options.global undefined (commander default) still errors', async () => {
+        const restoreExit = patchProcessExit();
+        const { restore: restoreErr } = captureStderr();
+        try {
+            let caught: ProcessExitError | null = null;
+            try { await envSet('KEY', 'value', undefined, {}); }
+            catch (e) { if (e instanceof ProcessExitError) caught = e; else throw e; }
+            expect(caught?.code).toBe(1);
+        } finally { restoreExit(); restoreErr(); }
+    });
+
+    it('3-arg project-mode call (no --global) is unaffected by the guard and proceeds', async () => {
+        const env = makeTmpEnv();
+        writeGlobal(env.home, { host: `http://127.0.0.1:${port}`, apiKey: 'sk_test', workspaceId: 'ws-1' });
+        const restoreExit = patchProcessExit();
+        try {
+            let caught: ProcessExitError | null = null;
+            try { await envSet('myproject', 'KEY', 'value', { yes: true }); }
+            catch (e) { if (e instanceof ProcessExitError) caught = e; else throw e; }
+            // envSet does not process.exit on success — no exit should have been thrown.
+            expect(caught).toBeNull();
+            expect(requests.some((r) => r.method === 'POST' && r.path.includes('/variable-mappings/bulk'))).toBe(true);
+        } finally { restoreExit(); env.cleanup(); }
+    });
+
+    it('2-arg call WITH --global proceeds to global mode', async () => {
+        const env = makeTmpEnv();
+        writeGlobal(env.home, { host: `http://127.0.0.1:${port}`, apiKey: 'sk_test', workspaceId: 'ws-1' });
+        const restoreExit = patchProcessExit();
+        try {
+            let caught: ProcessExitError | null = null;
+            try { await envSet('KEY', 'value', undefined, { global: true, yes: true }); }
+            catch (e) { if (e instanceof ProcessExitError) caught = e; else throw e; }
+            expect(caught).toBeNull();
+            expect(requests.some((r) => r.method === 'POST' && r.path === '/api/v1/variables')).toBe(true);
+        } finally { restoreExit(); env.cleanup(); }
+    });
+
+    it('3-arg project call PLUS --global is rejected as ambiguous', async () => {
+        const restoreExit = patchProcessExit();
+        const { lines, restore: restoreErr } = captureStderr();
+        try {
+            let caught: ProcessExitError | null = null;
+            try { await envSet('myproject', 'KEY', 'value', { global: true }); }
+            catch (e) { if (e instanceof ProcessExitError) caught = e; else throw e; }
+            expect(caught?.code).toBe(1);
+            expect(requests.length).toBe(0);
+            expect(lines.join('')).toContain('--global does not take a project argument');
+        } finally { restoreExit(); restoreErr(); }
+    });
+});

--- a/tests/env-set-global-note.test.ts
+++ b/tests/env-set-global-note.test.ts
@@ -52,7 +52,7 @@ describe('envSet prints the note in global mode only, before the API call', () =
     });
 
     it('2-arg global form prints the note before any HTTP call and still succeeds', async () => {
-        await envSet('MY_GLOBAL', 'value', undefined, { yes: true });
+        await envSet('MY_GLOBAL', 'value', undefined, { yes: true, global: true });
 
         const noteIndex = lines.findIndex((l) => l.includes('creating a GLOBAL variable'));
         expect(noteIndex).toBeGreaterThanOrEqual(0);

--- a/tests/env-set-non-tty.test.ts
+++ b/tests/env-set-non-tty.test.ts
@@ -91,7 +91,7 @@ describe('envSet non-TTY fast-fail', () => {
 
             try {
                 // Global mode: only two positional args (key, value), no third arg
-                await envSet('GLOBAL_KEY', 'new-value', undefined, { yes: false });
+                await envSet('GLOBAL_KEY', 'new-value', undefined, { yes: false, global: true });
             } catch (err: any) {
                 // Expected: process.exit mock throws, then caught by envSet's outer catch, may throw again
             }

--- a/tests/reserved-env-names.test.ts
+++ b/tests/reserved-env-names.test.ts
@@ -65,7 +65,7 @@ describe('commands hard-reject reserved names before any HTTP request', () => {
     });
 
     it('env set (global mode) exits 1 with no HTTP', async () => {
-        try { await envSet('SOLIDACTIONS_API_KEY', 'foo', undefined, {}); } catch { /* exit throws */ }
+        try { await envSet('SOLIDACTIONS_API_KEY', 'foo', undefined, { global: true }); } catch { /* exit throws */ }
         expect(exitCode).toBe(1);
         expect(httpCalls).toEqual([]);
     });


### PR DESCRIPTION
Track 4 of Sweep C (spec: solidactions-app docs/superpowers/specs/2026-07-04-sweep-c-design.md). Jordan Wall #4: `env set KEY VALUE` silently created a GLOBAL variable the workflow never read.

**BREAKING**: 2-arg global form now requires explicit `--global`; project+`--global` rejected as ambiguous. Guard fires before config/network. env-map hint + README updated to match. 19/19 covering tests green (in-process HTTP server, no mocks); adversarially reviewed + final whole-branch review with fix waves applied.

Ships as 1.23.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VRVMi2z12qcBqrPvvtB5Gg