### PR TITLE
fix(login): backup before config overwrite + informed non-interactive refusal

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ You can mix: e.g., set only `SOLIDACTIONS_WORKSPACE_ID` in the environment while
 
 In interactive shells, `login` without `--local`/`--global` prompts for a location. In non-interactive contexts, one of the flags is required.
 
+If the target config file already exists and its contents would change, `login` writes a timestamped backup (e.g. `config.json.bak-2026-07-05T12-30-00Z`) alongside it before overwriting, and prints the backup path. Non-interactive runs proceed automatically (with the backup); an interactive TTY additionally asks a y/N confirmation first.
+
 ### `solidactions logout` flags
 
 - `--local` — remove only the nearest local config (walks up from cwd).

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import chalk from 'chalk';
 import { ensureWorkspaceSelected } from '../utils/api';
 import { workspaceSet } from './workspaces';
@@ -5,13 +6,12 @@ import {
     Config,
     ConfigSource,
     resolveConfig,
-    readConfigFile,
     writeConfigFile,
     removeConfigFile,
     findLocalConfigPath,
     getGlobalConfigPath,
 } from '../utils/config';
-import { decideWriteTarget, pathForTarget, ensureGitignoreCovers } from '../utils/config-write-target';
+import { decideWriteTarget, pathForTarget, ensureGitignoreCovers, confirmOverwrite } from '../utils/config-write-target';
 
 export type { Config };
 
@@ -41,6 +41,21 @@ export function resolveLoginHost(options: { dev?: boolean; host?: string }): { h
     return { host: 'https://app.solidactions.com', isDefault: true };
 }
 
+/**
+ * Path for a timestamped backup of `targetPath`, e.g.
+ * `config.json.bak-2026-07-05T12-30-00Z`. Pure — takes `now` so tests are
+ * deterministic.
+ */
+export function backupPathFor(targetPath: string, now: Date = new Date()): string {
+    const timestamp = now.toISOString().replace(/\.\d{3}Z$/, 'Z').replace(/:/g, '-');
+    return `${targetPath}.bak-${timestamp}`;
+}
+
+const LOGIN_REFUSAL_MESSAGE =
+    'Refusing to write config non-interactively. Pass --global to update the machine-wide config ' +
+    'at ~/.solidactions/config.json (a backup is kept if one exists), or --local to write ' +
+    './.solidactions/config.json for just this directory.';
+
 export function loginHostLines(resolved: { host: string; isDefault: boolean }): string[] {
     if (resolved.isDefault) {
         return [
@@ -65,7 +80,7 @@ export async function login(
     }
 
     // Determine target location.
-    const target = await decideWriteTarget({ local: options.local, global: options.global });
+    const target = await decideWriteTarget({ local: options.local, global: options.global }, undefined, LOGIN_REFUSAL_MESSAGE);
     const targetPath = pathForTarget(target);
 
     console.log(chalk.blue(`Initializing SolidActions CLI...`));
@@ -73,14 +88,25 @@ export async function login(
         console.log(resolved.isDefault ? chalk.yellow(line) : chalk.gray(line));
     }
 
-    if (readConfigFile(targetPath)) {
-        console.log(chalk.yellow(`Existing config at ${targetPath} will be overwritten.`));
-    }
-
     const config: Config = {
         host,
         apiKey: apiKey.trim(),
     };
+
+    const existingRaw = fs.existsSync(targetPath) ? fs.readFileSync(targetPath, 'utf-8') : null;
+    const wouldChange = existingRaw !== null && existingRaw.trim() !== JSON.stringify(config, null, 2).trim();
+
+    if (wouldChange) {
+        const backupPath = backupPathFor(targetPath);
+        const proceed = await confirmOverwrite(targetPath, backupPath);
+        if (!proceed) {
+            console.log(chalk.yellow('Aborted. No changes were made.'));
+            process.exit(0);
+        }
+        fs.copyFileSync(targetPath, backupPath);
+        console.log(chalk.gray(`Backup saved to ${backupPath}`));
+    }
+
     writeConfigFile(targetPath, config);
 
     if (target === 'local') {

--- a/src/utils/config-write-target.ts
+++ b/src/utils/config-write-target.ts
@@ -17,6 +17,7 @@ export type WriteTarget = 'local' | 'global';
 export async function decideWriteTarget(
     options: { local?: boolean; global?: boolean },
     promptLabel = 'Save config locally (./.solidactions) or globally (~/.solidactions)? [global] ',
+    refusalMessage = 'Refusing to write config non-interactively. Pass --local or --global.',
 ): Promise<WriteTarget> {
     if (options.local && options.global) {
         console.error(chalk.red('Error: --local and --global are mutually exclusive.'));
@@ -39,12 +40,36 @@ export async function decideWriteTarget(
             rl.close();
         }
     }
-    console.error(chalk.red('Refusing to write config non-interactively. Pass --local or --global.'));
+    console.error(chalk.red(refusalMessage));
     process.exit(1);
 }
 
 export function pathForTarget(target: WriteTarget): string {
     return target === 'local' ? getLocalConfigPath() : getGlobalConfigPath();
+}
+
+/**
+ * Notify (and, on a TTY, confirm) that an existing config file is about to be
+ * overwritten. A backup will be written to `backupPath` regardless of mode —
+ * this always says so. Non-interactive callers (CI, agents) proceed
+ * automatically so they never wedge; an interactive TTY additionally asks a
+ * y/N confirm (default N).
+ */
+export async function confirmOverwrite(existingPath: string, backupPath: string): Promise<boolean> {
+    const notice = `Existing config at ${existingPath} will be overwritten (backup will be saved to ${backupPath}).`;
+
+    if (!process.stdin.isTTY) {
+        console.log(chalk.yellow(notice));
+        return true;
+    }
+
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    try {
+        const answer = await new Promise<string>((resolve) => rl.question(chalk.yellow(`${notice} Continue? [y/N] `), resolve));
+        return answer.trim().toLowerCase().startsWith('y');
+    } finally {
+        rl.close();
+    }
 }
 
 /**

--- a/tests/login-overwrite-guard.test.ts
+++ b/tests/login-overwrite-guard.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Cleanroom-gate Sev-4: `solidactions login <key> --host <url> --global` used
+ * to silently overwrite an existing ~/.solidactions/config.json with only a
+ * post-hoc "will be overwritten" notice — no prompt, no backup, no --force.
+ * During a cleanroom smoke this destroyed a real config.
+ *
+ * Fix: before overwriting an existing config whose contents would change,
+ * write a timestamped backup (config.json.bak-<ISO timestamp>) and print its
+ * path. Non-interactive mode (agents, CI) proceeds automatically WITH the
+ * backup so it never wedges; an interactive TTY additionally asks a y/N
+ * confirm (default N).
+ *
+ * Test-double policy: real fs in tmp dirs (makeTmpEnv/writeGlobal), no
+ * mock/spy/stub libraries. `--host` points at an unreachable local port so
+ * the post-login workspace-selection network call fails fast and is
+ * swallowed by login()'s own try/catch — it is not what these tests exercise.
+ */
+import fs from 'fs';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { login } from '../src/commands/login';
+import { makeTmpEnv, writeGlobal } from './helpers';
+
+const UNREACHABLE_HOST = 'http://127.0.0.1:1';
+
+class ProcessExitError extends Error {
+    constructor(public readonly code: number | undefined) {
+        super(`process.exit(${code})`);
+    }
+}
+
+describe('login — overwrite guard (cleanroom Sev-4)', () => {
+    let originalIsTTY: boolean | undefined;
+    let originalExit: typeof process.exit;
+    let originalLog: typeof console.log;
+    let originalError: typeof console.error;
+    let logLines: string[];
+    let errorLines: string[];
+    let env: ReturnType<typeof makeTmpEnv>;
+
+    beforeEach(() => {
+        env = makeTmpEnv();
+
+        originalIsTTY = process.stdin.isTTY;
+        Object.defineProperty(process.stdin, 'isTTY', { value: undefined, configurable: true });
+
+        originalExit = process.exit;
+        (process as any).exit = (code?: number) => { throw new ProcessExitError(code); };
+
+        logLines = [];
+        originalLog = console.log;
+        console.log = (...args: unknown[]) => { logLines.push(args.map(String).join(' ')); };
+
+        errorLines = [];
+        originalError = console.error;
+        console.error = (...args: unknown[]) => { errorLines.push(args.map(String).join(' ')); };
+    });
+
+    afterEach(() => {
+        Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true });
+        (process as any).exit = originalExit;
+        console.log = originalLog;
+        console.error = originalError;
+        env.cleanup();
+    });
+
+    it('existing config + non-interactive --global: backs up the OLD contents before overwriting, then writes the new config', async () => {
+        const globalPath = writeGlobal(env.home, { host: 'http://old-host.example', apiKey: 'old-api-key' });
+        const oldRaw = fs.readFileSync(globalPath, 'utf-8');
+
+        await login('new-api-key', { global: true, host: UNREACHABLE_HOST });
+
+        const dir = path.dirname(globalPath);
+        const entries = fs.readdirSync(dir);
+        const backups = entries.filter((f) => f.startsWith('config.json.bak-'));
+
+        expect(backups).toHaveLength(1);
+        const backupPath = path.join(dir, backups[0]);
+        expect(fs.readFileSync(backupPath, 'utf-8')).toBe(oldRaw);
+
+        // New config was written to the original path.
+        const newConfig = JSON.parse(fs.readFileSync(globalPath, 'utf-8'));
+        expect(newConfig.apiKey).toBe('new-api-key');
+        expect(newConfig.host).toBe(UNREACHABLE_HOST);
+
+        // Backup path was printed plainly (no prompt in non-interactive mode).
+        expect(logLines.some((l) => l.includes('Backup saved to') && l.includes(backupPath))).toBe(true);
+    });
+
+    it('no existing config: no backup is written, no prompt is needed', async () => {
+        // makeTmpEnv() gives a fresh $HOME with no .solidactions/ dir yet.
+        const dir = path.join(env.home, '.solidactions');
+        const globalPath = path.join(dir, 'config.json');
+        expect(fs.existsSync(globalPath)).toBe(false);
+
+        await login('brand-new-key', { global: true, host: UNREACHABLE_HOST });
+
+        expect(fs.existsSync(dir)).toBe(true);
+        const entries = fs.readdirSync(dir);
+        const backups = entries.filter((f) => f.startsWith('config.json.bak-'));
+        expect(backups).toHaveLength(0);
+        expect(logLines.some((l) => l.includes('Backup saved to'))).toBe(false);
+
+        const newConfig = JSON.parse(fs.readFileSync(globalPath, 'utf-8'));
+        expect(newConfig.apiKey).toBe('brand-new-key');
+    });
+
+    it('non-interactive refusal (neither --local nor --global) explains both options, including the backup guarantee', async () => {
+        let caught: ProcessExitError | null = null;
+        try {
+            await login('some-key', { host: UNREACHABLE_HOST });
+        } catch (e) {
+            if (e instanceof ProcessExitError) caught = e;
+            else throw e;
+        }
+
+        expect(caught?.code).toBe(1);
+        const out = errorLines.join(' ');
+        expect(out).toContain('--global');
+        expect(out).toContain('machine-wide');
+        expect(out).toContain('backup');
+        expect(out).toContain('--local');
+        expect(out).toContain('./.solidactions/config.json');
+    });
+});


### PR DESCRIPTION
Cleanroom-gate sev-4: `login --global` silently overwrote an existing ~/.solidactions/config.json (destroyed a real config during the smoke). Now: timestamped backup written before any changing overwrite (path printed), interactive TTY confirms y/N, non-interactive proceeds with backup so agents never wedge. Refusal message for flag-less non-interactive login now explains what --global and --local each do. 3 new tests (real fs, failing-first proven). Ships as 1.23.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VRVMi2z12qcBqrPvvtB5Gg