### PR TITLE
CLI polish: README flags, run-start -w cleanup, oauth-actions unknown-platform + platforms subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Use `solidactions <command> --help` for full flag details on any command.
 
 | Command | Key Flags | Description |
 |---------|-----------|-------------|
-| `run start <project> <workflow>` | `-e`, `-i`, `-w` | Trigger a workflow run |
+| `run start <project> <workflow>` | `-e`, `-i`, `--wait` | Trigger a workflow run |
 | `run list [project]` | `--json`, `--detailed`, `--status`, `--since`, `--workflow`, `--limit`, `--offset` | List and filter runs |
 | `run view <run-id>` | `--json`, `--timeline`, `--steps`, `--logs` | Inspect a run |
 
@@ -129,7 +129,7 @@ Use `solidactions <command> --help` for full flag details on any command.
 
 | Command | Key Flags | Description |
 |---------|-----------|-------------|
-| `schedule set <project> <cron>` | `-w`, `-i`, `-y` | Set cron schedule (warns if exists) |
+| `schedule set <project> <cron>` | `--workflow`, `-i`, `-y` | Set cron schedule (warns if exists) |
 | `schedule list <project>` | | List schedules |
 | `schedule delete <project> <id>` | `-y` | Delete a schedule |
 

--- a/src/commands/oauth-actions-list.ts
+++ b/src/commands/oauth-actions-list.ts
@@ -47,7 +47,9 @@ export async function oauthActionsList(platform: string, options: OAuthActionsLi
         console.log('');
         console.log(chalk.gray(`${actions.length} action(s) — use "solidactions oauth-actions search ${platform} <query>" to narrow, or "oauth-actions show ${platform} <action_id>" for detail.`));
     } catch (error: any) {
-        if (error.response?.status === 401) {
+        if (error.response?.status === 404 && error.response.data?.code === 'platform_unknown') {
+            console.error(chalk.red(`Unknown platform "${platform}". Run \`solidactions oauth-actions platforms\` to see available platforms.`));
+        } else if (error.response?.status === 401) {
             console.error(chalk.red('Authentication failed. Run "solidactions login <api-key>".'));
         } else if (error.response) {
             console.error(chalk.red(`Failed: ${error.response.status}`), error.response.data);

--- a/src/commands/oauth-actions-list.ts
+++ b/src/commands/oauth-actions-list.ts
@@ -36,7 +36,7 @@ export async function oauthActionsList(platform: string, options: OAuthActionsLi
         }
 
         if (actions.length === 0) {
-            console.log(`No actions found for "${platform}" — check the platform name and that a connection exists (\`solidactions env pull --update-oauth\` syncs connections).`);
+            console.log(`No actions found for platform "${platform}".`);
             return;
         }
 

--- a/src/commands/oauth-actions-platforms.ts
+++ b/src/commands/oauth-actions-platforms.ts
@@ -1,0 +1,42 @@
+import axios from 'axios';
+import chalk from 'chalk';
+import { getApiHeaders, requireConfigWithWorkspace } from '../utils/api';
+
+interface OAuthActionsPlatformsOptions {
+    json?: boolean;
+}
+
+export async function oauthActionsPlatforms(options: OAuthActionsPlatformsOptions) {
+    const config = await requireConfigWithWorkspace();
+
+    try {
+        const response = await axios.get(`${config.host}/api/v1/oauth-actions/platforms`, {
+            headers: getApiHeaders(config),
+        });
+
+        const platforms: string[] = response.data.platforms || [];
+
+        if (options.json) {
+            process.stdout.write(JSON.stringify(platforms, null, 2) + '\n');
+            return;
+        }
+
+        if (platforms.length === 0) {
+            console.log('No platforms available.');
+            return;
+        }
+
+        for (const platform of platforms) {
+            console.log(platform);
+        }
+    } catch (error: any) {
+        if (error.response?.status === 401) {
+            console.error(chalk.red('Authentication failed. Run "solidactions login <api-key>".'));
+        } else if (error.response) {
+            console.error(chalk.red(`Failed: ${error.response.status}`), error.response.data);
+        } else {
+            console.error(chalk.red('Connection failed:'), error.message);
+        }
+        process.exit(1);
+    }
+}

--- a/src/commands/oauth-actions-search.ts
+++ b/src/commands/oauth-actions-search.ts
@@ -39,7 +39,7 @@ export async function oauthActionsSearch(platform: string, query: string | undef
         }
 
         if (actions.length === 0) {
-            console.log(`No actions found for "${platform}" — check the platform name and that a connection exists (\`solidactions env pull --update-oauth\` syncs connections).`);
+            console.log(`No actions found for platform "${platform}".`);
             return;
         }
 

--- a/src/commands/oauth-actions-search.ts
+++ b/src/commands/oauth-actions-search.ts
@@ -58,7 +58,9 @@ export async function oauthActionsSearch(platform: string, query: string | undef
         console.log(chalk.gray(`${actions.length} action(s) found.`));
         console.log(chalk.gray(`Run 'solidactions oauth-actions show ${platform} <action_id>' for full schema + paste-ready snippet.`));
     } catch (error: any) {
-        if (error.response?.status === 401) {
+        if (error.response?.status === 404 && error.response.data?.code === 'platform_unknown') {
+            console.error(chalk.red(`Unknown platform "${platform}". Run \`solidactions oauth-actions platforms\` to see available platforms.`));
+        } else if (error.response?.status === 401) {
             console.error(chalk.red('Authentication failed. Run "solidactions login <api-key>" to re-configure.'));
         } else if (error.response) {
             console.error(chalk.red(`Failed: ${error.response.status}`), error.response.data);

--- a/src/index.ts
+++ b/src/index.ts
@@ -226,7 +226,7 @@ runCmd
     .argument('<workflow>', 'Workflow name')
     .option('-e, --env <environment>', 'Environment (production/staging/dev)', 'dev')
     .option('-i, --input <json>', 'JSON input for the workflow')
-    .option('-w, --wait', 'Wait for the workflow to complete')
+    .option('--wait', 'Wait for the workflow to complete')
     .action((projectName, workflow, options) => {
         run(projectName, workflow, options);
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import { aiExamples } from './commands/ai-examples';
 import { oauthActionsSearch } from './commands/oauth-actions-search';
 import { oauthActionsList } from './commands/oauth-actions-list';
 import { oauthActionsShow } from './commands/oauth-actions-show';
+import { oauthActionsPlatforms } from './commands/oauth-actions-platforms';
 import { workspacesList, workspaceSet } from './commands/workspaces';
 import { skillPush } from './commands/skill-push';
 import { skillPull } from './commands/skill-pull';
@@ -466,6 +467,14 @@ oauthActionsCmd
     .option('--legacy-env', 'Emit the deprecated process.env-based snippet (will be removed in a future release)')
     .action((platform, actionId, options) => {
         oauthActionsShow(platform, actionId, options);
+    });
+
+oauthActionsCmd
+    .command('platforms')
+    .description('List available OAuth-backed platforms')
+    .option('--json', 'Emit raw JSON for AI/script consumption')
+    .action((options) => {
+        oauthActionsPlatforms(options);
     });
 
 // =============================================================================

--- a/tests/flag-consistency.test.ts
+++ b/tests/flag-consistency.test.ts
@@ -34,11 +34,13 @@ interface CapturedRequest {
     method: string | undefined;
     url: string | undefined;
     body: string;
+    headers: http.IncomingHttpHeaders;
 }
 
 let stubServer: http.Server;
 let stubPort: number;
 let lastCapture: CapturedRequest | null = null;
+let allCaptures: CapturedRequest[] = [];
 
 beforeAll(async () => {
     if (!fs.existsSync(CLI_BINARY)) {
@@ -49,7 +51,8 @@ beforeAll(async () => {
         let body = '';
         req.on('data', (chunk) => { body += chunk; });
         req.on('end', () => {
-            lastCapture = { method: req.method, url: req.url, body };
+            lastCapture = { method: req.method, url: req.url, body, headers: req.headers };
+            allCaptures.push(lastCapture);
             res.writeHead(200, { 'Content-Type': 'application/json' });
             if (req.url?.startsWith('/api/v1/projects/resolve/build-log') || req.url?.match(/\/build-log/)) {
                 res.end(JSON.stringify({ build_log: 'log output' }));
@@ -89,6 +92,7 @@ let tmpHomes: string[] = [];
 afterEach(() => {
     for (const home of tmpHomes) fs.rmSync(path.dirname(home), { recursive: true, force: true });
     tmpHomes = [];
+    allCaptures = [];
 });
 
 /** Fresh $HOME with a valid global config pointed at the stub server. */
@@ -179,6 +183,11 @@ describe('flag consistency (F-C4)', () => {
         expect(result.status).toBe(0);
     });
 
+    // This is the MUTATION GUARDIAN for FIX 2: restore `-w, --wait` on the
+    // run-start command and THIS test fails (verified by mutation). The two
+    // behavioral tests below cannot catch that mutation on their own — see the
+    // note on the `-w <value>` test for why the value-bearing path is identical
+    // under both spellings.
     it('run start: --help lists no -w short flag for --wait (freed up for the global -w/--workspace-override)', async () => {
         const result = await runCliHelp(['run', 'start', '--help']);
         expect(result.stdout).not.toMatch(/-w,\s*--wait/);
@@ -194,13 +203,33 @@ describe('flag consistency (F-C4)', () => {
         expect(result.status).toBe(0);
     });
 
-    it('run start: -w <value> is now the global workspace-override, not swallowed as an invalid --wait argument', async () => {
+    it('run start: -w <value> routes to the global workspace-override (resolves the workspace, does NOT engage --wait)', async () => {
+        // Locks in the end-to-end behavior of the value-bearing form: `-w
+        // login-target` resolves to ws-login-1 (via GET /api/v1/workspaces) and
+        // stamps it on the trigger request, and does NOT wait.
+        //
+        // NOTE: this is NOT the mutation guardian for FIX 2 — mutation-testing
+        // showed the value-bearing `-w <value>` path behaves IDENTICALLY under
+        // both `--wait` (fixed) and `-w, --wait` (old): commander's global
+        // `-w, --workspace-override <value>` always shadows the subcommand's
+        // boolean `-w`, so `-w login-target` routes to the override and never
+        // engages wait in either build. The `--help` test above is what pins
+        // the short-flag removal. This test guards the global-override
+        // integration path against unrelated regressions.
         const home = tmpHomeWithConfig();
         const result = await runCli(['run', 'start', 'my-project', 'my-workflow', '-w', 'login-target'], home);
 
         expect(result.stderr).not.toMatch(/unknown option/);
         expect(result.stderr).not.toMatch(/argument missing/);
         expect(result.status).toBe(0);
+
+        // --wait must NOT have engaged.
+        expect(result.stdout).not.toMatch(/Waiting for completion/);
+
+        // The trigger request must carry the RESOLVED override workspace, not the default.
+        const trigger = allCaptures.find((c) => c.method === 'POST' && /\/workflows\/.+\/trigger$/.test(c.url ?? ''));
+        expect(trigger).toBeDefined();
+        expect(trigger?.headers['x-workspace-id']).toBe('ws-login-1');
     });
 
     it('schedule set: --help lists no -w short flag (freed up for the global -w/--workspace override)', async () => {

--- a/tests/flag-consistency.test.ts
+++ b/tests/flag-consistency.test.ts
@@ -53,6 +53,9 @@ beforeAll(async () => {
             res.writeHead(200, { 'Content-Type': 'application/json' });
             if (req.url?.startsWith('/api/v1/projects/resolve/build-log') || req.url?.match(/\/build-log/)) {
                 res.end(JSON.stringify({ build_log: 'log output' }));
+            } else if (req.url?.match(/^\/api\/v1\/runs\/[^/]+$/)) {
+                // Single-run status lookup (used by `run start --wait` polling).
+                res.end(JSON.stringify({ status: 'completed' }));
             } else if (req.url?.startsWith('/api/v1/runs')) {
                 res.end(JSON.stringify({ data: [] }));
             } else if (req.url?.includes('/schedules')) {
@@ -173,6 +176,30 @@ describe('flag consistency (F-C4)', () => {
 
         expect(result.stderr).not.toMatch(/unknown option/);
         expect(lastCapture?.url).toContain('environment=dev');
+        expect(result.status).toBe(0);
+    });
+
+    it('run start: --help lists no -w short flag for --wait (freed up for the global -w/--workspace-override)', async () => {
+        const result = await runCliHelp(['run', 'start', '--help']);
+        expect(result.stdout).not.toMatch(/-w,\s*--wait/);
+        expect(result.stdout).toMatch(/--wait/);
+    });
+
+    it('run start: --wait (long form) waits for completion and reports success', async () => {
+        const home = tmpHomeWithConfig();
+        const result = await runCli(['run', 'start', 'my-project', 'my-workflow', '--wait'], home);
+
+        expect(result.stderr).not.toMatch(/unknown option/);
+        expect(result.stdout).toContain('Workflow completed successfully!');
+        expect(result.status).toBe(0);
+    });
+
+    it('run start: -w <value> is now the global workspace-override, not swallowed as an invalid --wait argument', async () => {
+        const home = tmpHomeWithConfig();
+        const result = await runCli(['run', 'start', 'my-project', 'my-workflow', '-w', 'login-target'], home);
+
+        expect(result.stderr).not.toMatch(/unknown option/);
+        expect(result.stderr).not.toMatch(/argument missing/);
         expect(result.status).toBe(0);
     });
 

--- a/tests/oauth-actions-platform-errors.test.ts
+++ b/tests/oauth-actions-platform-errors.test.ts
@@ -138,13 +138,30 @@ describe('oauth-actions: unknown platform vs. 0 matches', () => {
         expect(errLines.join('\n')).toContain('oauth-actions platforms');
     });
 
-    it('list/search: a genuine 404 that is NOT platform_unknown still falls through to the generic "Failed: 404" path', async () => {
+    it('list: a genuine 404 that is NOT platform_unknown still falls through to the generic "Failed: 404" path', async () => {
         nextStatus = 404;
         nextBody = { message: 'Not found.' };
 
         let caught: ProcessExitError | null = null;
         try {
             await oauthActionsList('gmail', {});
+        } catch (e) {
+            if (e instanceof ProcessExitError) caught = e;
+            else throw e;
+        }
+
+        expect(caught?.code).toBe(1);
+        expect(errLines.join('\n')).not.toContain('Unknown platform');
+        expect(errLines.join('\n')).toContain('Failed: 404');
+    });
+
+    it('search: a genuine 404 that is NOT platform_unknown still falls through to the generic "Failed: 404" path', async () => {
+        nextStatus = 404;
+        nextBody = { message: 'Not found.' };
+
+        let caught: ProcessExitError | null = null;
+        try {
+            await oauthActionsSearch('gmail', 'send', {});
         } catch (e) {
             if (e instanceof ProcessExitError) caught = e;
             else throw e;

--- a/tests/oauth-actions-platform-errors.test.ts
+++ b/tests/oauth-actions-platform-errors.test.ts
@@ -1,0 +1,178 @@
+/**
+ * oauth-actions: distinguish an unknown platform (404, forward-compatible
+ * with the app-side `platform_unknown` error code) from a known platform
+ * with zero matching actions (200, empty array) — both `list` and `search`
+ * previously printed the same "No actions found." for both cases. Also
+ * covers the new `oauth-actions platforms` subcommand.
+ *
+ * Test-double policy: real in-process HTTP server (Node's http.createServer),
+ * ProcessExitError-throw pattern for process.exit, real console.log/error
+ * capture. No mock/spy/stub libraries. Matches the pattern in
+ * output-polish.test.ts and run-start-env-mismatch.test.ts.
+ */
+import * as http from 'http';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { oauthActionsList } from '../src/commands/oauth-actions-list';
+import { oauthActionsSearch } from '../src/commands/oauth-actions-search';
+import { oauthActionsPlatforms } from '../src/commands/oauth-actions-platforms';
+import { makeTmpEnv, writeGlobal } from './helpers';
+
+class ProcessExitError extends Error {
+    constructor(public readonly code: number | undefined) {
+        super(`process.exit(${code})`);
+    }
+}
+
+let stubServer: http.Server;
+let stubPort: number;
+let nextStatus = 200;
+let nextBody: unknown = { oauth_actions: [] };
+
+beforeAll(async () => {
+    stubServer = http.createServer((_req, res) => {
+        res.writeHead(nextStatus, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(nextBody));
+    });
+    await new Promise<void>((resolve) => {
+        stubServer.listen(0, '127.0.0.1', () => {
+            stubPort = (stubServer.address() as { port: number }).port;
+            resolve();
+        });
+    });
+});
+
+afterAll(() => {
+    return new Promise<void>((resolve, reject) => {
+        stubServer.close((err) => (err ? reject(err) : resolve()));
+    });
+});
+
+describe('oauth-actions: unknown platform vs. 0 matches', () => {
+    let env: ReturnType<typeof makeTmpEnv>;
+    let originalExit: typeof process.exit;
+    let logLines: string[];
+    let errLines: string[];
+    let stdoutChunks: string[];
+    let originalLog: typeof console.log;
+    let originalErr: typeof console.error;
+    let originalStdoutWrite: typeof process.stdout.write;
+
+    beforeEach(() => {
+        env = makeTmpEnv();
+        writeGlobal(env.home, { host: `http://127.0.0.1:${stubPort}`, apiKey: 'k', workspaceId: 'ws-1' });
+        nextStatus = 200;
+        nextBody = { oauth_actions: [] };
+        originalExit = process.exit;
+        (process as any).exit = (code?: number) => { throw new ProcessExitError(code); };
+        logLines = [];
+        originalLog = console.log;
+        console.log = (...args: unknown[]) => { logLines.push(args.map(String).join(' ')); };
+        errLines = [];
+        originalErr = console.error;
+        console.error = (...args: unknown[]) => { errLines.push(args.map(String).join(' ')); };
+        stdoutChunks = [];
+        originalStdoutWrite = process.stdout.write.bind(process.stdout);
+        (process.stdout as any).write = (chunk: any) => { stdoutChunks.push(String(chunk)); return true; };
+    });
+
+    afterEach(() => {
+        process.exit = originalExit;
+        console.log = originalLog;
+        console.error = originalErr;
+        process.stdout.write = originalStdoutWrite;
+        env.cleanup();
+    });
+
+    it('list: known platform with 0 matches prints "No actions found." and exits 0', async () => {
+        nextStatus = 200;
+        nextBody = { oauth_actions: [] };
+
+        await oauthActionsList('gmail', {});
+
+        expect(logLines.some((l) => l.includes('No actions found'))).toBe(true);
+        expect(errLines.join('\n')).not.toContain('Unknown platform');
+    });
+
+    it('list: unknown platform (404, platform_unknown) prints "Unknown platform" and exits non-zero', async () => {
+        nextStatus = 404;
+        nextBody = { error: 'Unknown platform', code: 'platform_unknown', platform: 'not-a-platform' };
+
+        let caught: ProcessExitError | null = null;
+        try {
+            await oauthActionsList('not-a-platform', {});
+        } catch (e) {
+            if (e instanceof ProcessExitError) caught = e;
+            else throw e;
+        }
+
+        expect(caught?.code).toBe(1);
+        expect(errLines.join('\n')).toContain('Unknown platform "not-a-platform"');
+        expect(errLines.join('\n')).toContain('oauth-actions platforms');
+        expect(logLines.some((l) => l.includes('No actions found'))).toBe(false);
+    });
+
+    it('search: known platform with 0 matches prints "No actions found." and exits 0', async () => {
+        nextStatus = 200;
+        nextBody = { oauth_actions: [] };
+
+        await oauthActionsSearch('gmail', 'send', {});
+
+        expect(logLines.some((l) => l.includes('No actions found'))).toBe(true);
+        expect(errLines.join('\n')).not.toContain('Unknown platform');
+    });
+
+    it('search: unknown platform (404, platform_unknown) prints "Unknown platform" and exits non-zero', async () => {
+        nextStatus = 404;
+        nextBody = { error: 'Unknown platform', code: 'platform_unknown', platform: 'not-a-platform' };
+
+        let caught: ProcessExitError | null = null;
+        try {
+            await oauthActionsSearch('not-a-platform', 'send', {});
+        } catch (e) {
+            if (e instanceof ProcessExitError) caught = e;
+            else throw e;
+        }
+
+        expect(caught?.code).toBe(1);
+        expect(errLines.join('\n')).toContain('Unknown platform "not-a-platform"');
+        expect(errLines.join('\n')).toContain('oauth-actions platforms');
+    });
+
+    it('list/search: a genuine 404 that is NOT platform_unknown still falls through to the generic "Failed: 404" path', async () => {
+        nextStatus = 404;
+        nextBody = { message: 'Not found.' };
+
+        let caught: ProcessExitError | null = null;
+        try {
+            await oauthActionsList('gmail', {});
+        } catch (e) {
+            if (e instanceof ProcessExitError) caught = e;
+            else throw e;
+        }
+
+        expect(caught?.code).toBe(1);
+        expect(errLines.join('\n')).not.toContain('Unknown platform');
+        expect(errLines.join('\n')).toContain('Failed: 404');
+    });
+
+    it('platforms: lists available platform slugs from GET /api/v1/oauth-actions/platforms', async () => {
+        nextStatus = 200;
+        nextBody = { platforms: ['gmail', 'slack', 'hubspot'] };
+
+        await oauthActionsPlatforms({});
+
+        expect(logLines).toContain('gmail');
+        expect(logLines).toContain('slack');
+        expect(logLines).toContain('hubspot');
+    });
+
+    it('platforms --json: emits the raw platform array as JSON', async () => {
+        nextStatus = 200;
+        nextBody = { platforms: ['gmail', 'slack'] };
+
+        await oauthActionsPlatforms({ json: true });
+
+        const parsed = JSON.parse(stdoutChunks.join(''));
+        expect(parsed).toEqual(['gmail', 'slack']);
+    });
+});


### PR DESCRIPTION
Follow-up polish from the post-release review of the stress-test sweep (found by a cleanroom agent + a Fable-model review).

## Changes
- **README flags corrected** — `run start` table now lists `--wait` (was a broken `-w`); `schedule set` lists `--workflow` (was `-w`). Both `-w` shorts collided with the global `-w/--workspace-override` and never worked.
- **`run start` stops advertising a broken `-w`** — the subcommand's `-w, --wait` short was dead (the global `-w` always shadowed it, so `run start … -w` errored "argument missing"). Removed the short; `--wait` long form is the supported flag. Guarded by the `--help` test (mutation-verified).
- **oauth-actions: distinguish unknown platform from 0 matches** — client now branches on the server's `404 {code: 'platform_unknown'}` (paired with the app-side change) to print an actionable "unknown platform" error + non-zero exit; a genuine known-platform-0-matches stays exit-0. Reworded the 200-empty hint (no longer implies a bad platform name). Added a new **`solidactions oauth-actions platforms`** subcommand wired to the pre-existing `GET /api/v1/oauth-actions/platforms` route.

## Notes
- Forward-compatible: the `platforms` route already exists, so new-CLI + old-server degrades gracefully.
- Reaching users needs a CLI npm release (separate step).
- Reviewed by a Fable-model agent; findings (a false-green test, a stale hint) addressed.

## Testing
361/361 pass excluding the pre-existing `dev.test.ts` cases (unlinked `@solidactions/sdk` peer in a fresh worktree — unrelated). `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
