### PR TITLE
feat(deploy): free-plan fallback prompt + env hints

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solidactions/cli",
-  "version": "1.25.0",
+  "version": "1.26.0",
   "description": "SolidActions CLI - Deploy and manage workflow automation",
   "main": "dist/index.js",
   "bin": {

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -6,6 +6,7 @@ import axios from 'axios';
 import FormData from 'form-data';
 import chalk from 'chalk';
 import yaml from 'js-yaml';
+import prompts from 'prompts';
 import { SolidActionsConfig, parseYamlEnvVars } from '../utils/env';
 import { getApiHeaders, requireConfigWithWorkspace } from '../utils/api';
 import { planDeployFiles } from '../utils/deploy-ignore';
@@ -172,6 +173,102 @@ export function shouldPrintWorkspaceMismatch(environment: string, willCreate: bo
     return environment !== 'production' && !willCreate;
 }
 
+/**
+ * Printed (after the server's own message) when a free-plan tenant hits the
+ * dev/staging environment gate in a non-interactive context, or declines the
+ * interactive fallback prompt.
+ */
+export const PLAN_LIMIT_NON_INTERACTIVE_HINT = 'Hint: pass -e production, or upgrade your plan for dev/staging environments.';
+
+/**
+ * True when `error` is the app's 422 response for a free-plan tenant hitting
+ * the multi-environment gate on project auto-create:
+ * `{ error: { code: 'plan_limit_reached', limit: 'multi_env', plan, max } }`.
+ */
+export function isPlanLimitReachedError(error: any): boolean {
+    const data = error?.response?.data;
+    return error?.response?.status === 422
+        && data?.error?.code === 'plan_limit_reached'
+        && data?.error?.limit === 'multi_env';
+}
+
+/**
+ * POST /api/v1/projects to create a new environment-project record. Returns
+ * the resolved slug (server-echoed slug, falling back to the requested one).
+ * Throws the raw axios error on failure — callers decide how to handle it.
+ */
+async function createEnvironmentProject(
+    config: { host: string; apiKey: string; workspaceId?: string },
+    projectName: string,
+    environment: string
+): Promise<string> {
+    const requestedSlug = buildProjectSlug(projectName, environment);
+    const createResponse = await axios.post(`${config.host}/api/v1/projects`, {
+        name: projectName,
+        slug: requestedSlug,
+        environment: environment,
+    }, {
+        headers: getApiHeaders(config, 'application/json'),
+    });
+    const slug = createResponse.data.slug || requestedSlug;
+    if (process.env.SOLIDACTIONS_DEPLOY_DEBUG === '1') {
+        process.stderr.write(`[deploy-debug] requestedSlug=${requestedSlug} responseSlug=${createResponse.data.slug ?? '(missing)'} responseName=${createResponse.data.name ?? '(missing)'} resolvedSlug=${slug}\n`);
+    }
+    return slug;
+}
+
+/**
+ * Handles a 422 plan_limit_reached/multi_env error from the env-project
+ * auto-create call (billing v0.5: free-plan tenants only get production).
+ *
+ * Interactive TTYs are offered a y/N fallback to production; declining exits
+ * 1 with an upgrade hint. Non-interactive callers (CI, agents) never see a
+ * prompt — they get the same hint and exit 1 immediately, so the command
+ * never hangs waiting for input that will never arrive.
+ *
+ * On confirmed fallback, resolves (and creates if necessary) the production
+ * project and returns its slug. Every other path calls process.exit(1) and
+ * never returns.
+ */
+export async function handlePlanLimitReached(
+    config: { host: string; apiKey: string; workspaceId?: string },
+    projectName: string,
+    error: any,
+    productionExists: boolean | null,
+    productionSlug: string | null
+): Promise<string> {
+    const serverMessage: string = error.response?.data?.message || 'Your plan does not support additional environments.';
+    console.error(chalk.red(serverMessage));
+
+    if (!process.stdin.isTTY) {
+        console.error(chalk.yellow(PLAN_LIMIT_NON_INTERACTIVE_HINT));
+        process.exit(1);
+    }
+
+    const response = await prompts({
+        type: 'confirm',
+        name: 'proceed',
+        message: 'Your plan has a single production environment — deploy to production instead?',
+        initial: false,
+    });
+
+    if (!response.proceed) {
+        console.error(chalk.yellow(PLAN_LIMIT_NON_INTERACTIVE_HINT));
+        process.exit(1);
+    }
+
+    if (productionExists === true && productionSlug !== null) {
+        return productionSlug;
+    }
+
+    try {
+        return await createEnvironmentProject(config, projectName, 'production');
+    } catch (prodError: any) {
+        console.error(chalk.red('Failed to create project:'), prodError.response?.data?.message || prodError.message);
+        process.exit(1);
+    }
+}
+
 export async function deploy(projectName: string, sourcePath?: string, options: DeployOptions = {}) {
     const config = await requireConfigWithWorkspace();
 
@@ -247,9 +344,11 @@ export async function deploy(projectName: string, sourcePath?: string, options: 
 
     // Apply default: if production already exists and the user didn't pass -e,
     // use 'dev' — this preserves existing behavior for mature projects.
-    const environment = explicitEnv ?? 'dev';
+    // `let`, not `const`: a free-plan 422 (plan_limit_reached/multi_env) on the
+    // env-project auto-create below can fall the deploy back to production.
+    let environment = explicitEnv ?? 'dev';
 
-    const envLabel = environment !== 'production' ? ` (${environment})` : '';
+    let envLabel = environment !== 'production' ? ` (${environment})` : '';
     console.log(chalk.blue(`Deploying to project "${projectName}"${envLabel}...`));
     console.log(chalk.gray(`Source: ${sourceDir}`));
 
@@ -320,27 +419,21 @@ export async function deploy(projectName: string, sourcePath?: string, options: 
             }
 
             console.log(chalk.yellow(`Project "${projectName}"${envLabel} not found. Creating...`));
-            const requestedSlug = buildProjectSlug(projectName, environment);
             try {
-                const createResponse = await axios.post(`${config.host}/api/v1/projects`, {
-                    name: projectName,
-                    slug: requestedSlug,
-                    environment: environment,
-                }, {
-                    headers: getApiHeaders(config, 'application/json'),
-                });
-                // Fallback chain: prefer the server-echoed slug; if absent, use the slug we
-                // *requested* in the POST body (server stored that value). Falling back to
-                // `name` strips the env suffix and causes the polling GET to 404 with
-                // "Project 'X' not found in your active workspace 'Y'.".
-                projectSlug = createResponse.data.slug || requestedSlug;
-                if (process.env.SOLIDACTIONS_DEPLOY_DEBUG === '1') {
-                    process.stderr.write(`[deploy-debug] requestedSlug=${requestedSlug} responseSlug=${createResponse.data.slug ?? '(missing)'} responseName=${createResponse.data.name ?? '(missing)'} resolvedSlug=${projectSlug}\n`);
-                }
+                projectSlug = await createEnvironmentProject(config, projectName, environment);
                 console.log(chalk.green(`Project "${projectName}"${envLabel} created.`));
             } catch (createError: any) {
-                console.error(chalk.red('Failed to create project:'), createError.response?.data?.message || createError.message);
-                process.exit(1);
+                if (isPlanLimitReachedError(createError)) {
+                    // Free-plan tenant hit the multi_env gate. handlePlanLimitReached()
+                    // exits(1) on every path except a confirmed fallback to production.
+                    projectSlug = await handlePlanLimitReached(config, projectName, createError, productionExists, productionSlug);
+                    environment = 'production';
+                    envLabel = '';
+                    console.log(chalk.blue(`Deploying to project "${projectName}" (production) instead.`));
+                } else {
+                    console.error(chalk.red('Failed to create project:'), createError.response?.data?.message || createError.message);
+                    process.exit(1);
+                }
             }
         } else {
             console.error(chalk.red('Failed to check project:'), error.response?.data?.message || error.message);

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -342,7 +342,11 @@ export async function runDev(opts: RunDevOptions): Promise<RunDevResult> {
         try {
             platformVars = await apiClient.fetchVarsAndConnections(opts.env);
         } catch (e: any) {
-            err(`failed to fetch platform vars: ${e?.message ?? e}`);
+            let msg = `failed to fetch platform vars: ${e?.message ?? e}`;
+            if (e?.response?.status === 404 && opts.env !== 'production') {
+                msg += `\nThe '${opts.env}' environment project doesn't exist — staging/dev environments require a paid plan. On the free plan, use --env production.`;
+            }
+            err(msg);
         }
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,7 +145,7 @@ program
     .description('Run a workflow locally using an in-memory mock server (no deploy needed)')
     .argument('<file>', 'Workflow file to run (e.g., src/simple-steps.ts)')
     .option('-i, --input <json>', 'JSON input for the workflow', '{}')
-    .option('-e, --env <env>', 'Pull platform variables for this environment (e.g. dev, staging, production)')
+    .option('-e, --env <env>', 'Pull platform variables for this environment (e.g. production, staging, dev)')
     .action((file, options) => {
         // Unified in-process invoke path. With --env: fetch declared vars, build
         // ctx.vars, invoke locally. Without --env: NO platform fetch, ctx.vars is

--- a/tests/deploy-plan-limit.test.ts
+++ b/tests/deploy-plan-limit.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Free-plan environment fallback (billing v0.5): the app gates staging/dev
+ * environment projects behind Pro+. `project deploy`'s env-project
+ * auto-create call can now receive a 422
+ * `{ message, errors, error: { code: 'plan_limit_reached', limit: 'multi_env', plan, max } }`
+ * from a free-plan tenant. `deploy` defaults to env 'dev', so this needs a
+ * graceful fallback instead of a dead-end.
+ *
+ * `isPlanLimitReachedError` and `handlePlanLimitReached` are the two
+ * exported, independently-testable units behind that fallback (deploy()
+ * itself is not unit-tested anywhere in this suite — its archive/upload/poll
+ * pipeline is event-driven and fire-and-forget past `archive.finalize()`,
+ * so existing deploy tests only exercise its extracted pure helpers, e.g.
+ * shouldPrintWorkspaceMismatch in deploy-workspace-warning.test.ts. This
+ * file follows that same convention).
+ *
+ * Test-double policy: real in-process HTTP server (Node's http.createServer)
+ * for the one network call handlePlanLimitReached can make (production
+ * project creation) — no mock/spy/stub libraries. `prompts.inject()` is the
+ * `prompts` package's own built-in test-injection API (not a mock of our
+ * code), matching how the package is meant to be tested.
+ */
+import * as http from 'http';
+import prompts from 'prompts';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import {
+    isPlanLimitReachedError,
+    handlePlanLimitReached,
+    PLAN_LIMIT_NON_INTERACTIVE_HINT,
+} from '../src/commands/deploy';
+
+class ProcessExitError extends Error {
+    constructor(public readonly code: number | undefined) {
+        super(`process.exit(${code})`);
+    }
+}
+
+function makePlanLimitError(): any {
+    const err: any = new Error('Request failed with status code 422');
+    err.response = {
+        status: 422,
+        data: {
+            message: 'Your plan only supports a production environment. Upgrade to add staging or dev environments.',
+            errors: { environment: ['plan_limit_reached'] },
+            error: { code: 'plan_limit_reached', limit: 'multi_env', plan: 'free', max: 1 },
+        },
+    };
+    return err;
+}
+
+// ---------------------------------------------------------------------------
+// isPlanLimitReachedError — pure predicate
+// ---------------------------------------------------------------------------
+
+describe('isPlanLimitReachedError', () => {
+    it('is true for the exact plan_limit_reached/multi_env 422 shape', () => {
+        expect(isPlanLimitReachedError(makePlanLimitError())).toBe(true);
+    });
+
+    it('is false for a generic 422 (e.g. duplicate project name) — non-plan errors are unaffected', () => {
+        const err: any = new Error('Request failed with status code 422');
+        err.response = { status: 422, data: { message: "A project named 'foo' already exists in workspace 'acme'." } };
+        expect(isPlanLimitReachedError(err)).toBe(false);
+    });
+
+    it('is false for a 422 with an unrelated error.code', () => {
+        const err: any = new Error('422');
+        err.response = { status: 422, data: { message: 'nope', error: { code: 'validation_failed', limit: 'multi_env' } } };
+        expect(isPlanLimitReachedError(err)).toBe(false);
+    });
+
+    it("is false for a 422 plan_limit_reached with a different limit (not 'multi_env')", () => {
+        const err: any = new Error('422');
+        err.response = { status: 422, data: { message: 'nope', error: { code: 'plan_limit_reached', limit: 'workflows' } } };
+        expect(isPlanLimitReachedError(err)).toBe(false);
+    });
+
+    it('is false for a 404', () => {
+        const err: any = new Error('404');
+        err.response = { status: 404, data: { message: 'not found' } };
+        expect(isPlanLimitReachedError(err)).toBe(false);
+    });
+
+    it('is false when there is no response body at all (network error)', () => {
+        const err: any = new Error('Network error');
+        expect(isPlanLimitReachedError(err)).toBe(false);
+    });
+});
+
+describe('PLAN_LIMIT_NON_INTERACTIVE_HINT', () => {
+    it('points at -e production and mentions upgrading', () => {
+        expect(PLAN_LIMIT_NON_INTERACTIVE_HINT).toContain('-e production');
+        expect(PLAN_LIMIT_NON_INTERACTIVE_HINT).toContain('upgrade');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// handlePlanLimitReached — the interactive/non-interactive fallback
+// ---------------------------------------------------------------------------
+
+let server: http.Server;
+let port: number;
+let createRequests: Array<{ body: any }> = [];
+
+beforeAll(async () => {
+    server = http.createServer((req, res) => {
+        let raw = '';
+        req.on('data', (c) => { raw += c; });
+        req.on('end', () => {
+            let body: any = null;
+            try { body = raw ? JSON.parse(raw) : null; } catch { /* ignore */ }
+            if (req.method === 'POST' && req.url === '/api/v1/projects') {
+                createRequests.push({ body });
+                res.writeHead(200, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ slug: body?.slug ?? 'unknown', name: body?.name }));
+                return;
+            }
+            res.writeHead(404, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ message: `unhandled ${req.method} ${req.url}` }));
+        });
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => {
+        port = (server.address() as any).port;
+        resolve();
+    }));
+});
+
+afterAll(() => new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve()))));
+
+beforeEach(() => { createRequests = []; });
+
+describe('handlePlanLimitReached', () => {
+    let originalIsTTY: boolean | undefined;
+    let originalExit: typeof process.exit;
+    let originalError: typeof console.error;
+    let errorLines: string[];
+
+    beforeEach(() => {
+        originalIsTTY = process.stdin.isTTY;
+        originalExit = process.exit;
+        (process as any).exit = (code?: number) => { throw new ProcessExitError(code); };
+        errorLines = [];
+        originalError = console.error;
+        console.error = (...args: unknown[]) => { errorLines.push(args.map(String).join(' ')); };
+    });
+
+    afterEach(() => {
+        Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true });
+        (process as any).exit = originalExit;
+        console.error = originalError;
+    });
+
+    // Computed lazily (not at describe-collection time) because `port` isn't
+    // assigned until the async beforeAll above has run.
+    const config = () => ({ host: `http://127.0.0.1:${port}`, apiKey: 'test-key', workspaceId: 'ws-1' });
+
+    it('non-interactive (no TTY): exits 1 with the server message + hint, WITHOUT prompting (no injected answer needed)', async () => {
+        Object.defineProperty(process.stdin, 'isTTY', { value: undefined, configurable: true });
+
+        let caught: ProcessExitError | null = null;
+        try {
+            await handlePlanLimitReached(config(), 'my-project', makePlanLimitError(), true, 'my-project');
+        } catch (e) {
+            if (e instanceof ProcessExitError) caught = e;
+            else throw e;
+        }
+
+        expect(caught?.code).toBe(1);
+        const out = errorLines.join('\n');
+        expect(out).toContain('Your plan only supports a production environment');
+        expect(out).toContain(PLAN_LIMIT_NON_INTERACTIVE_HINT);
+        // No network call was made — non-interactive path never attempts production creation.
+        expect(createRequests).toHaveLength(0);
+    }, 5_000);
+
+    it('interactive, answers yes, production already exists: returns the cached production slug (no network call)', async () => {
+        Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
+        prompts.inject([true]);
+
+        const slug = await handlePlanLimitReached(config(), 'my-project', makePlanLimitError(), true, 'my-project-prod-slug');
+
+        expect(slug).toBe('my-project-prod-slug');
+        expect(createRequests).toHaveLength(0);
+    });
+
+    it('interactive, answers yes, production does not exist yet: creates it and returns the server-echoed slug', async () => {
+        Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
+        prompts.inject([true]);
+
+        const slug = await handlePlanLimitReached(config(), 'my-project', makePlanLimitError(), false, null);
+
+        expect(slug).toBe('my-project');
+        expect(createRequests).toHaveLength(1);
+        expect(createRequests[0].body).toMatchObject({ name: 'my-project', environment: 'production' });
+    });
+
+    it('interactive, answers no: exits 1 with the hint, no project is created', async () => {
+        Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
+        prompts.inject([false]);
+
+        let caught: ProcessExitError | null = null;
+        try {
+            await handlePlanLimitReached(config(), 'my-project', makePlanLimitError(), true, 'my-project');
+        } catch (e) {
+            if (e instanceof ProcessExitError) caught = e;
+            else throw e;
+        }
+
+        expect(caught?.code).toBe(1);
+        expect(errorLines.join('\n')).toContain(PLAN_LIMIT_NON_INTERACTIVE_HINT);
+        expect(createRequests).toHaveLength(0);
+    });
+});

--- a/tests/dev-env-404-hint.test.ts
+++ b/tests/dev-env-404-hint.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Free-plan environment fallback (billing v0.5): `dev --env <env>` 404s
+ * unhelpfully when the requested environment project can't exist because
+ * the tenant is on the free plan (staging/dev are Pro+ only).
+ *
+ * runDev() now appends a hint to the "failed to fetch platform vars" error
+ * when the failure is a 404 AND the requested env isn't 'production' —
+ * pointing the user at `--env production` instead of leaving a bare 404.
+ *
+ * Test-double policy: the SaApiClient injection seam (api option) is a real
+ * object implementing the interface — same pattern as the "dropped secret"
+ * test in dev.test.ts. No mock/spy/stub libraries.
+ */
+import * as path from 'path';
+import { describe, expect, it } from 'vitest';
+import { runDev, type SaApiClient, type PlatformVar } from '../src/commands/dev';
+
+const ECHO_FIXTURE = path.resolve(__dirname, '../fixtures/echo.ts');
+
+function fakeApi404(): SaApiClient {
+    return {
+        projectSlug: 'test-project-dev',
+        async fetchVarsAndConnections(_env: string): Promise<PlatformVar[]> {
+            const err: any = new Error('Request failed with status code 404');
+            err.response = { status: 404, data: { message: "Project 'test-project-dev' not found." } };
+            throw err;
+        },
+    };
+}
+
+function fakeApi500(): SaApiClient {
+    return {
+        projectSlug: 'test-project-dev',
+        async fetchVarsAndConnections(_env: string): Promise<PlatformVar[]> {
+            const err: any = new Error('Request failed with status code 500');
+            err.response = { status: 500, data: { message: 'Internal server error' } };
+            throw err;
+        },
+    };
+}
+
+describe('runDev — free-plan 404 hint on vars-fetch failure', () => {
+    it("appends the free-plan hint when env='dev' 404s", async () => {
+        const out = await runDev({ entry: ECHO_FIXTURE, input: '{"n":1}', env: 'dev', api: fakeApi404() });
+        expect(out.stderr).toContain("The 'dev' environment project doesn't exist");
+        expect(out.stderr).toContain('staging/dev environments require a paid plan');
+        expect(out.stderr).toContain('use --env production');
+    }, 20_000);
+
+    it("appends the free-plan hint when env='staging' 404s", async () => {
+        const out = await runDev({ entry: ECHO_FIXTURE, input: '{"n":1}', env: 'staging', api: fakeApi404() });
+        expect(out.stderr).toContain("The 'staging' environment project doesn't exist");
+    }, 20_000);
+
+    it("does NOT append the hint when env='production' 404s", async () => {
+        const out = await runDev({ entry: ECHO_FIXTURE, input: '{"n":1}', env: 'production', api: fakeApi404() });
+        expect(out.stderr).toMatch(/failed to fetch platform vars/);
+        expect(out.stderr).not.toContain('environment project doesn\'t exist');
+        expect(out.stderr).not.toContain('use --env production');
+    }, 20_000);
+
+    it('does NOT append the hint for a non-404 failure (e.g. 500)', async () => {
+        const out = await runDev({ entry: ECHO_FIXTURE, input: '{"n":1}', env: 'dev', api: fakeApi500() });
+        expect(out.stderr).toMatch(/failed to fetch platform vars/);
+        expect(out.stderr).not.toContain('environment project doesn\'t exist');
+    }, 20_000);
+
+    it('the run still completes despite the vars-fetch failure (hint is additive, not fatal)', async () => {
+        const out = await runDev({ entry: ECHO_FIXTURE, input: '{"n":3}', env: 'dev', api: fakeApi404() });
+        expect(out.result).toEqual({ status: 'completed', output: 6 });
+    }, 20_000);
+});

--- a/tests/dev-help-env-example.test.ts
+++ b/tests/dev-help-env-example.test.ts
@@ -1,0 +1,35 @@
+/**
+ * `dev --help`'s --env example listed dev before production
+ * ("e.g. dev, staging, production"), which read as an endorsement of the
+ * (Pro+-gated) dev environment as the default choice. Free-plan tenants only
+ * have production, so the example order is now production-first
+ * ("e.g. production, staging, dev") to match every other command's ordering.
+ *
+ * Test-double policy: spawns the real built CLI binary (dist/index.js) —
+ * matches the pattern in tests/flag-consistency.test.ts.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import * as childProcess from 'child_process';
+import { describe, expect, it } from 'vitest';
+
+const CLI_BINARY = path.resolve(__dirname, '../dist/index.js');
+
+describe('dev --help — --env example order', () => {
+    it('CLI is built', () => {
+        expect(fs.existsSync(CLI_BINARY)).toBe(true);
+    });
+
+    it('lists the example as "e.g. production, staging, dev"', () => {
+        const result = childProcess.spawnSync(process.execPath, [CLI_BINARY, 'dev', '--help'], {
+            encoding: 'utf8',
+            timeout: 15_000,
+        });
+
+        // Commander wraps long option descriptions onto a continuation line at
+        // the terminal width, so match across whitespace/newlines rather than
+        // requiring the literal substring on one line.
+        expect(result.stdout).toMatch(/e\.g\.\s+production,\s+staging,\s+dev/);
+        expect(result.stdout).not.toMatch(/e\.g\.\s+dev,\s+staging,\s+production/);
+    });
+});


### PR DESCRIPTION
Companion to solidactions-app#409 (billing v0.5 subscription tiers).

The app now gates staging/dev environment projects behind Pro+. \`project deploy\` defaults to env \`dev\` (unchanged — it's the right safety default), so this PR makes the free-plan collision graceful instead of a dead end:

- **deploy**: on a 422 \`plan_limit_reached/multi_env\` from env-project creation — interactive: *"Your plan has a single production environment — deploy to production instead? [y/N]"* (yes → continues the normal production flow, reusing the existing production project when present); non-interactive: server message + \`-e production\` hint, exit 1, never prompts.
- **dev --env <env>**: vars-fetch 404 for a non-production env now appends the free-plan hint.
- **help**: \`--env\` example reordered to \`production, staging, dev\`.

18 new tests (suite 386 green, tsc clean). Live-smoked against the app dev stack with a fresh free-plan org, both interactive branches driven through a real pty.

**Sequencing**: safe to merge/release before the app PR (inert against today's API); must not ship after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kd3AB3MXjuXvGyp5nrHMhK