### PR TITLE
fix(skill push/role push): send frontmatter as top-level params — properties/properties_patch retired server-side (#49)

### DIFF
--- a/src/commands/role-push.ts
+++ b/src/commands/role-push.ts
@@ -20,7 +20,7 @@ import chalk from 'chalk';
 import { Config } from '../utils/config';
 import { requireConfigWithWorkspace } from '../utils/api';
 import { callCrewsTool } from '../utils/mcp';
-import { parseSkillFile } from './skill-push';
+import { parseSkillFile, assertNoReservedFrontmatterKeys } from './skill-push';
 
 export interface RolePushOptions {
     json?: boolean;
@@ -65,6 +65,7 @@ export async function rolePushWithConfig(
 
     try {
         ({ name, description, properties, body } = parseSkillFile(skillMdContent));
+        assertNoReservedFrontmatterKeys(properties);
     } catch (e: any) {
         process.stderr.write(chalk.red(`error: ${e.message}\n`));
         process.exit(1);
@@ -108,14 +109,15 @@ export async function rolePushWithConfig(
 
     // Upsert: try create first; on name_collision switch to edit.
     // Roles carry NO references — do not send references key.
+    // Frontmatter extras are spread FIRST so the fixed protocol keys always win.
     let result: Awaited<ReturnType<typeof callCrewsTool>>;
     try {
         result = await callCrewsTool(config, 'roles', {
+            ...properties,
             action: 'create',
             name,
             description,
             body,
-            properties,
         });
     } catch (e: any) {
         process.stderr.write(chalk.red(`error: ${e.message}\n`));
@@ -123,15 +125,15 @@ export async function rolePushWithConfig(
     }
 
     // On name collision, switch to the edit path.
-    // Roles edit uses 'name' (NOT 'identifier'), and properties → properties_patch.
+    // Roles edit uses 'name' (NOT 'identifier').
     if (!result.ok && result.data?.code === 'name_collision') {
         try {
             result = await callCrewsTool(config, 'roles', {
+                ...properties,
                 action: 'edit',
                 name,
                 description,
                 body,
-                properties_patch: properties,
             });
         } catch (e: any) {
             process.stderr.write(chalk.red(`error: ${e.message}\n`));

--- a/src/commands/skill-push.ts
+++ b/src/commands/skill-push.ts
@@ -24,6 +24,24 @@ export interface SkillPushOptions {
 }
 
 /**
+ * Protocol param names reserved by the skills/roles MCP tool actions. Frontmatter
+ * keys that collide with these would silently corrupt the request once spread
+ * top-level into the call arguments.
+ */
+export const RESERVED_PARAM_KEYS = ['action', 'identifier', 'role', 'name', 'description', 'body', 'references', 'base_version_id'];
+
+/**
+ * Throws if any frontmatter-derived property key collides with a reserved
+ * protocol param name.
+ */
+export function assertNoReservedFrontmatterKeys(properties: Record<string, unknown>): void {
+    const offending = Object.keys(properties).filter((key) => RESERVED_PARAM_KEYS.includes(key));
+    if (offending.length > 0) {
+        throw new Error(`SKILL.md frontmatter contains reserved key(s) that would collide with protocol params: ${offending.join(', ')}`);
+    }
+}
+
+/**
  * Parse a SKILL.md file that begins with a YAML frontmatter block.
  *
  * Returns { name, description, properties, body } where:
@@ -221,6 +239,7 @@ export async function pushParsedSkill(
     config: Config,
 ): Promise<PushResult> {
     const { name, description, properties, body, references } = payload;
+    assertNoReservedFrontmatterKeys(properties);
     const isRole = !!options.role;
     const tool = isRole ? 'roles' : 'skills';
 
@@ -255,9 +274,10 @@ export async function pushParsedSkill(
         return { status: 'would-update', name, data: {} };
     }
 
+    // Spread frontmatter extras FIRST so the fixed protocol keys always win.
     const createArgs: Record<string, unknown> = isRole
-        ? { action: 'create_skill', role: options.role, name, description, body, properties, references }
-        : { action: 'create', name, description, body, properties, references };
+        ? { ...properties, action: 'create_skill', role: options.role, name, description, body, references }
+        : { ...properties, action: 'create', name, description, body, references };
 
     let result: Awaited<ReturnType<typeof callCrewsTool>>;
     try {
@@ -266,11 +286,11 @@ export async function pushParsedSkill(
         throw new Error(`${e.message}`);
     }
 
-    // On name collision, switch to the edit path. properties → properties_patch.
+    // On name collision, switch to the edit path.
     if (!result.ok && result.data?.code === 'name_collision') {
         const editArgs: Record<string, unknown> = isRole
-            ? { action: 'edit_skill', role: options.role, name, description, body, properties_patch: properties, references }
-            : { action: 'edit', identifier: name, description, body, properties_patch: properties, references };
+            ? { ...properties, action: 'edit_skill', role: options.role, name, description, body, references }
+            : { ...properties, action: 'edit', identifier: name, description, body, references };
 
         try {
             result = await callCrewsTool(config, tool, editArgs);

--- a/tests/role-push.test.ts
+++ b/tests/role-push.test.ts
@@ -288,7 +288,7 @@ describe('role push — create success', () => {
 // ---------------------------------------------------------------------------
 
 describe('role push — collision → edit (upsert)', () => {
-    it('on name_collision switches to roles.edit and reports "updated role", sends name + properties_patch, NO references', async () => {
+    it('on name_collision switches to roles.edit and reports "updated role", sends name + top-level extras, NO properties_patch, NO references', async () => {
         responseQueue = [
             makeMcpError('name_collision', 'A role with this name already exists.'),
             makeMcpSuccess({ version_id: 5, body_blob_sha: 'abc' }),
@@ -299,7 +299,7 @@ describe('role push — collision → edit (upsert)', () => {
                 '---',
                 'name: existing-role',
                 'description: Updated description',
-                'catalog_advertised: true',
+                'inherits_from: some-parent',
                 '---',
                 'Updated body',
             ].join('\n'),
@@ -327,6 +327,8 @@ describe('role push — collision → edit (upsert)', () => {
             // First call: create
             expect(allCaptures[0].body.params.name).toBe('crews_roles');
             expect(allCaptures[0].body.params.arguments.action).toBe('create');
+            // inherits_from (frontmatter extra) sent top-level on create too
+            expect(allCaptures[0].body.params.arguments.inherits_from).toBe('some-parent');
 
             // Second call: edit
             const editArgs = allCaptures[1].body.params.arguments;
@@ -334,8 +336,8 @@ describe('role push — collision → edit (upsert)', () => {
             expect(editArgs.action).toBe('edit');
             // roles edit uses 'name', NOT 'identifier'
             expect(editArgs.name).toBe('existing-role');
-            // catalog_advertised (frontmatter extra) sent top-level, no wrapper key
-            expect(editArgs.catalog_advertised).toBe(true);
+            // inherits_from (frontmatter extra) sent top-level, no wrapper key
+            expect(editArgs.inherits_from).toBe('some-parent');
             expect(editArgs).not.toHaveProperty('properties_patch');
             expect(editArgs).not.toHaveProperty('properties');
             // NO references key on roles edit

--- a/tests/role-push.test.ts
+++ b/tests/role-push.test.ts
@@ -216,6 +216,71 @@ describe('role push — create success', () => {
             cleanup();
         }
     });
+
+    it('sends frontmatter extras (e.g. inherits_from) top-level on create, with no properties wrapper', async () => {
+        responseQueue = [makeMcpSuccess({ role_doc_id: 1, folder_id: 2 })];
+
+        const { dir, cleanup } = makeTmpRoleDir(
+            [
+                '---',
+                'name: extras-role',
+                'description: A role with extras',
+                'inherits_from: base-role',
+                '---',
+                'body',
+            ].join('\n'),
+        );
+
+        const restoreExit = patchProcessExit();
+        const logs: string[] = [];
+        const origLog = console.log;
+        console.log = (m?: any) => { logs.push(String(m)); };
+
+        try {
+            let caughtExit: ProcessExitError | null = null;
+            try {
+                await rolePushWithConfig(dir, {}, stubConfig());
+            } catch (e) {
+                if (e instanceof ProcessExitError) caughtExit = e;
+                else throw e;
+            }
+
+            expect(caughtExit?.code).toBe(0);
+            const args = lastCapture!.body.params.arguments;
+            expect(args.inherits_from).toBe('base-role');
+            expect(args).not.toHaveProperty('properties');
+        } finally {
+            console.log = origLog;
+            restoreExit();
+            cleanup();
+        }
+    });
+
+    it('fails with a clear error before any HTTP call when frontmatter contains a reserved key (e.g. name)', async () => {
+        const { dir, cleanup } = makeTmpRoleDir(
+            ['---', 'name: hijack-role', 'description: nope', 'action: delete', '---', 'body'].join('\n'),
+        );
+
+        const restoreExit = patchProcessExit();
+        const { lines: stderrLines, restore: restoreStderr } = captureStderr();
+
+        try {
+            let caughtExit: ProcessExitError | null = null;
+            try {
+                await rolePushWithConfig(dir, {}, stubConfig());
+            } catch (e) {
+                if (e instanceof ProcessExitError) caughtExit = e; else throw e;
+            }
+            expect(caughtExit).not.toBeNull();
+            expect(caughtExit!.code).not.toBe(0);
+            expect(stderrLines.join('')).toContain('action');
+            expect(allCaptures.length).toBe(0);
+        } finally {
+            restoreExit();
+            restoreStderr();
+            cleanup();
+        }
+    });
 });
 
 // ---------------------------------------------------------------------------
@@ -269,8 +334,10 @@ describe('role push — collision → edit (upsert)', () => {
             expect(editArgs.action).toBe('edit');
             // roles edit uses 'name', NOT 'identifier'
             expect(editArgs.name).toBe('existing-role');
-            // properties_patch must be present (not properties)
-            expect(editArgs).toHaveProperty('properties_patch');
+            // catalog_advertised (frontmatter extra) sent top-level, no wrapper key
+            expect(editArgs.catalog_advertised).toBe(true);
+            expect(editArgs).not.toHaveProperty('properties_patch');
+            expect(editArgs).not.toHaveProperty('properties');
             // NO references key on roles edit
             expect(editArgs).not.toHaveProperty('references');
 

--- a/tests/skill-push.test.ts
+++ b/tests/skill-push.test.ts
@@ -377,14 +377,53 @@ describe('skillPushWithConfig — shared library (no --role)', () => {
             expect(body.params.arguments.name).toBe('My Cool Skill');
             expect(body.params.arguments.description).toBe('Does cool things');
 
-            // catalog_advertised should be in properties
-            expect(body.params.arguments.properties).toMatchObject({ catalog_advertised: false });
+            // catalog_advertised should be sent top-level, not wrapped in properties
+            expect(body.params.arguments.catalog_advertised).toBe(false);
+            expect(body.params.arguments).not.toHaveProperty('properties');
 
             // references should include the sibling file
             expect(body.params.arguments.references).toHaveProperty('usage.ts', 'export const usage = "example";');
 
             // SKILL.md should NOT be in references
             expect(body.params.arguments.references).not.toHaveProperty('SKILL.md');
+        } finally {
+            restoreExit();
+            cleanup();
+        }
+    });
+
+    it('sends license and allowed-tools frontmatter extras top-level on create, with no properties wrapper', async () => {
+        const { dir, cleanup } = makeTmpSkillDir(
+            [
+                '---',
+                'name: Licensed Skill',
+                'description: Has license and allowed-tools extras',
+                'license: MIT',
+                'allowed-tools: Read',
+                '---',
+                '',
+                'body content',
+            ].join('\n'),
+        );
+
+        const restoreExit = patchProcessExit();
+
+        try {
+            let caughtExit: ProcessExitError | null = null;
+            try {
+                await skillPushWithConfig(dir, {}, stubConfig());
+            } catch (e) {
+                if (e instanceof ProcessExitError) caughtExit = e;
+                else throw e;
+            }
+
+            expect(caughtExit?.code).toBe(0);
+            expect(lastCapture).not.toBeNull();
+
+            const args = lastCapture!.body.params.arguments;
+            expect(args.license).toBe('MIT');
+            expect(args['allowed-tools']).toBe('Read');
+            expect(args).not.toHaveProperty('properties');
         } finally {
             restoreExit();
             cleanup();
@@ -504,6 +543,34 @@ describe('skillPushWithConfig — error cases', () => {
             cleanup();
         }
     });
+
+    it('fails with a clear error before any HTTP call when frontmatter contains a reserved key (e.g. identifier)', async () => {
+        const { dir, cleanup } = makeTmpSkillDir(
+            ['---', 'name: Hijack Skill', 'description: nope', 'identifier: hijack', '---', 'body'].join('\n'),
+        );
+
+        const restoreExit = patchProcessExit();
+        const { lines: stderrLines, restore: restoreStderr } = captureStderr();
+
+        try {
+            let caughtExit: ProcessExitError | null = null;
+            try {
+                await skillPushWithConfig(dir, {}, stubConfig());
+            } catch (e) {
+                if (e instanceof ProcessExitError) caughtExit = e; else throw e;
+            }
+            expect(caughtExit).not.toBeNull();
+            expect(caughtExit!.code).not.toBe(0);
+            expect(stderrLines.join('')).toContain('identifier');
+
+            // No HTTP call was made — the guard fired before any create attempt.
+            expect(allCaptures.length).toBe(0);
+        } finally {
+            restoreExit();
+            restoreStderr();
+            cleanup();
+        }
+    });
 });
 
 // ---------------------------------------------------------------------------
@@ -517,7 +584,7 @@ describe('skillPushWithConfig — idempotent upsert', () => {
             makeMcpSuccess({ version_id: 42, body_blob_sha: 'deadbeef' }),
         ];
         const { dir, cleanup } = makeTmpSkillDir(
-            ['---', 'name: Existing Skill', 'description: updated desc', '---', 'new body'].join('\n'),
+            ['---', 'name: Existing Skill', 'description: updated desc', 'catalog_advertised: true', '---', 'new body'].join('\n'),
             { 'ref.ts': 'export const x = 1;' },
         );
         const restoreExit = patchProcessExit();
@@ -534,7 +601,8 @@ describe('skillPushWithConfig — idempotent upsert', () => {
             expect(allCaptures[1].body.params.name).toBe('crews_skills');
             expect(allCaptures[1].body.params.arguments.action).toBe('edit');
             expect(allCaptures[1].body.params.arguments.identifier).toBe('Existing Skill');
-            expect(allCaptures[1].body.params.arguments).toHaveProperty('properties_patch');
+            expect(allCaptures[1].body.params.arguments.catalog_advertised).toBe(true);
+            expect(allCaptures[1].body.params.arguments).not.toHaveProperty('properties_patch');
             expect(allCaptures[1].body.params.arguments.references).toHaveProperty('ref.ts');
             expect(logs.join('')).toContain('updated skill');
         } finally { console.log = origLog; restoreExit(); cleanup(); }
@@ -621,7 +689,8 @@ describe('pushParsedSkill — core payload-based upsert', () => {
             expect(args.action).toBe('create');
             expect(args.name).toBe('Core Skill');
             expect(args.description).toBe('A payload-based skill');
-            expect(args.properties).toMatchObject({ catalog_advertised: true });
+            expect(args.catalog_advertised).toBe(true);
+            expect(args).not.toHaveProperty('properties');
             expect(args.references).toHaveProperty('helper.ts', 'export const x = 1;');
             expect(args.body).toBe('The skill body');
         } finally {
@@ -656,8 +725,8 @@ describe('pushParsedSkill — core payload-based upsert', () => {
             expect(editArgs.action).toBe('edit');
             expect(editArgs.identifier).toBe('Core Skill');
             expect(editArgs.description).toBe('A payload-based skill');
-            expect(editArgs).toHaveProperty('properties_patch');
-            expect(editArgs.properties_patch).toMatchObject({ catalog_advertised: true });
+            expect(editArgs.catalog_advertised).toBe(true);
+            expect(editArgs).not.toHaveProperty('properties_patch');
             expect(editArgs.references).toHaveProperty('helper.ts');
         } finally {
             restoreExit();


### PR DESCRIPTION
## Why

Every real `skill push` / `role push` write has failed with `unknown_params: Unknown params: properties` since the server retired the free-form `properties`/`properties_patch` params (solidactions-app#280, 2026-06-01) in favor of constrained top-level params. Fixes #49. (`docs push` was never affected; `--dry-run` passed because it only does a read pre-flight.)

## What

- `skill push` (shared + `--role`) and `role push` now spread SKILL.md frontmatter extras as **top-level params** on create/edit — no wrapper object; the server's param list is the single validity authority.
- New guard `assertNoReservedFrontmatterKeys`: frontmatter keys colliding with protocol params (`action`, `identifier`, `role`, `name`, `description`, `body`, `references`, `base_version_id`) fail fast with a clear error before any HTTP call.
- `parseSkillFile` / `SkillPayload` shapes unchanged — wire format only.

## Verification

- `skill-push.test.ts` + `role-push.test.ts`: 47/47 (payload-shape tests written red-first against the old code); full suite green apart from 5 pre-existing `dev.test.ts` failures confirmed on main via stash bisection; `npm run build` clean.
- Live smoke against a real dev stack (server + Postgres): create, re-push update, `license`/`compatibility`/`allowed-tools`/`metadata` persisted and verified in DB, `skill pull`→push round-trip, `--role` push, reserved-key guard — 7/7.

## Deploy order

Publish after solidactions-app#413 deploys — round-trip fields (`license` etc.) need the server-side params. Plain name+description skills (the common case) work against today's production already.

🤖 Generated with [Claude Code](https://claude.com/claude-code)