### PR TITLE
skill publish + push publish-awareness (staged-not-published warning, --publish, skill publish)

### DIFF
--- a/src/commands/skill-publish.ts
+++ b/src/commands/skill-publish.ts
@@ -1,0 +1,26 @@
+/**
+ * solidactions skill publish <name>
+ *
+ * Publishes (snapshots) a shared skill so its latest pushed revision goes live
+ * for agents.
+ */
+
+import { Config } from '../utils/config';
+import { requireConfigWithWorkspace } from '../utils/api';
+import { publishSkillByName, emitPublishOutcome } from '../utils/skill-snapshot';
+
+export interface SkillPublishOptions {
+    json?: boolean;
+}
+
+/** Core implementation — accepts an injected config for tests. */
+export async function skillPublishWithConfig(name: string, options: SkillPublishOptions, config: Config): Promise<void> {
+    const outcome = await publishSkillByName(config, name);
+    emitPublishOutcome(name, outcome, { json: options.json });
+}
+
+/** Entry point called from index.ts. */
+export async function skillPublish(name: string, options: SkillPublishOptions): Promise<void> {
+    const config = await requireConfigWithWorkspace();
+    await skillPublishWithConfig(name, options, config);
+}

--- a/src/commands/skill-push.ts
+++ b/src/commands/skill-push.ts
@@ -16,11 +16,13 @@ import yaml from 'js-yaml';
 import { Config } from '../utils/config';
 import { requireConfigWithWorkspace } from '../utils/api';
 import { callCrewsTool } from '../utils/mcp';
+import { publishSkillByName, publishSkillByDocId, emitPublishOutcome, PublishOutcome } from '../utils/skill-snapshot';
 
 export interface SkillPushOptions {
     role?: string;
     json?: boolean;
     dryRun?: boolean;
+    publish?: boolean;
 }
 
 /**
@@ -394,6 +396,11 @@ export async function skillPushWithConfig(
         process.exit(1);
     }
 
+    if (options.publish && options.role) {
+        process.stderr.write(chalk.red('error: --publish is not supported with --role yet; publish the role-scoped skill via the MCP take_snapshot tool.\n'));
+        process.exit(1);
+    }
+
     const topLevelSkillMd = path.join(absDir, 'SKILL.md');
 
     // -------------------------------------------------------------------------
@@ -416,14 +423,30 @@ export async function skillPushWithConfig(
             process.exit(1);
         }
 
-        if (options.json) {
-            console.log(JSON.stringify(pushResult.data));
-        } else {
-            printPushResult(pushResult, options);
-            const warning = stagedPushWarning(pushResult, !!options.role);
-            if (warning) {
-                process.stderr.write(chalk.yellow(warning));
+        // Optionally publish (snapshot) the just-pushed revision (single-skill mode).
+        let publishOutcome: PublishOutcome | null = null;
+        if (options.publish && !options.dryRun) {
+            if (pushResult.status === 'created') {
+                const createdDocId = (pushResult.data.skill_doc_id ?? pushResult.data.doc_id ?? pushResult.data.id) as number | string;
+                publishOutcome = await publishSkillByDocId(config, createdDocId);
+            } else {
+                publishOutcome = await publishSkillByName(config, pushResult.name);
             }
+        }
+
+        if (options.json) {
+            const payload = publishOutcome ? { ...pushResult.data, publish: publishOutcome } : pushResult.data;
+            console.log(JSON.stringify(payload));
+            process.exit(publishOutcome?.status === 'error' ? 1 : 0);
+        }
+
+        printPushResult(pushResult, options);
+        if (publishOutcome) {
+            emitPublishOutcome(pushResult.name, publishOutcome, { pushed: true });
+        }
+        const warning = stagedPushWarning(pushResult, !!options.role);
+        if (warning) {
+            process.stderr.write(chalk.yellow(warning));
         }
         process.exit(0);
     }
@@ -431,6 +454,11 @@ export async function skillPushWithConfig(
     // -------------------------------------------------------------------------
     // Plugin mode: push skills/<name>/SKILL.md + commands/<name>.md
     // -------------------------------------------------------------------------
+    if (options.publish) {
+        process.stderr.write(chalk.red('error: --publish is not supported when pushing a plugin bundle (multiple skills); publish each with "solidactions skill publish <name>".\n'));
+        process.exit(1);
+    }
+
     const payloads: SkillPayload[] = [];
 
     // One-level glob: skills/*/SKILL.md

--- a/src/commands/skill-push.ts
+++ b/src/commands/skill-push.ts
@@ -427,8 +427,13 @@ export async function skillPushWithConfig(
         let publishOutcome: PublishOutcome | null = null;
         if (options.publish && !options.dryRun) {
             if (pushResult.status === 'created') {
-                const createdDocId = (pushResult.data.skill_doc_id ?? pushResult.data.doc_id ?? pushResult.data.id) as number | string;
-                publishOutcome = await publishSkillByDocId(config, createdDocId);
+                if (!pushResult.data.snapshot_hint) {
+                    // Live-mode (version_mode=live) skill: no snapshot to take — already live.
+                    publishOutcome = { status: 'live_mode' };
+                } else {
+                    const createdDocId = (pushResult.data.skill_doc_id ?? pushResult.data.doc_id ?? pushResult.data.id) as number | string;
+                    publishOutcome = await publishSkillByDocId(config, createdDocId);
+                }
             } else {
                 publishOutcome = await publishSkillByName(config, pushResult.name);
             }

--- a/src/commands/skill-push.ts
+++ b/src/commands/skill-push.ts
@@ -341,6 +341,41 @@ function printPushResult(result: PushResult, options: SkillPushOptions): void {
 }
 
 /**
+ * Build the "staged, not published" warning for a successful single-skill push,
+ * or null when nothing needs publishing.
+ *
+ * Edit path (status 'updated'): default reads return the active snapshot, so a
+ * new revision is dark to agents until published — warn when the server reports
+ * has_unpublished_revisions === true.
+ * Create path (status 'created'): a brand-new skill has no snapshot, so reads
+ * fall back to the unversioned draft (it runs, just isn't pinned) — warn on a
+ * truthy snapshot_hint (null when the skill is version_mode=live).
+ * Dry-run statuses never warn.
+ */
+export function stagedPushWarning(result: PushResult, isRole: boolean): string | null {
+    const { status, name, data } = result;
+    if (status === 'created') {
+        if (!data.snapshot_hint) {
+            return null;
+        }
+    } else if (status === 'updated') {
+        if (data.has_unpublished_revisions !== true) {
+            return null;
+        }
+    } else {
+        return null;
+    }
+
+    const publishLine = isRole
+        ? `  Publish this role-scoped skill via the MCP crews_versions take_snapshot tool.\n`
+        : `  Run: solidactions skill publish ${name}\n`;
+    const headline = status === 'updated'
+        ? `⚠ Staged, not published. This revision won't run for agents until you publish it.\n`
+        : `⚠ Not yet published. Agents read the unversioned draft until you publish to pin a version.\n`;
+    return headline + publishLine;
+}
+
+/**
  * Core implementation — accepts an injected config so tests can point at a
  * stub server without touching the filesystem config.
  *
@@ -385,6 +420,10 @@ export async function skillPushWithConfig(
             console.log(JSON.stringify(pushResult.data));
         } else {
             printPushResult(pushResult, options);
+            const warning = stagedPushWarning(pushResult, !!options.role);
+            if (warning) {
+                process.stderr.write(chalk.yellow(warning));
+            }
         }
         process.exit(0);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -512,6 +512,7 @@ skill
     .option('--role <name>', 'Scope the skill to a role instead of the shared library')
     .option('--json', 'Output result as JSON')
     .option('--dry-run', 'Preview create vs update without writing')
+    .option('--publish', 'Publish (snapshot) the skill after pushing, making it live for agents')
     .action(async (dir, options) => {
         await skillPush(dir, options);
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ import { oauthActionsShow } from './commands/oauth-actions-show';
 import { oauthActionsPlatforms } from './commands/oauth-actions-platforms';
 import { workspacesList, workspaceSet } from './commands/workspaces';
 import { skillPush } from './commands/skill-push';
+import { skillPublish } from './commands/skill-publish';
 import { skillPull } from './commands/skill-pull';
 import { skillList } from './commands/skill-list';
 import { skillView } from './commands/skill-view';
@@ -513,6 +514,15 @@ skill
     .option('--dry-run', 'Preview create vs update without writing')
     .action(async (dir, options) => {
         await skillPush(dir, options);
+    });
+
+skill
+    .command('publish')
+    .description('Publish (snapshot) a skill so its latest pushed revision goes live for agents')
+    .argument('<name>', 'Skill name/identifier (e.g. "my-skill" or "shared/my-skill")')
+    .option('--json', 'Output result as JSON')
+    .action(async (name, options) => {
+        await skillPublish(name, options);
     });
 
 skill

--- a/src/utils/skill-snapshot.ts
+++ b/src/utils/skill-snapshot.ts
@@ -1,0 +1,91 @@
+/**
+ * Publish (snapshot) helpers for crews skills.
+ *
+ * Composes two existing MCP actions: crews_skills.read resolves a skill name to
+ * its doc_id and reports whether the current revision is unpublished, and
+ * crews_versions.take_snapshot promotes that revision to all agents.
+ */
+
+import chalk from 'chalk';
+import { Config } from './config';
+import { callCrewsTool } from './mcp';
+
+export type PublishOutcome =
+    | { status: 'published'; snapshotId: number | string }
+    | { status: 'already_published' }
+    | { status: 'live_mode' }
+    | { status: 'error'; code: string; message: string };
+
+/** Snapshot a skill by its doc_id (crews_versions.take_snapshot). */
+export async function publishSkillByDocId(config: Config, docId: number | string): Promise<PublishOutcome> {
+    let result: Awaited<ReturnType<typeof callCrewsTool>>;
+    try {
+        result = await callCrewsTool(config, 'crews_versions', { action: 'take_snapshot', doc_id: docId });
+    } catch (e: any) {
+        return { status: 'error', code: 'mcp_request_failed', message: e.message };
+    }
+    if (!result.ok) {
+        return { status: 'error', code: result.data?.code ?? 'unknown_error', message: result.data?.message ?? 'take_snapshot returned an error with no message' };
+    }
+    return { status: 'published', snapshotId: result.data.snapshot_id };
+}
+
+/**
+ * Resolve a skill name to its doc_id, then publish — short-circuiting when the
+ * current revision is already live (no take_snapshot call). Detection uses the
+ * read response, NOT the take_snapshot error code (the server maps both
+ * "nothing to snapshot" and "live-mode" to the same not_snapshotable code).
+ */
+export async function publishSkillByName(config: Config, name: string): Promise<PublishOutcome> {
+    let read: Awaited<ReturnType<typeof callCrewsTool>>;
+    try {
+        read = await callCrewsTool(config, 'skills', { action: 'read', identifier: name });
+    } catch (e: any) {
+        return { status: 'error', code: 'mcp_request_failed', message: e.message };
+    }
+    if (!read.ok) {
+        return { status: 'error', code: read.data?.code ?? 'unknown_error', message: read.data?.message ?? 'read returned an error with no message' };
+    }
+
+    const data = read.data;
+    // Metadata absent entirely → live-mode doc (edits are already live).
+    if (data.has_unpublished_revisions === undefined) {
+        return { status: 'live_mode' };
+    }
+    // HEAD already snapshotted → nothing to publish.
+    if (data.has_unpublished_revisions === false) {
+        return { status: 'already_published' };
+    }
+    return publishSkillByDocId(config, data.doc_id);
+}
+
+/**
+ * Print a PublishOutcome and exit. `opts.pushed` tailors error copy for the
+ * `skill push --publish` case (push succeeded, publish failed). `opts.json`
+ * prints the raw outcome as JSON instead of human text.
+ */
+export function emitPublishOutcome(name: string, outcome: PublishOutcome, opts: { pushed?: boolean; json?: boolean } = {}): void {
+    if (opts.json) {
+        console.log(JSON.stringify(outcome));
+        process.exit(outcome.status === 'error' ? 1 : 0);
+    }
+    switch (outcome.status) {
+        case 'published':
+            console.log(chalk.green(`✔ published '${name}' — now live for agents`));
+            process.exit(0);
+        case 'already_published':
+            console.log(chalk.green('already published — nothing to do'));
+            process.exit(0);
+        case 'live_mode':
+            console.log(chalk.green('live-mode skill — edits are already live, nothing to publish'));
+            process.exit(0);
+        case 'error': {
+            const prefix = opts.pushed ? 'pushed, but publish failed — ' : '';
+            process.stderr.write(chalk.red(`${prefix}${outcome.code}: ${outcome.message}\n`));
+            if (opts.pushed) {
+                process.stderr.write(chalk.yellow(`  The skill was pushed. Retry: solidactions skill publish ${name}\n`));
+            }
+            process.exit(1);
+        }
+    }
+}

--- a/tests/skill-publish.test.ts
+++ b/tests/skill-publish.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Tests for `solidactions skill publish <name>` and the underlying
+ * publish/snapshot helpers.
+ *
+ * Uses a real in-process HTTP server (Node's http.createServer) to stub the
+ * /mcp endpoint. No mock/spy/stub libraries — follows the pattern in
+ * skill-push.test.ts.
+ */
+
+import * as http from 'http';
+import { describe, expect, it, beforeAll, afterAll, beforeEach } from 'vitest';
+import { publishSkillByName, publishSkillByDocId } from '../src/utils/skill-snapshot';
+import { skillPublishWithConfig } from '../src/commands/skill-publish';
+import type { Config } from '../src/utils/config';
+
+// ---------------------------------------------------------------------------
+// Stub MCP server — records the last request and returns a canned response
+// ---------------------------------------------------------------------------
+
+interface CapturedRequest {
+    method: string | undefined;
+    path: string | undefined;
+    headers: http.IncomingHttpHeaders;
+    body: any;
+}
+
+let stubServer: http.Server;
+let stubPort: number;
+let lastCapture: CapturedRequest | null = null;
+let allCaptures: CapturedRequest[] = [];
+
+/** Canned MCP success response for a skill create. */
+function makeMcpSuccess(toolData: object): string {
+    return JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        result: {
+            isError: false,
+            content: [{ type: 'text', text: JSON.stringify(toolData) }],
+        },
+    });
+}
+
+/** Canned MCP error response (isError: true). */
+function makeMcpError(code: string, message: string): string {
+    return JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        result: {
+            isError: true,
+            content: [{ type: 'text', text: JSON.stringify({ code, message }) }],
+        },
+    });
+}
+
+// Server state — a FIFO queue of canned responses; falls back to a default create-success.
+const DEFAULT_RESPONSE = makeMcpSuccess({ skill_doc_id: 'doc-abc123', reference_doc_ids: {} });
+let responseQueue: string[] = [];
+
+function nextResponseBody(): string {
+    return responseQueue.length > 0 ? responseQueue.shift()! : DEFAULT_RESPONSE;
+}
+
+beforeAll(async () => {
+    stubServer = http.createServer((req, res) => {
+        let rawBody = '';
+        req.on('data', (chunk) => { rawBody += chunk; });
+        req.on('end', () => {
+            let parsedBody: any = null;
+            try { parsedBody = JSON.parse(rawBody); } catch { /* ignore */ }
+
+            const capture: CapturedRequest = {
+                method: req.method,
+                path: req.url,
+                headers: req.headers,
+                body: parsedBody,
+            };
+
+            lastCapture = capture;
+            allCaptures.push(capture);
+
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(nextResponseBody());
+        });
+    });
+
+    await new Promise<void>((resolve) => {
+        stubServer.listen(0, '127.0.0.1', () => {
+            stubPort = (stubServer.address() as { port: number }).port;
+            resolve();
+        });
+    });
+});
+
+afterAll(() => {
+    return new Promise<void>((resolve, reject) => {
+        stubServer.close((err) => (err ? reject(err) : resolve()));
+    });
+});
+
+beforeEach(() => {
+    lastCapture = null;
+    allCaptures = [];
+    responseQueue = [];
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a Config that points at the stub server. */
+function stubConfig(workspaceId = 'ws-test-uuid'): Config {
+    return {
+        host: `http://127.0.0.1:${stubPort}`,
+        apiKey: 'test-api-key',
+        workspaceId,
+    };
+}
+
+/** Sentinel thrown by the patched process.exit so execution stops. */
+class ProcessExitError extends Error {
+    constructor(public readonly code: number | undefined) {
+        super(`process.exit(${code})`);
+    }
+}
+
+/**
+ * Patch process.exit to throw ProcessExitError so tests can catch it.
+ * Returns a function that restores the original process.exit.
+ */
+function patchProcessExit(): () => void {
+    const orig = process.exit.bind(process);
+    (process as any).exit = (code?: number) => { throw new ProcessExitError(code); };
+    return () => { (process as any).exit = orig; };
+}
+
+/**
+ * Patch process.stderr.write to capture output.
+ * Returns captured lines and a restore function.
+ */
+function captureStderr(): { lines: string[]; restore: () => void } {
+    const lines: string[] = [];
+    const orig = process.stderr.write.bind(process.stderr);
+    (process.stderr as any).write = (chunk: string) => { lines.push(String(chunk)); return true; };
+    return { lines, restore: () => { (process.stderr as any).write = orig; } };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('publishSkillByName', () => {
+    it('reads by name then snapshots by doc_id when there are unpublished revisions', async () => {
+        responseQueue = [
+            makeMcpSuccess({ doc_id: 118, published: false, has_unpublished_revisions: true }),
+            makeMcpSuccess({ snapshot_taken: true, snapshot_id: 900 }),
+        ];
+        const outcome = await publishSkillByName(stubConfig(), 'my-skill');
+        expect(outcome).toEqual({ status: 'published', snapshotId: 900 });
+        expect(allCaptures.length).toBe(2);
+        expect(allCaptures[0].body.params.name).toBe('crews_skills');
+        expect(allCaptures[0].body.params.arguments).toEqual({ action: 'read', identifier: 'my-skill' });
+        expect(allCaptures[1].body.params.name).toBe('crews_versions');
+        expect(allCaptures[1].body.params.arguments).toEqual({ action: 'take_snapshot', doc_id: 118 });
+    });
+
+    it('returns already_published (no snapshot call) when has_unpublished_revisions is false', async () => {
+        responseQueue = [makeMcpSuccess({ doc_id: 5, has_unpublished_revisions: false, active_snapshot_id: 3 })];
+        const outcome = await publishSkillByName(stubConfig(), 'my-skill');
+        expect(outcome).toEqual({ status: 'already_published' });
+        expect(allCaptures.length).toBe(1);
+    });
+
+    it('returns live_mode (no snapshot call) when metadata is absent', async () => {
+        responseQueue = [makeMcpSuccess({ doc_id: 6, published: true })];
+        const outcome = await publishSkillByName(stubConfig(), 'my-skill');
+        expect(outcome).toEqual({ status: 'live_mode' });
+        expect(allCaptures.length).toBe(1);
+    });
+
+    it('returns error when read resolution fails', async () => {
+        responseQueue = [makeMcpError('skill_not_found', "No skill 'nope'.")];
+        const outcome = await publishSkillByName(stubConfig(), 'nope');
+        expect(outcome).toEqual({ status: 'error', code: 'skill_not_found', message: "No skill 'nope'." });
+    });
+
+    it('returns error when take_snapshot fails', async () => {
+        responseQueue = [
+            makeMcpSuccess({ doc_id: 7, has_unpublished_revisions: true }),
+            makeMcpError('unauthorized', 'Only Developer or Admin can take snapshots'),
+        ];
+        const outcome = await publishSkillByName(stubConfig(), 'my-skill');
+        expect(outcome).toEqual({ status: 'error', code: 'unauthorized', message: 'Only Developer or Admin can take snapshots' });
+    });
+});
+
+describe('publishSkillByDocId', () => {
+    it('snapshots directly and returns published', async () => {
+        responseQueue = [makeMcpSuccess({ snapshot_taken: true, snapshot_id: 777 })];
+        const outcome = await publishSkillByDocId(stubConfig(), 200);
+        expect(outcome).toEqual({ status: 'published', snapshotId: 777 });
+        expect(allCaptures.length).toBe(1);
+        expect(allCaptures[0].body.params.name).toBe('crews_versions');
+        expect(allCaptures[0].body.params.arguments).toEqual({ action: 'take_snapshot', doc_id: 200 });
+    });
+});
+
+describe('skillPublishWithConfig — standalone command output', () => {
+    it('prints published confirmation and exits 0 on success', async () => {
+        responseQueue = [
+            makeMcpSuccess({ doc_id: 8, has_unpublished_revisions: true }),
+            makeMcpSuccess({ snapshot_taken: true, snapshot_id: 901 }),
+        ];
+        const restoreExit = patchProcessExit();
+        const logs: string[] = []; const origLog = console.log; console.log = (m?: any) => { logs.push(String(m)); };
+        try {
+            let code: number | undefined;
+            try { await skillPublishWithConfig('my-skill', {}, stubConfig()); }
+            catch (e) { if (e instanceof ProcessExitError) code = e.code; else throw e; }
+            expect(code).toBe(0);
+            expect(logs.join('')).toContain("published 'my-skill'");
+        } finally { console.log = origLog; restoreExit(); }
+    });
+
+    it('prints the server error and exits 1 on failure', async () => {
+        responseQueue = [makeMcpError('skill_not_found', "No skill 'nope'.")];
+        const restoreExit = patchProcessExit();
+        const { lines, restore } = captureStderr();
+        try {
+            let code: number | undefined;
+            try { await skillPublishWithConfig('nope', {}, stubConfig()); }
+            catch (e) { if (e instanceof ProcessExitError) code = e.code; else throw e; }
+            expect(code).toBe(1);
+            expect(lines.join('')).toContain('skill_not_found');
+        } finally { restore(); restoreExit(); }
+    });
+});

--- a/tests/skill-push.test.ts
+++ b/tests/skill-push.test.ts
@@ -1458,4 +1458,35 @@ describe('skillPushWithConfig — --publish (single-skill)', () => {
             expect(lines.join('')).toMatch(/--publish is not supported.*plugin|multiple skills/i);
         } finally { restore(); restoreExit(); fs.rmSync(root, { recursive: true, force: true }); }
     });
+
+    it('create push --publish of a live-mode skill (null snapshot_hint) makes NO take_snapshot call and reports live-mode', async () => {
+        responseQueue = [makeMcpSuccess({ skill_doc_id: 300, reference_doc_ids: {}, snapshot_hint: null })];
+        const { dir, cleanup } = makeTmpSkillDir(['---', 'name: my-skill', 'description: d', '---', 'body'].join('\n'));
+        const restoreExit = patchProcessExit();
+        const logs: string[] = []; const origLog = console.log; console.log = (m?: any) => { logs.push(String(m)); };
+        try {
+            let code: number | undefined;
+            try { await skillPushWithConfig(dir, { publish: true }, stubConfig()); }
+            catch (e) { if (e instanceof ProcessExitError) code = e.code; else throw e; }
+            expect(code).toBe(0);
+            expect(allCaptures.length).toBe(1); // create only, no take_snapshot
+            expect(logs.join('')).toContain('live-mode skill');
+        } finally { console.log = origLog; restoreExit(); cleanup(); }
+    });
+
+    it('--publish combined with --dry-run performs NO publish call', async () => {
+        // dry-run does a single read pre-flight (skill_not_found → would-create), no create/edit/snapshot.
+        responseQueue = [makeMcpError('skill_not_found', 'absent')];
+        const { dir, cleanup } = makeTmpSkillDir(['---', 'name: my-skill', 'description: d', '---', 'body'].join('\n'));
+        const restoreExit = patchProcessExit();
+        const logs: string[] = []; const origLog = console.log; console.log = (m?: any) => { logs.push(String(m)); };
+        try {
+            let code: number | undefined;
+            try { await skillPushWithConfig(dir, { publish: true, dryRun: true }, stubConfig()); }
+            catch (e) { if (e instanceof ProcessExitError) code = e.code; else throw e; }
+            expect(code).toBe(0);
+            expect(allCaptures.length).toBe(1); // dry-run read pre-flight only, no take_snapshot
+            expect(allCaptures.every((c) => c.body.params.arguments.action !== 'take_snapshot')).toBe(true);
+        } finally { console.log = origLog; restoreExit(); cleanup(); }
+    });
 });

--- a/tests/skill-push.test.ts
+++ b/tests/skill-push.test.ts
@@ -1289,3 +1289,77 @@ describe('skill push --dry-run', () => {
         }
     });
 });
+
+describe('skillPushWithConfig — staged-not-published warning (single-skill)', () => {
+    async function run(dir: string, options: SkillPushOptions) {
+        const restoreExit = patchProcessExit();
+        const { lines: errLines, restore: restoreErr } = captureStderr();
+        const logs: string[] = [];
+        const origLog = console.log;
+        console.log = (m?: any) => { logs.push(String(m)); };
+        try {
+            try { await skillPushWithConfig(dir, options, stubConfig()); }
+            catch (e) { if (!(e instanceof ProcessExitError)) throw e; }
+        } finally {
+            console.log = origLog; restoreErr(); restoreExit();
+        }
+        return { err: errLines.join(''), out: logs.join('') };
+    }
+
+    it('warns (edit path) when has_unpublished_revisions is true', async () => {
+        responseQueue = [
+            makeMcpError('name_collision', 'exists'),
+            makeMcpSuccess({ version_id: 42, has_unpublished_revisions: true }),
+        ];
+        const { dir, cleanup } = makeTmpSkillDir(['---', 'name: my-skill', 'description: d', '---', 'body'].join('\n'));
+        try {
+            const { err } = await run(dir, {});
+            expect(err).toContain('Staged, not published');
+            expect(err).toContain('solidactions skill publish my-skill');
+        } finally { cleanup(); }
+    });
+
+    it('does NOT warn (edit path) when has_unpublished_revisions is false', async () => {
+        responseQueue = [
+            makeMcpError('name_collision', 'exists'),
+            makeMcpSuccess({ version_id: 43, has_unpublished_revisions: false }),
+        ];
+        const { dir, cleanup } = makeTmpSkillDir(['---', 'name: my-skill', 'description: d', '---', 'body'].join('\n'));
+        try {
+            const { err } = await run(dir, {});
+            expect(err).not.toContain('Staged, not published');
+        } finally { cleanup(); }
+    });
+
+    it('warns (create path, draft wording) when snapshot_hint is truthy', async () => {
+        responseQueue = [makeMcpSuccess({ skill_doc_id: 118, reference_doc_ids: {}, snapshot_hint: 'no snapshot yet' })];
+        const { dir, cleanup } = makeTmpSkillDir(['---', 'name: my-skill', 'description: d', '---', 'body'].join('\n'));
+        try {
+            const { err } = await run(dir, {});
+            expect(err).toContain('unversioned draft');
+            expect(err).toContain('solidactions skill publish my-skill');
+        } finally { cleanup(); }
+    });
+
+    it('does NOT warn (create path) when snapshot_hint is null (live-mode skill)', async () => {
+        responseQueue = [makeMcpSuccess({ skill_doc_id: 119, reference_doc_ids: {}, snapshot_hint: null })];
+        const { dir, cleanup } = makeTmpSkillDir(['---', 'name: my-skill', 'description: d', '---', 'body'].join('\n'));
+        try {
+            const { err } = await run(dir, {});
+            expect(err).not.toContain('published');
+        } finally { cleanup(); }
+    });
+
+    it('warns with MCP-hint wording (not the publish command) on a --role push', async () => {
+        responseQueue = [
+            makeMcpError('name_collision', 'exists'),
+            makeMcpSuccess({ version_id: 5, has_unpublished_revisions: true }),
+        ];
+        const { dir, cleanup } = makeTmpSkillDir(['---', 'name: my-skill', 'description: d', '---', 'body'].join('\n'));
+        try {
+            const { err } = await run(dir, { role: 'builder' });
+            expect(err).toContain('crews_versions take_snapshot');
+            expect(err).not.toContain('skill publish');
+        } finally { cleanup(); }
+    });
+});

--- a/tests/skill-push.test.ts
+++ b/tests/skill-push.test.ts
@@ -1363,3 +1363,99 @@ describe('skillPushWithConfig — staged-not-published warning (single-skill)', 
         } finally { cleanup(); }
     });
 });
+
+describe('skillPushWithConfig — --publish (single-skill)', () => {
+    it('rejects --publish combined with --role BEFORE any HTTP request', async () => {
+        const { dir, cleanup } = makeTmpSkillDir(['---', 'name: my-skill', 'description: d', '---', 'body'].join('\n'));
+        const restoreExit = patchProcessExit();
+        const { lines, restore } = captureStderr();
+        try {
+            let code: number | undefined;
+            try { await skillPushWithConfig(dir, { role: 'builder', publish: true }, stubConfig()); }
+            catch (e) { if (e instanceof ProcessExitError) code = e.code; else throw e; }
+            expect(code).toBe(1);
+            expect(lastCapture).toBeNull();
+            expect(lines.join('')).toContain('--publish is not supported with --role');
+        } finally { restore(); restoreExit(); cleanup(); }
+    });
+
+    it('after a create push, snapshots by skill_doc_id and prints published (no warning)', async () => {
+        responseQueue = [
+            makeMcpSuccess({ skill_doc_id: 200, reference_doc_ids: {}, snapshot_hint: 'no snapshot yet' }),
+            makeMcpSuccess({ snapshot_taken: true, snapshot_id: 950 }),
+        ];
+        const { dir, cleanup } = makeTmpSkillDir(['---', 'name: my-skill', 'description: d', '---', 'body'].join('\n'));
+        const restoreExit = patchProcessExit();
+        const { lines: errLines, restore: restoreErr } = captureStderr();
+        const logs: string[] = []; const origLog = console.log; console.log = (m?: any) => { logs.push(String(m)); };
+        try {
+            let code: number | undefined;
+            try { await skillPushWithConfig(dir, { publish: true }, stubConfig()); }
+            catch (e) { if (e instanceof ProcessExitError) code = e.code; else throw e; }
+            expect(code).toBe(0);
+            expect(allCaptures.length).toBe(2);
+            expect(allCaptures[1].body.params.name).toBe('crews_versions');
+            expect(allCaptures[1].body.params.arguments).toEqual({ action: 'take_snapshot', doc_id: 200 });
+            expect(logs.join('')).toContain("published 'my-skill'");
+            expect(errLines.join('')).not.toContain('Not yet published');
+        } finally { console.log = origLog; restoreErr(); restoreExit(); cleanup(); }
+    });
+
+    it('after an edit push, resolves by name then snapshots and prints published', async () => {
+        responseQueue = [
+            makeMcpError('name_collision', 'exists'),
+            makeMcpSuccess({ version_id: 51, has_unpublished_revisions: true }),
+            makeMcpSuccess({ doc_id: 201, has_unpublished_revisions: true }),
+            makeMcpSuccess({ snapshot_taken: true, snapshot_id: 951 }),
+        ];
+        const { dir, cleanup } = makeTmpSkillDir(['---', 'name: my-skill', 'description: d', '---', 'body'].join('\n'));
+        const restoreExit = patchProcessExit();
+        const logs: string[] = []; const origLog = console.log; console.log = (m?: any) => { logs.push(String(m)); };
+        try {
+            let code: number | undefined;
+            try { await skillPushWithConfig(dir, { publish: true }, stubConfig()); }
+            catch (e) { if (e instanceof ProcessExitError) code = e.code; else throw e; }
+            expect(code).toBe(0);
+            expect(allCaptures.length).toBe(4); // create(collision) → edit → read → take_snapshot
+            expect(allCaptures[2].body.params.arguments).toEqual({ action: 'read', identifier: 'my-skill' });
+            expect(allCaptures[3].body.params.arguments).toEqual({ action: 'take_snapshot', doc_id: 201 });
+            expect(logs.join('')).toContain("published 'my-skill'");
+        } finally { console.log = origLog; restoreExit(); cleanup(); }
+    });
+
+    it('under --json, still performs the publish and emits combined JSON', async () => {
+        responseQueue = [
+            makeMcpSuccess({ skill_doc_id: 202, reference_doc_ids: {}, snapshot_hint: 'x' }),
+            makeMcpSuccess({ snapshot_taken: true, snapshot_id: 952 }),
+        ];
+        const { dir, cleanup } = makeTmpSkillDir(['---', 'name: my-skill', 'description: d', '---', 'body'].join('\n'));
+        const restoreExit = patchProcessExit();
+        const logs: string[] = []; const origLog = console.log; console.log = (m?: any) => { logs.push(String(m)); };
+        try {
+            let code: number | undefined;
+            try { await skillPushWithConfig(dir, { publish: true, json: true }, stubConfig()); }
+            catch (e) { if (e instanceof ProcessExitError) code = e.code; else throw e; }
+            expect(code).toBe(0);
+            expect(allCaptures.length).toBe(2);
+            const printed = JSON.parse(logs.join(''));
+            expect(printed.publish).toEqual({ status: 'published', snapshotId: 952 });
+        } finally { console.log = origLog; restoreExit(); cleanup(); }
+    });
+
+    it('rejects --publish in plugin mode (no top-level SKILL.md) before pushing', async () => {
+        // Plugin dir: skills/<name>/SKILL.md, no top-level SKILL.md.
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), 'sa-plugin-'));
+        fs.mkdirSync(path.join(root, 'skills', 'alpha'), { recursive: true });
+        fs.writeFileSync(path.join(root, 'skills', 'alpha', 'SKILL.md'), ['---', 'name: alpha', 'description: d', '---', 'body'].join('\n'));
+        const restoreExit = patchProcessExit();
+        const { lines, restore } = captureStderr();
+        try {
+            let code: number | undefined;
+            try { await skillPushWithConfig(root, { publish: true }, stubConfig()); }
+            catch (e) { if (e instanceof ProcessExitError) code = e.code; else throw e; }
+            expect(code).toBe(1);
+            expect(lastCapture).toBeNull();
+            expect(lines.join('')).toMatch(/--publish is not supported.*plugin|multiple skills/i);
+        } finally { restore(); restoreExit(); fs.rmSync(root, { recursive: true, force: true }); }
+    });
+});


### PR DESCRIPTION
## What

Makes `solidactions skill push` publish-aware and adds CLI publishing. Pushing a skill **stages** a revision — it does not make it live for agents (publishing = an MCP `crews_versions take_snapshot`). The CLI previously gave no hint of this and had no way to publish, so agents pushed edits and reasonably assumed they were live.

Three changes (single-skill push mode, shared skills — v1 scope):

1. **Staged-not-published warning** on `skill push`. Edit path: `⚠ Staged, not published. This revision won't run for agents until you publish it.` Create path (draft is served, just unpinned): `⚠ Not yet published. Agents read the unversioned draft until you publish to pin a version.` Both point to `skill publish <name>`; a `--role` push points to the MCP `take_snapshot` tool instead.
2. **`skill publish <name>`** — new command that snapshots a skill so its latest pushed revision goes live. Resolves name → doc_id via `crews_skills read`, then `crews_versions take_snapshot`. Detects already-published / live-mode from the read response (not the ambiguous `not_snapshotable` error code) and no-ops cleanly.
3. **`skill push --publish`** — push then snapshot in one step. Suppresses the warning and prints the published confirmation. Rejected (before any request) with `--role` and in plugin/bulk mode.

## Why it's CLI-only

The backend already returns the staged-state signal (`has_unpublished_revisions`, `snapshot_hint`) on push and already exposes `crews_versions take_snapshot`. No app changes. The MCP transport was already unified (`/mcp` + `crews_*`) on main.

## Testing

- 60 unit/integration tests (vitest, real in-process HTTP stub — no mocks), incl. edit/create/`--role` warning variants, no-op detection, `--publish` create/edit routing, `--json` combined payload, `--publish`+`--role` / plugin-mode / `--dry-run` guards, and a live-mode create-publish no-op regression.
- **Live smoke** against a local dev backend: create push → warning; `skill publish` → `published: true`; re-publish → no-op; edit push → warning; `skill push --publish` → published, no warning. All green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)