### PR TITLE
skill run/exec + dev secrets: local dev loop for crew skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ Manage agent skills on the crews SOP surface. `push` is an idempotent upsert (cr
 | `skill run <dir> -- <command...>` | `--crew <nameOrId>`, `--environment <env>` (default `dev`), `--env-file <path>` | Run a skill script LOCALLY with crew variables fetched from the platform (dev loop). Secret values need a token with `env:reveal`; see `skill exec` for the remote/deployed counterpart |
 | `skill exec <name> -- <command...>` | `--role <name>`, `--in-crew <crew>`, `--environment <env>` (default `production`) | Run a command against the DEPLOYED skill in its real sandbox runtime (post-push smoke); see `skill run` for the local dev-loop counterpart |
 
+For `skill run` / `skill exec`, pass the command as separate words after `--` (e.g. `-- python script.py --flag`); to run a single preformed shell string, wrap it explicitly with `sh -c '...'`.
+
 ### role
 
 | Command | Key Flags | Description |

--- a/README.md
+++ b/README.md
@@ -145,11 +145,13 @@ Manage agent skills on the crews SOP surface. `push` is an idempotent upsert (cr
 
 | Command | Key Flags | Description |
 |---------|-----------|-------------|
-| `skill push <dir>` | `--role <name>`, `--dry-run`, `--json` | Push a skill folder, or a whole plugin dir — recursive: pushes every `skills/*/SKILL.md`, converts `commands/*.md` → skills, and ingests each skill's `references/`. `--role` scopes to a role instead of the shared library |
+| `skill push <dir>` | `--role <name>`, `--dry-run`, `--json`, `--force` | Push a skill folder, or a whole plugin dir — recursive: pushes every `skills/*/SKILL.md`, converts `commands/*.md` → skills, and ingests each skill's `references/`. `--role` scopes to a role instead of the shared library. Drift-guarded against the local `.solidactions-skill.json` sidecar revision; `--force` skips the guard |
 | `skill list` | `--json`, `--limit <n>` | List skills in the library |
 | `skill view <name>` | `--json` | Show one skill |
-| `skill pull <name> [dest]` | `--json` | Fetch a skill to a local folder for editing (inverse of push) |
+| `skill pull <name> [dest]` | `--json` | Fetch a skill to a local folder for editing (inverse of push); writes a `.solidactions-skill.json` provenance sidecar used by `push`'s drift guard |
 | `skill delete <name>` | `--json` | Delete a skill (Admin only) |
+| `skill run <dir> -- <command...>` | `--crew <nameOrId>`, `--environment <env>` (default `dev`), `--env-file <path>` | Run a skill script LOCALLY with crew variables fetched from the platform (dev loop). Secret values need a token with `env:reveal`; see `skill exec` for the remote/deployed counterpart |
+| `skill exec <name> -- <command...>` | `--role <name>`, `--in-crew <crew>`, `--environment <env>` (default `production`) | Run a command against the DEPLOYED skill in its real sandbox runtime (post-push smoke); see `skill run` for the local dev-loop counterpart |
 
 ### role
 

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -7,6 +7,7 @@ import yaml from 'js-yaml';
 import { randomUUID } from 'crypto';
 import { createRequire } from 'module';
 import { SolidActionsConfig } from '../utils/env';
+import { Config } from '../utils/config';
 
 // ---------------------------------------------------------------------------
 // runDev — programmatic entry point (testable, no process.exit)
@@ -43,6 +44,39 @@ export interface SaApiClient {
     projectSlug: string;
     /** Fetch declared variable-mappings for the given env from the SA API. */
     fetchVarsAndConnections(env: string): Promise<PlatformVar[]>;
+    /** Set true when the API token lacks `env:reveal` and the reveal request had to fall back. */
+    revealDenied?: boolean;
+}
+
+/**
+ * Build the production `SaApiClient`: fetches `variable-mappings` with
+ * `reveal=true` so secret values are populated on `ctx.vars`. When the token
+ * lacks the `env:reveal` ability, the API responds 403
+ * `{ code: 'token_missing_ability' }` — retry once without `reveal` and mark
+ * `revealDenied` so the caller can tell the user secrets were withheld.
+ */
+export function buildSaApiClient(config: Config, projectSlug: string): SaApiClient {
+    const client: SaApiClient = {
+        projectSlug,
+        revealDenied: false,
+        async fetchVarsAndConnections(_env: string): Promise<PlatformVar[]> {
+            const axios = (await import('axios')).default;
+            const { getApiHeaders } = await import('../utils/api');
+            const base = `${config.host}/api/v1/projects/${projectSlug}/variable-mappings?resolve_oauth=true`;
+            try {
+                const response = await axios.get(`${base}&reveal=true`, { headers: getApiHeaders(config) });
+                return response.data || [];
+            } catch (e: any) {
+                if (e?.response?.status === 403 && e.response.data?.code === 'token_missing_ability') {
+                    client.revealDenied = true;
+                    const response = await axios.get(base, { headers: getApiHeaders(config) });
+                    return response.data || [];
+                }
+                throw e;
+            }
+        },
+    };
+    return client;
 }
 
 /** Structured return value of runDev — never calls process.exit. */
@@ -317,22 +351,11 @@ export async function runDev(opts: RunDevOptions): Promise<RunDevResult> {
             // Production path: build from CLI config.
             // Lazy-import to keep tests fast (no config resolution needed).
             const { requireConfigWithWorkspace } = await import('../utils/api');
-            const { getApiHeaders } = await import('../utils/api');
-            const axios = (await import('axios')).default;
             const config = await requireConfigWithWorkspace();
             // Real project resolution: read the project name from the workflow
             // file's solidactions.yaml and apply the deploy env→slug rule.
             const projectSlug = resolveProjectSlug(opts.entry, opts.env);
-            apiClient = {
-                projectSlug,
-                async fetchVarsAndConnections(_env: string): Promise<PlatformVar[]> {
-                    const response = await axios.get(
-                        `${config.host}/api/v1/projects/${projectSlug}/variable-mappings?resolve_oauth=true`,
-                        { headers: getApiHeaders(config) },
-                    );
-                    return response.data || [];
-                },
-            };
+            apiClient = buildSaApiClient(config, projectSlug);
         }
     }
 
@@ -397,7 +420,11 @@ export async function runDev(opts: RunDevOptions): Promise<RunDevResult> {
             summary += ` (${droppedCount} declared ${droppedCount === 1 ? 'var' : 'vars'} had no value in this env and ${droppedCount === 1 ? 'was' : 'were'} skipped)`;
         }
         if (droppedSecretCount > 0) {
-            summary += ` (${droppedSecretCount} secret ${droppedSecretCount === 1 ? 'var is' : 'vars are'} not available to local dev — set a test value in your dev environment with \`solidactions env set\`, or pass values via \`-i\`.)`;
+            if (apiClient!.revealDenied) {
+                summary += ` — ${droppedSecretCount} secret ${droppedSecretCount === 1 ? 'var' : 'vars'} unavailable: your API key lacks the 'env:reveal' ability. Mint a key with env:reveal, or set a test value with \`solidactions env set\`.`;
+            } else {
+                summary += ` (${droppedSecretCount} secret ${droppedSecretCount === 1 ? 'var is' : 'vars are'} not available to local dev — set a test value in your dev environment with \`solidactions env set\`, or pass values via \`-i\`.)`;
+            }
         }
         out(summary);
     } else {

--- a/src/commands/skill-exec.ts
+++ b/src/commands/skill-exec.ts
@@ -11,6 +11,7 @@ import chalk from 'chalk';
 import { Config } from '../utils/config';
 import { requireConfigWithWorkspace } from '../utils/api';
 import { callCrewsTool } from '../utils/mcp';
+import { shellQuoteArg } from './skill-run';
 
 export interface SkillExecOptions {
     role?: string;
@@ -28,7 +29,7 @@ export async function skillExecWithConfig(
         process.stderr.write(chalk.red('error: no command given — usage: skill exec <name> -- <command...>\n'));
         process.exit(1);
     }
-    const command = commandParts.join(' ');
+    const command = commandParts.map(shellQuoteArg).join(' ');
 
     const isRole = Boolean(options.role);
     const tool = isRole ? 'roles' : 'skills';

--- a/src/commands/skill-exec.ts
+++ b/src/commands/skill-exec.ts
@@ -1,0 +1,66 @@
+/**
+ * solidactions skill exec <name> [--role <r>] [--environment <env>] -- <command...>
+ *
+ * Runs a command against the DEPLOYED skill in its real sandbox runtime via
+ * the crews MCP exec_skill action — the post-push smoke step. Counterpart to
+ * `skill run` (local). DELIBERATE DIVERGENCE from `skill run`: default
+ * environment here is `production` (matches the server default — this is the
+ * "verify deployed" step); `skill run` defaults to `dev` (a local dev loop).
+ */
+import chalk from 'chalk';
+import { Config } from '../utils/config';
+import { requireConfigWithWorkspace } from '../utils/api';
+import { callCrewsTool } from '../utils/mcp';
+
+export interface SkillExecOptions {
+    role?: string;
+    inCrew?: string;
+    environment?: string;
+}
+
+export async function skillExecWithConfig(
+    name: string,
+    commandParts: string[],
+    options: SkillExecOptions,
+    config: Config,
+): Promise<void> {
+    if (commandParts.length === 0) {
+        process.stderr.write(chalk.red('error: no command given — usage: skill exec <name> -- <command...>\n'));
+        process.exit(1);
+    }
+    const command = commandParts.join(' ');
+
+    const isRole = Boolean(options.role);
+    const tool = isRole ? 'roles' : 'skills';
+    const args: Record<string, unknown> = isRole
+        ? { action: 'exec_skill', role: options.role, name, command }
+        : { action: 'exec_skill', identifier: name, command };
+    if (options.environment) args.environment = options.environment;
+    if (isRole && options.inCrew) args.in_crew = options.inCrew;
+
+    let result: Awaited<ReturnType<typeof callCrewsTool>>;
+    try {
+        result = await callCrewsTool(config, tool, args);
+    } catch (e: any) {
+        process.stderr.write(chalk.red(`error: ${e.message}\n`));
+        process.exit(1);
+    }
+
+    if (!result.ok) {
+        const code = result.data?.code ?? 'unknown_error';
+        const message = result.data?.message ?? 'MCP returned an error with no message';
+        process.stderr.write(chalk.red(`error: ${code}: ${message}\n`));
+        process.exit(1);
+    }
+
+    const data = result.data as { stdout?: string; stderr?: string; exit_code?: number; status?: string };
+    if (data.stdout) process.stdout.write(data.stdout.endsWith('\n') ? data.stdout : data.stdout + '\n');
+    if (data.stderr) process.stderr.write(data.stderr.endsWith('\n') ? data.stderr : data.stderr + '\n');
+    process.stderr.write(chalk.blue(`remote exec: status=${data.status ?? 'unknown'} exit_code=${data.exit_code ?? 'unknown'}\n`));
+    process.exit(data.exit_code ?? 1);
+}
+
+export async function skillExec(name: string, commandParts: string[], options: SkillExecOptions): Promise<void> {
+    const config = await requireConfigWithWorkspace();
+    await skillExecWithConfig(name, commandParts, options, config);
+}

--- a/src/commands/skill-pull.ts
+++ b/src/commands/skill-pull.ts
@@ -22,6 +22,9 @@ export interface SkillPullOptions {
     json?: boolean;
 }
 
+/** Filename of the provenance sidecar written alongside a pulled skill. */
+export const SKILL_SIDECAR = '.solidactions-skill.json';
+
 /**
  * Core implementation — accepts an injected config so tests can point at a
  * stub server without touching the filesystem config.
@@ -60,6 +63,7 @@ export async function skillPullWithConfig(
     const data = result.data as {
         identifier: string;
         doc_id: number | string;
+        head_revision_id?: number;
         properties: Record<string, unknown>;
         body: string;
         reference: Record<string, string>;
@@ -135,6 +139,16 @@ export async function skillPullWithConfig(
         fs.writeFileSync(target, content, 'utf8');
         writtenCount++;
     }
+
+    // Write the provenance sidecar so downstream commands (e.g. `skill push`)
+    // can detect drift against the revision this pull was taken from.
+    const sidecar = {
+        identifier: data.identifier,
+        doc_id: typeof data.doc_id === 'string' ? parseInt(data.doc_id, 10) : data.doc_id,
+        head_revision_id: data.head_revision_id ?? null,
+        role: null as string | null,
+    };
+    fs.writeFileSync(path.join(absOut, SKILL_SIDECAR), JSON.stringify(sidecar, null, 2) + '\n', 'utf8');
 
     const refSummary = writtenCount === 1 ? '1 reference' : `${writtenCount} references`;
     console.log(chalk.green(`pulled skill '${name}' → ${out} (${refSummary})`));

--- a/src/commands/skill-pull.ts
+++ b/src/commands/skill-pull.ts
@@ -63,7 +63,7 @@ export async function skillPullWithConfig(
     const data = result.data as {
         identifier: string;
         doc_id: number | string;
-        head_revision_id?: number;
+        head_revision_id?: number | string;
         properties: Record<string, unknown>;
         body: string;
         reference: Record<string, string>;
@@ -145,7 +145,7 @@ export async function skillPullWithConfig(
     const sidecar = {
         identifier: data.identifier,
         doc_id: typeof data.doc_id === 'string' ? parseInt(data.doc_id, 10) : data.doc_id,
-        head_revision_id: data.head_revision_id ?? null,
+        head_revision_id: typeof data.head_revision_id === 'string' ? parseInt(data.head_revision_id, 10) : (data.head_revision_id ?? null),
         role: null as string | null,
     };
     fs.writeFileSync(path.join(absOut, SKILL_SIDECAR), JSON.stringify(sidecar, null, 2) + '\n', 'utf8');

--- a/src/commands/skill-push.ts
+++ b/src/commands/skill-push.ts
@@ -112,6 +112,11 @@ export function parseSkillFile(content: string): {
  * keep a bare-filename key (e.g. "helper.py"), and files in subfolders keep
  * their relative path (e.g. "references/member-roles.md") — matching how
  * SKILL.md cites them, so bundled reference docs land complete (#247).
+ *
+ * Also excludes `skill pull`'s provenance sidecar (SKILL_SIDECAR) and
+ * `skill run`'s local runtime-state dir (.sa-state/) — neither is skill
+ * content, and uploading them would leak local revision bookkeeping / state
+ * into the remote library and agent sandboxes.
  */
 export function readReferences(dir: string): Record<string, string> {
     const references: Record<string, string> = {};
@@ -120,6 +125,7 @@ export function readReferences(dir: string): Record<string, string> {
         for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
             const abs = path.join(current, entry.name);
             if (entry.isDirectory()) {
+                if (entry.name === '.sa-state') continue; // skill run's local runtime-state dir
                 walk(abs);
                 continue;
             }
@@ -128,6 +134,7 @@ export function readReferences(dir: string): Record<string, string> {
             // POSIX-normalised path relative to the skill dir, used as the key.
             const key = path.relative(dir, abs).split(path.sep).join('/');
             if (key === 'SKILL.md') continue; // exclude only the top-level skill file
+            if (key === SKILL_SIDECAR) continue; // exclude the skill pull provenance sidecar
 
             references[key] = fs.readFileSync(abs, 'utf8');
         }
@@ -411,12 +418,21 @@ function readSidecar(dir: string): Record<string, unknown> | null {
 }
 
 /**
- * After a successful guarded edit, refresh the local sidecar's head_revision_id
- * so the *next* push's drift check is against the version we just wrote, not the
- * stale one from the original pull. Prefers the revision id carried on the edit
- * response; falls back to one skills.read (or roles.read_skill for --role) when
- * the response doesn't carry one. Best-effort: a failed lookup just leaves the
- * sidecar as-is rather than failing the push (which already succeeded).
+ * After a successful guarded edit or a create, refresh the local sidecar's
+ * head_revision_id so the *next* push's drift check is against the version we
+ * just wrote, not a stale one from the original pull. Prefers the revision id
+ * carried on the response; falls back to one skills.read (or roles.read_skill
+ * for --role) when the response doesn't carry one.
+ *
+ * On 'created' specifically, a lookup miss clears head_revision_id to null
+ * rather than leaving the sidecar's old value in place: 'created' means the
+ * name didn't collide, so this is either a brand-new skill or a remote
+ * delete+recreate — either way the old revision id belongs to a different
+ * (possibly now-deleted) document, and sending it as base_version_id on a
+ * future edit would false-positive the concurrent_edit drift guard.
+ *
+ * Best-effort otherwise: a failed lookup on the 'updated' path just leaves
+ * the sidecar as-is rather than failing the push (which already succeeded).
  */
 async function refreshSidecarRevision(
     dir: string,
@@ -443,7 +459,7 @@ async function refreshSidecarRevision(
         }
     }
 
-    if (headRevisionId === null) {
+    if (headRevisionId === null && pushResult.status !== 'created') {
         return;
     }
 
@@ -500,7 +516,7 @@ export async function skillPushWithConfig(
             process.exit(1);
         }
 
-        if (sidecar && pushResult.status === 'updated') {
+        if (sidecar && (pushResult.status === 'updated' || pushResult.status === 'created')) {
             await refreshSidecarRevision(absDir, sidecar, pushResult, options, config);
         }
 

--- a/src/commands/skill-push.ts
+++ b/src/commands/skill-push.ts
@@ -17,12 +17,14 @@ import { Config } from '../utils/config';
 import { requireConfigWithWorkspace } from '../utils/api';
 import { callCrewsTool } from '../utils/mcp';
 import { publishSkillByName, publishSkillByDocId, emitPublishOutcome, PublishOutcome } from '../utils/skill-snapshot';
+import { SKILL_SIDECAR } from './skill-pull';
 
 export interface SkillPushOptions {
     role?: string;
     json?: boolean;
     dryRun?: boolean;
     publish?: boolean;
+    force?: boolean;
 }
 
 /**
@@ -234,11 +236,19 @@ export function parseCommandFile(filename: string, content: string): SkillPayloa
  * When options.dryRun is true, performs only a skills.read pre-flight and
  * returns {status:'would-create'} or {status:'would-update'} without any
  * create or edit call.
+ *
+ * sidecarRevision (edit path only): the pulled skill's last-known head_revision_id
+ * (from the local .solidactions-skill.json sidecar), sent as base_version_id so the
+ * server can detect drift. undefined = no sidecar (nothing to guard); null = sidecar
+ * present but never published. Ignored when options.force is set. On a concurrent_edit
+ * response, throws a message naming the remote's current_revision_id, the local base,
+ * and --force as the override.
  */
 export async function pushParsedSkill(
     payload: SkillPayload,
     options: SkillPushOptions,
     config: Config,
+    sidecarRevision?: number | null,
 ): Promise<PushResult> {
     const { name, description, properties, body, references } = payload;
     assertNoReservedFrontmatterKeys(properties);
@@ -290,9 +300,10 @@ export async function pushParsedSkill(
 
     // On name collision, switch to the edit path.
     if (!result.ok && result.data?.code === 'name_collision') {
+        const guardBaseVersion = sidecarRevision != null && !options.force;
         const editArgs: Record<string, unknown> = isRole
-            ? { ...properties, action: 'edit_skill', role: options.role, name, description, body, references }
-            : { ...properties, action: 'edit', identifier: name, description, body, references };
+            ? { ...properties, action: 'edit_skill', role: options.role, name, description, body, references, ...(guardBaseVersion ? { base_version_id: sidecarRevision } : {}) }
+            : { ...properties, action: 'edit', identifier: name, description, body, references, ...(guardBaseVersion ? { base_version_id: sidecarRevision } : {}) };
 
         try {
             result = await callCrewsTool(config, tool, editArgs);
@@ -303,6 +314,12 @@ export async function pushParsedSkill(
         if (!result.ok) {
             const errData = result.data;
             const errCode = errData?.code ?? 'unknown_error';
+            if (errCode === 'concurrent_edit') {
+                const currentRevisionId = errData?.current_revision_id;
+                throw new Error(
+                    `remote skill changed since your pull (their revision ${currentRevisionId}, your base ${sidecarRevision}) — re-pull to merge, or pass --force to overwrite`,
+                );
+            }
             const errMsg = errData?.message ?? 'MCP returned an error with no message';
             throw new Error(`${errCode}: ${errMsg}`);
         }
@@ -378,6 +395,63 @@ export function stagedPushWarning(result: PushResult, isRole: boolean): string |
 }
 
 /**
+ * Read the local provenance sidecar (written by `skill pull`), if present.
+ * Returns null when absent, or unreadable/malformed — nothing to guard against on push.
+ */
+function readSidecar(dir: string): Record<string, unknown> | null {
+    const sidecarPath = path.join(dir, SKILL_SIDECAR);
+    if (!fs.existsSync(sidecarPath)) {
+        return null;
+    }
+    try {
+        return JSON.parse(fs.readFileSync(sidecarPath, 'utf8'));
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * After a successful guarded edit, refresh the local sidecar's head_revision_id
+ * so the *next* push's drift check is against the version we just wrote, not the
+ * stale one from the original pull. Prefers the revision id carried on the edit
+ * response; falls back to one skills.read (or roles.read_skill for --role) when
+ * the response doesn't carry one. Best-effort: a failed lookup just leaves the
+ * sidecar as-is rather than failing the push (which already succeeded).
+ */
+async function refreshSidecarRevision(
+    dir: string,
+    sidecar: Record<string, unknown>,
+    pushResult: PushResult,
+    options: SkillPushOptions,
+    config: Config,
+): Promise<void> {
+    const fromResponse = pushResult.data.head_revision_id ?? pushResult.data.version_id;
+    let headRevisionId: number | null = typeof fromResponse === 'number' ? fromResponse : null;
+
+    if (headRevisionId === null) {
+        const isRole = !!options.role;
+        const readArgs: Record<string, unknown> = isRole
+            ? { action: 'read_skill', role: options.role, name: pushResult.name }
+            : { action: 'read', identifier: pushResult.name };
+        try {
+            const readResult = await callCrewsTool(config, isRole ? 'roles' : 'skills', readArgs);
+            if (readResult.ok && typeof readResult.data?.head_revision_id === 'number') {
+                headRevisionId = readResult.data.head_revision_id;
+            }
+        } catch {
+            // Best-effort refresh — leave the sidecar stale rather than failing the push.
+        }
+    }
+
+    if (headRevisionId === null) {
+        return;
+    }
+
+    const updated = { ...sidecar, head_revision_id: headRevisionId };
+    fs.writeFileSync(path.join(dir, SKILL_SIDECAR), JSON.stringify(updated, null, 2) + '\n', 'utf8');
+}
+
+/**
  * Core implementation — accepts an injected config so tests can point at a
  * stub server without touching the filesystem config.
  *
@@ -415,12 +489,19 @@ export async function skillPushWithConfig(
             process.exit(1);
         }
 
+        const sidecar = readSidecar(absDir);
+        const sidecarRevision = sidecar ? ((sidecar.head_revision_id as number | null) ?? null) : undefined;
+
         let pushResult: PushResult;
         try {
-            pushResult = await pushParsedSkill(payload, options, config);
+            pushResult = await pushParsedSkill(payload, options, config, sidecarRevision);
         } catch (e: any) {
             process.stderr.write(chalk.red(`error: ${e.message}\n`));
             process.exit(1);
+        }
+
+        if (sidecar && pushResult.status === 'updated') {
+            await refreshSidecarRevision(absDir, sidecar, pushResult, options, config);
         }
 
         // Optionally publish (snapshot) the just-pushed revision (single-skill mode).

--- a/src/commands/skill-run.ts
+++ b/src/commands/skill-run.ts
@@ -36,7 +36,7 @@ function isReservedEnvName(name: string): boolean {
  * each word individually keeps it intact as a single shell token, while
  * still letting `shell: true` run multi-word commands.
  */
-function shellQuoteArg(arg: string): string {
+export function shellQuoteArg(arg: string): string {
     return `'${arg.replace(/'/g, `'\\''`)}'`;
 }
 

--- a/src/commands/skill-run.ts
+++ b/src/commands/skill-run.ts
@@ -81,7 +81,7 @@ export function assembleEnv(opts: {
             continue;
         }
         if (key in env) {
-            warnings.push(`env-file override shadows platform var: ${key}`);
+            warnings.push(`env-file override shadows crew variable: ${key}`);
         }
         env[key] = value;
     }
@@ -144,7 +144,7 @@ export async function skillRunWithConfig(
                 `${config.host}/api/v1/crews/${crew.id}/variables/resolve?environment=${encodeURIComponent(environment)}`,
                 { headers: getApiHeaders(config) },
             );
-            resolved = response.data?.env ?? {};
+            resolved = response.data?.variables ?? {};
             skippedSecrets = response.data?.skipped_secrets ?? [];
         } catch (e: any) {
             process.stderr.write(chalk.red(`error: failed to resolve crew variables: ${e?.response?.data?.message ?? e.message}\n`));

--- a/src/commands/skill-run.ts
+++ b/src/commands/skill-run.ts
@@ -65,7 +65,15 @@ export function assembleEnv(opts: {
     config: Config;
 }): { env: Record<string, string>; warnings: string[] } {
     const warnings: string[] = [];
-    const env: Record<string, string> = { ...opts.resolved };
+    const env: Record<string, string> = {};
+
+    for (const [key, value] of Object.entries(opts.resolved)) {
+        if (isReservedEnvName(key)) {
+            warnings.push(`crew variable '${key}' is reserved (set by the platform at runtime) — ignored`);
+            continue;
+        }
+        env[key] = value;
+    }
 
     for (const [key, value] of Object.entries(opts.fileVars)) {
         if (isReservedEnvName(key)) {
@@ -95,7 +103,7 @@ function readStorageScope(dir: string): string | null {
     const skillMd = path.join(dir, 'SKILL.md');
     if (!fs.existsSync(skillMd)) return null;
     const content = fs.readFileSync(skillMd, 'utf8');
-    const match = content.match(/^---\n([\s\S]*?)\n---/);
+    const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
     if (!match) return null;
     const fm = yaml.load(match[1]) as Record<string, any> | null;
     const scope = fm?.storage?.scope ?? fm?.['storage.scope'] ?? null;
@@ -133,7 +141,7 @@ export async function skillRunWithConfig(
         const crew = await resolveCrewId(config, options.crew);
         try {
             const response = await axios.get(
-                `${config.host}/api/v1/crews/${crew.id}/variables/resolve?environment=${environment}`,
+                `${config.host}/api/v1/crews/${crew.id}/variables/resolve?environment=${encodeURIComponent(environment)}`,
                 { headers: getApiHeaders(config) },
             );
             resolved = response.data?.env ?? {};

--- a/src/commands/skill-run.ts
+++ b/src/commands/skill-run.ts
@@ -1,0 +1,178 @@
+/**
+ * solidactions skill run <dir> [--crew <c>] [--environment <env>] [--env-file <f>] -- <command...>
+ *
+ * Local analogue of the crews MCP exec_skill: runs <command> with cwd=<dir>
+ * (matching the sandbox's cwd=/work/skills/<slug>), with crew variables
+ * fetched at runtime from /api/v1/crews/{id}/variables/resolve. Secrets are
+ * included only when the API key holds env:reveal; skipped names are printed.
+ * DELIBERATE DIVERGENCE from remote exec_skill: default environment is `dev`
+ * (this is a dev tool); remote defaults to production. Always prints the env.
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { spawnSync } from 'child_process';
+import axios from 'axios';
+import chalk from 'chalk';
+import yaml from 'js-yaml';
+import { Config } from '../utils/config';
+import { getApiHeaders, requireConfigWithWorkspace } from '../utils/api';
+import { resolveCrewId } from '../utils/crew';
+
+const RESERVED_KEYS = ['WORKFLOW_INPUT', 'WORKFLOW_INPUT_URL', 'STEPS_TRIGGER_ID', 'TENANT_ID', 'SA_PROXY_URL', 'SA_PROXY_TOKEN', 'WORKFLOW_SLUG', 'PATH', 'HOME'];
+const RESERVED_PREFIXES = ['SOLIDACTIONS_'];
+
+function isReservedEnvName(name: string): boolean {
+    return RESERVED_KEYS.includes(name) || RESERVED_PREFIXES.some((p) => name.toUpperCase().startsWith(p));
+}
+
+/**
+ * Single-quote a commander-parsed argument for re-injection into a shell
+ * command line. commander's `<command...>` variadic already split the
+ * user's invocation into discrete argv words (the outer shell did any
+ * quote-stripping); joining those words back together with bare spaces and
+ * handing them to `sh -c` would let the inner shell reinterpret any
+ * metacharacters they contain (spaces, quotes, parens, `&&`, ...). Quoting
+ * each word individually keeps it intact as a single shell token, while
+ * still letting `shell: true` run multi-word commands.
+ */
+function shellQuoteArg(arg: string): string {
+    return `'${arg.replace(/'/g, `'\\''`)}'`;
+}
+
+export function parseEnvFile(content: string): Record<string, string> {
+    const out: Record<string, string> = {};
+    for (const raw of content.split('\n')) {
+        const line = raw.trim();
+        if (!line || line.startsWith('#')) continue;
+        const eq = line.indexOf('=');
+        if (eq <= 0) continue;
+        const key = line.slice(0, eq).trim();
+        let value = line.slice(eq + 1).trim();
+        if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+            value = value.slice(1, -1);
+        }
+        out[key] = value;
+    }
+    return out;
+}
+
+export function assembleEnv(opts: {
+    resolved: Record<string, string>;
+    fileVars: Record<string, string>;
+    storageScope: string | null;
+    dir: string;
+    config: Config;
+}): { env: Record<string, string>; warnings: string[] } {
+    const warnings: string[] = [];
+    const env: Record<string, string> = { ...opts.resolved };
+
+    for (const [key, value] of Object.entries(opts.fileVars)) {
+        if (isReservedEnvName(key)) {
+            warnings.push(`env-file key '${key}' is reserved (set by the platform at runtime) — ignored`);
+            continue;
+        }
+        if (key in env) {
+            warnings.push(`env-file override shadows platform var: ${key}`);
+        }
+        env[key] = value;
+    }
+
+    if (opts.storageScope === 'crew') {
+        env.SOLIDACTIONS_STATE_DIR = path.join(opts.dir, '.sa-state');
+    } else if (opts.storageScope === 'workspace') {
+        env.SOLIDACTIONS_SHARED_DIR = path.join(os.homedir(), '.solidactions', 'shared', opts.config.workspaceId ?? 'default');
+    }
+
+    env.SOLIDACTIONS_API_URL = `${opts.config.host}/api/v1`;
+    env.SOLIDACTIONS_API_TOKEN = opts.config.apiKey;
+    env.SOLIDACTIONS_WORKSPACE_ID = opts.config.workspaceId ?? '';
+
+    return { env, warnings };
+}
+
+function readStorageScope(dir: string): string | null {
+    const skillMd = path.join(dir, 'SKILL.md');
+    if (!fs.existsSync(skillMd)) return null;
+    const content = fs.readFileSync(skillMd, 'utf8');
+    const match = content.match(/^---\n([\s\S]*?)\n---/);
+    if (!match) return null;
+    const fm = yaml.load(match[1]) as Record<string, any> | null;
+    const scope = fm?.storage?.scope ?? fm?.['storage.scope'] ?? null;
+    return scope === 'crew' || scope === 'workspace' ? scope : null;
+}
+
+export interface SkillRunOptions {
+    crew?: string;
+    environment?: string;
+    envFile?: string;
+}
+
+export async function skillRunWithConfig(
+    dir: string,
+    commandParts: string[],
+    options: SkillRunOptions,
+    config: Config,
+): Promise<void> {
+    const absDir = path.resolve(dir);
+    if (!fs.existsSync(path.join(absDir, 'SKILL.md'))) {
+        process.stderr.write(chalk.red(`error: ${dir} does not contain a SKILL.md\n`));
+        process.exit(1);
+    }
+    if (commandParts.length === 0) {
+        process.stderr.write(chalk.red('error: no command given — usage: skill run <dir> -- <command...>\n'));
+        process.exit(1);
+    }
+
+    const environment = options.environment ?? 'dev';
+
+    // Crew vars: --crew wins; else no crew vars (shared-skill parity).
+    let resolved: Record<string, string> = {};
+    let skippedSecrets: string[] = [];
+    if (options.crew) {
+        const crew = await resolveCrewId(config, options.crew);
+        try {
+            const response = await axios.get(
+                `${config.host}/api/v1/crews/${crew.id}/variables/resolve?environment=${environment}`,
+                { headers: getApiHeaders(config) },
+            );
+            resolved = response.data?.env ?? {};
+            skippedSecrets = response.data?.skipped_secrets ?? [];
+        } catch (e: any) {
+            process.stderr.write(chalk.red(`error: failed to resolve crew variables: ${e?.response?.data?.message ?? e.message}\n`));
+            process.exit(1);
+        }
+    } else {
+        process.stderr.write(chalk.gray('no --crew given — running without crew variables (shared-skill parity)\n'));
+    }
+
+    const fileVars = options.envFile ? parseEnvFile(fs.readFileSync(path.resolve(options.envFile), 'utf8')) : {};
+    const storageScope = readStorageScope(absDir);
+    const { env, warnings } = assembleEnv({ resolved, fileVars, storageScope, dir: absDir, config });
+
+    for (const w of warnings) process.stderr.write(chalk.yellow(`warn: ${w}\n`));
+    if (env.SOLIDACTIONS_STATE_DIR) fs.mkdirSync(env.SOLIDACTIONS_STATE_DIR, { recursive: true });
+    if (env.SOLIDACTIONS_SHARED_DIR) fs.mkdirSync(env.SOLIDACTIONS_SHARED_DIR, { recursive: true });
+
+    const plainCount = Object.keys(resolved).length;
+    process.stderr.write(chalk.blue(`running locally in ${dir} — env '${environment}', ${plainCount} crew vars loaded\n`));
+    if (skippedSecrets.length > 0) {
+        process.stderr.write(chalk.yellow(
+            `${skippedSecrets.length} secret ${skippedSecrets.length === 1 ? 'var' : 'vars'} unavailable (${skippedSecrets.join(', ')}): ` +
+            `your API key lacks the 'env:reveal' ability. Mint a key with env:reveal, set a dev value with \`solidactions crew env set\`, or use --env-file.\n`,
+        ));
+    }
+
+    const result = spawnSync(commandParts.map(shellQuoteArg).join(' '), {
+        shell: true,
+        cwd: absDir,
+        stdio: 'inherit',
+        env: { ...process.env, ...env },
+    });
+    process.exit(result.status ?? 1);
+}
+
+export async function skillRun(dir: string, commandParts: string[], options: SkillRunOptions): Promise<void> {
+    const config = await requireConfigWithWorkspace();
+    await skillRunWithConfig(dir, commandParts, options, config);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ import { skillPull } from './commands/skill-pull';
 import { skillList } from './commands/skill-list';
 import { skillView } from './commands/skill-view';
 import { skillDelete } from './commands/skill-delete';
+import { skillRun } from './commands/skill-run';
 import { rolePush } from './commands/role-push';
 import { docsPush } from './commands/docs-push';
 import { docsUpload } from './commands/docs-upload';
@@ -615,6 +616,18 @@ skill
     .option('--json', 'Output as JSON')
     .action(async (name, options) => {
         await skillDelete(name, options);
+    });
+
+skill
+    .command('run')
+    .description('Run a skill script LOCALLY with crew variables fetched from the platform (dev loop; secrets need env:reveal)')
+    .argument('<dir>', 'Local skill directory (must contain SKILL.md)')
+    .argument('<command...>', 'Command to run (after --), e.g. -- node scripts/q.js')
+    .option('--crew <nameOrId>', 'Crew whose variables to fetch (omit for shared skills)')
+    .option('--environment <env>', 'Variable environment: production|staging|dev', 'dev')
+    .option('--env-file <path>', 'Local KEY=VALUE overrides (reserved names ignored)')
+    .action(async (dir, commandParts, options) => {
+        await skillRun(dir, commandParts, options);
     });
 
 // =============================================================================

--- a/src/index.ts
+++ b/src/index.ts
@@ -568,6 +568,7 @@ skill
     .option('--json', 'Output result as JSON')
     .option('--dry-run', 'Preview create vs update without writing')
     .option('--publish', 'Publish (snapshot) the skill after pushing, making it live for agents')
+    .option('--force', 'Skip the drift guard: push without checking the remote against your local sidecar revision')
     .action(async (dir, options) => {
         await skillPush(dir, options);
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ import { skillList } from './commands/skill-list';
 import { skillView } from './commands/skill-view';
 import { skillDelete } from './commands/skill-delete';
 import { skillRun } from './commands/skill-run';
+import { skillExec } from './commands/skill-exec';
 import { rolePush } from './commands/role-push';
 import { docsPush } from './commands/docs-push';
 import { docsUpload } from './commands/docs-upload';
@@ -620,7 +621,7 @@ skill
 
 skill
     .command('run')
-    .description('Run a skill script LOCALLY with crew variables fetched from the platform (dev loop; secrets need env:reveal)')
+    .description('Run a skill script LOCALLY with crew variables fetched from the platform (dev loop; default env dev; secrets need env:reveal; see `skill exec` for the remote/deployed counterpart, default env production)')
     .argument('<dir>', 'Local skill directory (must contain SKILL.md)')
     .argument('<command...>', 'Command to run (after --), e.g. -- node scripts/q.js')
     .option('--crew <nameOrId>', 'Crew whose variables to fetch (omit for shared skills)')
@@ -628,6 +629,18 @@ skill
     .option('--env-file <path>', 'Local KEY=VALUE overrides (reserved names ignored)')
     .action(async (dir, commandParts, options) => {
         await skillRun(dir, commandParts, options);
+    });
+
+skill
+    .command('exec')
+    .description('Run a command against the DEPLOYED skill in its real sandbox runtime (post-push smoke; default env production; see `skill run` for the local dev-loop counterpart, default env dev)')
+    .argument('<name>', 'Skill name or identifier')
+    .argument('<command...>', 'Command to run remotely (after --), e.g. -- node scripts/q.js')
+    .option('--role <name>', 'Role-scoped skill (uses roles.exec_skill)')
+    .option('--in-crew <crew>', 'Disambiguate when the role name exists in multiple crews')
+    .option('--environment <env>', 'Sandbox environment: production|staging|dev (default production)')
+    .action(async (name, commandParts, options) => {
+        await skillExec(name, commandParts, options);
     });
 
 // =============================================================================

--- a/tests/dev-reveal.test.ts
+++ b/tests/dev-reveal.test.ts
@@ -1,8 +1,11 @@
 import http from 'http';
+import * as path from 'path';
 import { AddressInfo } from 'net';
 import { describe, it, expect, afterEach } from 'vitest';
-import { buildSaApiClient } from '../src/commands/dev';
+import { buildSaApiClient, runDev, type PlatformVar } from '../src/commands/dev';
 import { Config } from '../src/utils/config';
+
+const ECHO_FIXTURE = path.resolve(__dirname, '../fixtures/echo.ts');
 
 let server: http.Server | null = null;
 afterEach(() => new Promise<void>((r) => (server ? server.close(() => r()) : r())));
@@ -73,4 +76,26 @@ describe('buildSaApiClient reveal behavior', () => {
         const client = buildSaApiClient(cfg(host), 'my-proj');
         await expect(client.fetchVarsAndConnections('dev')).rejects.toThrow();
     });
+});
+
+describe('runDev', () => {
+    it('reports secrets withheld for lacking env:reveal distinctly from a genuinely unset secret', async () => {
+        const out = await runDev({
+            entry: ECHO_FIXTURE,
+            input: '{"n":1}',
+            env: 'staging',
+            api: {
+                projectSlug: 'test-project-staging',
+                revealDenied: true,
+                async fetchVarsAndConnections(): Promise<PlatformVar[]> {
+                    return [
+                        { env_name: 'SECRET_VAR', resolved_value: null, is_secret: true, source_type: 'plain' },
+                    ];
+                },
+            },
+        });
+
+        expect(out.stdout).toMatch(/1 secret var unavailable: your API key lacks the 'env:reveal' ability/);
+        expect(out.stdout).not.toMatch(/not available to local dev/);
+    }, 20_000);
 });

--- a/tests/dev-reveal.test.ts
+++ b/tests/dev-reveal.test.ts
@@ -1,0 +1,76 @@
+import http from 'http';
+import { AddressInfo } from 'net';
+import { describe, it, expect, afterEach } from 'vitest';
+import { buildSaApiClient } from '../src/commands/dev';
+import { Config } from '../src/utils/config';
+
+let server: http.Server | null = null;
+afterEach(() => new Promise<void>((r) => (server ? server.close(() => r()) : r())));
+
+function startServer(handler: http.RequestListener): Promise<string> {
+    return new Promise((resolve) => {
+        server = http.createServer(handler);
+        server.listen(0, '127.0.0.1', () => {
+            const { port } = server!.address() as AddressInfo;
+            resolve(`http://127.0.0.1:${port}`);
+        });
+    });
+}
+
+function cfg(host: string): Config {
+    return { host, apiKey: 'test-api-key', workspaceId: 'ws-123' } as Config;
+}
+
+describe('buildSaApiClient reveal behavior', () => {
+    it('requests reveal=true and returns secret values when permitted', async () => {
+        const seen: string[] = [];
+        const host = await startServer((req, res) => {
+            seen.push(req.url!);
+            res.setHeader('content-type', 'application/json');
+            res.end(JSON.stringify([
+                { env_name: 'SECRET_VAR', is_secret: true, source_type: 'local', resolved_value: 's3cret' },
+            ]));
+        });
+
+        const client = buildSaApiClient(cfg(host), 'my-proj');
+        const vars = await client.fetchVarsAndConnections('dev');
+
+        expect(seen[0]).toContain('reveal=true');
+        expect(vars[0].resolved_value).toBe('s3cret');
+    });
+
+    it('falls back without reveal on 403 token_missing_ability', async () => {
+        const seen: string[] = [];
+        const host = await startServer((req, res) => {
+            seen.push(req.url!);
+            res.setHeader('content-type', 'application/json');
+            if (req.url!.includes('reveal=true')) {
+                res.statusCode = 403;
+                res.end(JSON.stringify({ code: 'token_missing_ability', required_ability: 'env:reveal' }));
+                return;
+            }
+            res.end(JSON.stringify([
+                { env_name: 'SECRET_VAR', is_secret: true, source_type: 'local', resolved_value: null },
+            ]));
+        });
+
+        const client = buildSaApiClient(cfg(host), 'my-proj');
+        const vars = await client.fetchVarsAndConnections('dev');
+
+        expect(seen).toHaveLength(2);
+        expect(seen[1]).not.toContain('reveal=true');
+        expect(vars[0].resolved_value).toBeNull();
+        expect(client.revealDenied).toBe(true);
+    });
+
+    it('rethrows non-ability 403s', async () => {
+        const host = await startServer((_req, res) => {
+            res.statusCode = 403;
+            res.setHeader('content-type', 'application/json');
+            res.end(JSON.stringify({ code: 'workspace_forbidden' }));
+        });
+
+        const client = buildSaApiClient(cfg(host), 'my-proj');
+        await expect(client.fetchVarsAndConnections('dev')).rejects.toThrow();
+    });
+});

--- a/tests/dev.test.ts
+++ b/tests/dev.test.ts
@@ -192,6 +192,26 @@ describe('runDev', () => {
         expect(out.stdout).not.toMatch(/had no value/);
     }, 20_000);
 
+    it('reports secrets withheld for lacking env:reveal distinctly from a genuinely unset secret', async () => {
+        const out = await runDev({
+            entry: ECHO_FIXTURE,
+            input: '{"n":1}',
+            env: 'staging',
+            api: {
+                projectSlug: 'test-project-staging',
+                revealDenied: true,
+                async fetchVarsAndConnections(): Promise<PlatformVar[]> {
+                    return [
+                        { env_name: 'SECRET_VAR', resolved_value: null, is_secret: true, source_type: 'plain' },
+                    ];
+                },
+            },
+        });
+
+        expect(out.stdout).toMatch(/1 secret var unavailable: your API key lacks the 'env:reveal' ability/);
+        expect(out.stdout).not.toMatch(/not available to local dev/);
+    }, 20_000);
+
     it('prints an npm-install hint (not a raw stack trace) when the SDK cannot be resolved', async () => {
         // A fixture entry OUTSIDE this repo's tree has no node_modules ancestor
         // containing @solidactions/sdk, so require.resolve(...) genuinely fails —

--- a/tests/dev.test.ts
+++ b/tests/dev.test.ts
@@ -192,26 +192,6 @@ describe('runDev', () => {
         expect(out.stdout).not.toMatch(/had no value/);
     }, 20_000);
 
-    it('reports secrets withheld for lacking env:reveal distinctly from a genuinely unset secret', async () => {
-        const out = await runDev({
-            entry: ECHO_FIXTURE,
-            input: '{"n":1}',
-            env: 'staging',
-            api: {
-                projectSlug: 'test-project-staging',
-                revealDenied: true,
-                async fetchVarsAndConnections(): Promise<PlatformVar[]> {
-                    return [
-                        { env_name: 'SECRET_VAR', resolved_value: null, is_secret: true, source_type: 'plain' },
-                    ];
-                },
-            },
-        });
-
-        expect(out.stdout).toMatch(/1 secret var unavailable: your API key lacks the 'env:reveal' ability/);
-        expect(out.stdout).not.toMatch(/not available to local dev/);
-    }, 20_000);
-
     it('prints an npm-install hint (not a raw stack trace) when the SDK cannot be resolved', async () => {
         // A fixture entry OUTSIDE this repo's tree has no node_modules ancestor
         // containing @solidactions/sdk, so require.resolve(...) genuinely fails —

--- a/tests/skill-exec.test.ts
+++ b/tests/skill-exec.test.ts
@@ -163,7 +163,7 @@ describe('skillExecWithConfig — shared skill (no --role)', () => {
         expect(body.params.name).toBe('crews_skills');
         expect(body.params.arguments.action).toBe('exec_skill');
         expect(body.params.arguments.identifier).toBe('my-skill');
-        expect(body.params.arguments.command).toBe('node scripts/q.js');
+        expect(body.params.arguments.command).toBe("'node' 'scripts/q.js'");
     });
 });
 
@@ -209,6 +209,17 @@ describe('skillExecWithConfig — options passthrough', () => {
     it('does not send in_crew when --role is absent, even if inCrew is set', async () => {
         await run('my-skill', ['echo', 'hi'], { inCrew: 'crew-a' });
         expect(lastCapture!.body.params.arguments).not.toHaveProperty('in_crew');
+    });
+});
+
+describe('skillExecWithConfig — command quoting', () => {
+    it('shell-quotes each command word before joining into params.arguments.command, so shell metacharacters in an argv word (e.g. parens in a `node -e` script) survive the remote shell unmangled', async () => {
+        const { code } = await run('my-skill', ['node', '-e', 'console.log(42)'], {});
+
+        expect(code).toBe(0);
+        // Matches shellQuoteArg's single-quote-every-word behavior in skill-run.ts:
+        // each word wrapped in '...', embedded single quotes escaped as '\''.
+        expect(lastCapture!.body.params.arguments.command).toBe("'node' '-e' 'console.log(42)'");
     });
 });
 

--- a/tests/skill-exec.test.ts
+++ b/tests/skill-exec.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Tests for `solidactions skill exec <name> -- <command...>`.
+ *
+ * Test-double policy: no mock/spy/stub libraries. Uses a real in-process HTTP
+ * server (Node's http.createServer) to stub the unified /mcp endpoint —
+ * matching the pattern in tests/skill-push.test.ts.
+ *
+ * Unlike `skill run` (tests/skill-run.test.ts), which spawns the built CLI
+ * binary because production code uses `stdio: 'inherit'` (unobservable via a
+ * JS-level monkeypatch), `skill exec` writes remote stdout/stderr via
+ * `process.stdout.write` / `process.stderr.write` directly. That makes the
+ * in-process pattern (patchProcessExit + captured writes) sufficient here —
+ * no subprocess needed.
+ */
+import * as http from 'http';
+import { describe, expect, it, beforeAll, afterAll, beforeEach } from 'vitest';
+import { skillExecWithConfig } from '../src/commands/skill-exec';
+import type { Config } from '../src/utils/config';
+
+interface CapturedRequest {
+    method: string | undefined;
+    path: string | undefined;
+    headers: http.IncomingHttpHeaders;
+    body: any;
+}
+
+let stubServer: http.Server;
+let stubPort: number;
+let lastCapture: CapturedRequest | null = null;
+
+/** Canned MCP success response. */
+function makeMcpSuccess(toolData: object): string {
+    return JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        result: {
+            isError: false,
+            content: [{ type: 'text', text: JSON.stringify(toolData) }],
+        },
+    });
+}
+
+/** Canned MCP error response (isError: true). */
+function makeMcpError(code: string, message: string): string {
+    return JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        result: {
+            isError: true,
+            content: [{ type: 'text', text: JSON.stringify({ code, message }) }],
+        },
+    });
+}
+
+// Server state — a FIFO queue of canned responses; falls back to a default success.
+const DEFAULT_RESPONSE = makeMcpSuccess({ stdout: 'hi', stderr: '', exit_code: 0, status: 'ok' });
+let responseQueue: string[] = [];
+
+function nextResponseBody(): string {
+    return responseQueue.length > 0 ? responseQueue.shift()! : DEFAULT_RESPONSE;
+}
+
+beforeAll(async () => {
+    stubServer = http.createServer((req, res) => {
+        let rawBody = '';
+        req.on('data', (chunk) => { rawBody += chunk; });
+        req.on('end', () => {
+            let parsedBody: any = null;
+            try { parsedBody = JSON.parse(rawBody); } catch { /* ignore */ }
+
+            lastCapture = { method: req.method, path: req.url, headers: req.headers, body: parsedBody };
+
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(nextResponseBody());
+        });
+    });
+
+    await new Promise<void>((resolve) => {
+        stubServer.listen(0, '127.0.0.1', () => {
+            stubPort = (stubServer.address() as { port: number }).port;
+            resolve();
+        });
+    });
+});
+
+afterAll(() => {
+    return new Promise<void>((resolve, reject) => {
+        stubServer.close((err) => (err ? reject(err) : resolve()));
+    });
+});
+
+beforeEach(() => {
+    lastCapture = null;
+    responseQueue = [];
+});
+
+/** Build a Config that points at the stub server. */
+function stubConfig(): Config {
+    return {
+        host: `http://127.0.0.1:${stubPort}`,
+        apiKey: 'test-api-key',
+        workspaceId: 'ws-test-uuid',
+    };
+}
+
+/** Sentinel thrown by the patched process.exit so execution stops. */
+class ProcessExitError extends Error {
+    constructor(public readonly code: number | undefined) {
+        super(`process.exit(${code})`);
+    }
+}
+
+function patchProcessExit(): () => void {
+    const orig = process.exit.bind(process);
+    (process as any).exit = (code?: number) => { throw new ProcessExitError(code); };
+    return () => { (process as any).exit = orig; };
+}
+
+function captureWrites(stream: NodeJS.WriteStream): { lines: string[]; restore: () => void } {
+    const lines: string[] = [];
+    const orig = stream.write.bind(stream);
+    (stream as any).write = (chunk: string) => { lines.push(String(chunk)); return true; };
+    return { lines, restore: () => { (stream as any).write = orig; } };
+}
+
+async function run(name: string, commandParts: string[], options: Record<string, unknown>) {
+    const restoreExit = patchProcessExit();
+    const { lines: stdoutLines, restore: restoreStdout } = captureWrites(process.stdout);
+    const { lines: stderrLines, restore: restoreStderr } = captureWrites(process.stderr);
+    try {
+        let code: number | undefined;
+        try {
+            await skillExecWithConfig(name, commandParts, options as any, stubConfig());
+        } catch (e) {
+            if (e instanceof ProcessExitError) code = e.code;
+            else throw e;
+        }
+        return { code, stdout: stdoutLines.join(''), stderr: stderrLines.join('') };
+    } finally {
+        restoreStdout();
+        restoreStderr();
+        restoreExit();
+    }
+}
+
+describe('skillExecWithConfig — shared skill (no --role)', () => {
+    it('posts tools/call with name:crews_skills and action:exec_skill, exits 0, prints remote stdout', async () => {
+        responseQueue = [makeMcpSuccess({ stdout: 'hi', stderr: '', exit_code: 0, status: 'ok' })];
+
+        const { code, stdout } = await run('my-skill', ['node', 'scripts/q.js'], {});
+
+        expect(code).toBe(0);
+        expect(stdout).toContain('hi');
+
+        expect(lastCapture).not.toBeNull();
+        expect(lastCapture!.method).toBe('POST');
+        expect(lastCapture!.path).toBe('/mcp');
+        expect(lastCapture!.headers['x-workspace-id']).toBe('ws-test-uuid');
+        expect(lastCapture!.headers['authorization']).toBe('Bearer test-api-key');
+
+        const body = lastCapture!.body;
+        expect(body.method).toBe('tools/call');
+        expect(body.params.name).toBe('crews_skills');
+        expect(body.params.arguments.action).toBe('exec_skill');
+        expect(body.params.arguments.identifier).toBe('my-skill');
+        expect(body.params.arguments.command).toBe('node scripts/q.js');
+    });
+});
+
+describe('skillExecWithConfig — role-scoped skill (--role)', () => {
+    it('posts tools/call with name:crews_roles and action:exec_skill, sends role and name arguments', async () => {
+        responseQueue = [makeMcpSuccess({ stdout: 'hi', stderr: '', exit_code: 0, status: 'ok', available_variables: [] })];
+
+        const { code } = await run('my-skill', ['node', 'scripts/q.js'], { role: 'writer' });
+
+        expect(code).toBe(0);
+        expect(lastCapture).not.toBeNull();
+
+        const body = lastCapture!.body;
+        expect(body.params.name).toBe('crews_roles');
+        expect(body.params.arguments.action).toBe('exec_skill');
+        expect(body.params.arguments.role).toBe('writer');
+        expect(body.params.arguments.name).toBe('my-skill');
+    });
+});
+
+describe('skillExecWithConfig — remote exit_code propagation', () => {
+    it('exits with the remote exit_code (non-zero)', async () => {
+        responseQueue = [makeMcpSuccess({ stdout: '', stderr: 'boom', exit_code: 3, status: 'failed' })];
+
+        const { code, stderr } = await run('my-skill', ['node', 'scripts/q.js'], {});
+
+        expect(code).toBe(3);
+        expect(stderr).toContain('boom');
+    });
+});
+
+describe('skillExecWithConfig — options passthrough', () => {
+    it('sends --environment as top-level environment argument', async () => {
+        await run('my-skill', ['echo', 'hi'], { environment: 'staging' });
+        expect(lastCapture!.body.params.arguments.environment).toBe('staging');
+    });
+
+    it('sends --in-crew as in_crew only when --role is also given', async () => {
+        await run('my-skill', ['echo', 'hi'], { role: 'writer', inCrew: 'crew-a' });
+        expect(lastCapture!.body.params.arguments.in_crew).toBe('crew-a');
+    });
+
+    it('does not send in_crew when --role is absent, even if inCrew is set', async () => {
+        await run('my-skill', ['echo', 'hi'], { inCrew: 'crew-a' });
+        expect(lastCapture!.body.params.arguments).not.toHaveProperty('in_crew');
+    });
+});
+
+describe('skillExecWithConfig — error cases', () => {
+    it('exits 1 with no command given, without making any HTTP request', async () => {
+        const { code, stderr } = await run('my-skill', [], {});
+        expect(code).toBe(1);
+        expect(stderr).toContain('no command given');
+        expect(lastCapture).toBeNull();
+    });
+
+    it('surfaces an MCP error code and message and exits 1', async () => {
+        responseQueue = [makeMcpError('skill_not_found', 'No skill with that identifier exists.')];
+
+        const { code, stderr } = await run('missing-skill', ['echo', 'hi'], {});
+
+        expect(code).toBe(1);
+        expect(stderr).toContain('skill_not_found');
+        expect(stderr).toContain('No skill with that identifier exists.');
+    });
+});

--- a/tests/skill-pull.test.ts
+++ b/tests/skill-pull.test.ts
@@ -511,6 +511,54 @@ describe('skill pull — default dest uses ./<name>/', () => {
     });
 });
 
+describe('skill pull — provenance sidecar', () => {
+    it('writes .solidactions-skill.json with identifier, doc_id, head_revision_id, and role:null', async () => {
+        responseQueue = [
+            makeMcpSuccess({
+                identifier: 'my-skill',
+                doc_id: 42,
+                head_revision_id: 716,
+                properties: {
+                    name: 'my-skill',
+                    description: 'My skill description',
+                    type: 'skill',
+                },
+                body: 'The skill body content.',
+                reference: {},
+            }),
+        ];
+
+        const dest = fs.mkdtempSync(path.join(os.tmpdir(), 'sa-pull-sidecar-'));
+        const restoreExit = patchProcessExit();
+
+        try {
+            let caughtExit: ProcessExitError | null = null;
+            try {
+                await skillPullWithConfig('my-skill', dest, {}, stubConfig());
+            } catch (e) {
+                if (e instanceof ProcessExitError) caughtExit = e;
+                else throw e;
+            }
+
+            expect(caughtExit?.code).toBe(0);
+
+            const sidecarPath = path.join(dest, '.solidactions-skill.json');
+            expect(fs.existsSync(sidecarPath)).toBe(true);
+
+            const sidecar = JSON.parse(fs.readFileSync(sidecarPath, 'utf8'));
+            expect(sidecar).toEqual({
+                identifier: 'my-skill',
+                doc_id: 42,
+                head_revision_id: 716,
+                role: null,
+            });
+        } finally {
+            restoreExit();
+            fs.rmSync(dest, { recursive: true, force: true });
+        }
+    });
+});
+
 describe('skill pull — --json flag', () => {
     it('--json prints raw read result to stdout and does NOT write files', async () => {
         const rawData = {

--- a/tests/skill-pull.test.ts
+++ b/tests/skill-pull.test.ts
@@ -557,6 +557,45 @@ describe('skill pull — provenance sidecar', () => {
             fs.rmSync(dest, { recursive: true, force: true });
         }
     });
+
+    it('normalizes a string head_revision_id to a number, same as doc_id', async () => {
+        responseQueue = [
+            makeMcpSuccess({
+                identifier: 'my-skill',
+                doc_id: '42',
+                head_revision_id: '716',
+                properties: {
+                    name: 'my-skill',
+                    description: 'My skill description',
+                    type: 'skill',
+                },
+                body: 'The skill body content.',
+                reference: {},
+            }),
+        ];
+
+        const dest = fs.mkdtempSync(path.join(os.tmpdir(), 'sa-pull-sidecar-str-'));
+        const restoreExit = patchProcessExit();
+
+        try {
+            let caughtExit: ProcessExitError | null = null;
+            try {
+                await skillPullWithConfig('my-skill', dest, {}, stubConfig());
+            } catch (e) {
+                if (e instanceof ProcessExitError) caughtExit = e;
+                else throw e;
+            }
+
+            expect(caughtExit?.code).toBe(0);
+
+            const sidecar = JSON.parse(fs.readFileSync(path.join(dest, '.solidactions-skill.json'), 'utf8'));
+            expect(sidecar.doc_id).toBe(42);
+            expect(sidecar.head_revision_id).toBe(716);
+        } finally {
+            restoreExit();
+            fs.rmSync(dest, { recursive: true, force: true });
+        }
+    });
 });
 
 describe('skill pull — --json flag', () => {

--- a/tests/skill-push.test.ts
+++ b/tests/skill-push.test.ts
@@ -320,6 +320,29 @@ describe('readReferences', () => {
             cleanup();
         }
     });
+
+    it('excludes the skill-pull provenance sidecar and the skill-run .sa-state/ runtime dir', () => {
+        const { dir, cleanup } = makeTmpSkillDir(
+            '---\nname: S\ndescription: D\n---\nbody',
+            {
+                'real-reference.md': 'a real reference',
+                [SKILL_SIDECAR]: JSON.stringify({ identifier: 'S', doc_id: 1, head_revision_id: 1, role: null }),
+            },
+        );
+
+        try {
+            const stateDir = path.join(dir, '.sa-state');
+            fs.mkdirSync(stateDir);
+            fs.writeFileSync(path.join(stateDir, 'cache.json'), '{"secret":"local-state"}', 'utf8');
+
+            const refs = readReferences(dir);
+            expect(refs).toEqual({ 'real-reference.md': 'a real reference' });
+            expect(refs).not.toHaveProperty(SKILL_SIDECAR);
+            expect(refs).not.toHaveProperty('.sa-state/cache.json');
+        } finally {
+            cleanup();
+        }
+    });
 });
 
 // ---------------------------------------------------------------------------
@@ -427,6 +450,41 @@ describe('skillPushWithConfig — shared library (no --role)', () => {
             expect(args).not.toHaveProperty('properties');
         } finally {
             restoreExit();
+            cleanup();
+        }
+    });
+
+    it('sends only the real reference — excludes the pull sidecar and .sa-state runtime dir from the wire payload', async () => {
+        const { dir, cleanup } = makeTmpSkillDir(
+            ['---', 'name: my-skill', 'description: d', '---', 'body'].join('\n'),
+            {
+                'real-reference.md': 'a real reference',
+                [SKILL_SIDECAR]: JSON.stringify({ identifier: 'my-skill', doc_id: 42, head_revision_id: 716, role: null }),
+            },
+        );
+
+        try {
+            fs.mkdirSync(path.join(dir, '.sa-state'));
+            fs.writeFileSync(path.join(dir, '.sa-state', 'cache.json'), '{"secret":"local-state"}', 'utf8');
+
+            const restoreExit = patchProcessExit();
+            let caughtExit: ProcessExitError | null = null;
+            try {
+                await skillPushWithConfig(dir, {}, stubConfig());
+            } catch (e) {
+                if (e instanceof ProcessExitError) caughtExit = e;
+                else throw e;
+            }
+            restoreExit();
+
+            expect(caughtExit?.code).toBe(0);
+            // A sidecar is present, so a successful "created" push (no collision) also triggers the
+            // best-effort sidecar-revision refresh (item 2), which may issue a follow-up read call —
+            // find the create call specifically rather than assuming it's the last one captured.
+            const createCapture = allCaptures.find((c) => c.body.params.arguments.action === 'create');
+            expect(createCapture).toBeDefined();
+            expect(createCapture!.body.params.arguments.references).toEqual({ 'real-reference.md': 'a real reference' });
+        } finally {
             cleanup();
         }
     });
@@ -744,6 +802,50 @@ describe('skillPushWithConfig — drift guard via base_version_id', () => {
             expect(sidecar.doc_id).toBe(42);
         } finally { restoreExit(); cleanup(); }
     });
+
+    it('refreshes the sidecar head_revision_id from the create response on a "created" push (remote delete+recreate)', async () => {
+        // No name_collision this time — the remote skill was deleted and this push recreates it under the
+        // same name, so the create call succeeds directly with a fresh revision.
+        responseQueue = [makeMcpSuccess({ skill_doc_id: 'doc-99', reference_doc_ids: {}, head_revision_id: 5 })];
+        const { dir, cleanup } = makeTmpSkillDir(
+            ['---', 'name: my-skill', 'description: d', '---', 'body'].join('\n'),
+            { [SKILL_SIDECAR]: JSON.stringify({ identifier: 'my-skill', doc_id: 42, head_revision_id: 716, role: null }) },
+        );
+        const restoreExit = patchProcessExit();
+        try {
+            let caughtExit: ProcessExitError | null = null;
+            try { await skillPushWithConfig(dir, {}, stubConfig()); }
+            catch (e) { if (e instanceof ProcessExitError) caughtExit = e; else throw e; }
+            expect(caughtExit?.code).toBe(0);
+            expect(allCaptures.length).toBe(1);
+            const sidecar = JSON.parse(fs.readFileSync(path.join(dir, SKILL_SIDECAR), 'utf8'));
+            // Refreshed to the new doc's revision — NOT left at the stale 716 from the deleted doc.
+            expect(sidecar.head_revision_id).toBe(5);
+        } finally { restoreExit(); cleanup(); }
+    });
+
+    it('clears a stale sidecar head_revision_id to null on "created" when the new revision cannot be determined', async () => {
+        responseQueue = [
+            // create succeeds but the response carries no head_revision_id/version_id
+            makeMcpSuccess({ skill_doc_id: 'doc-99', reference_doc_ids: {} }),
+            // the best-effort fallback read also fails to produce one
+            makeMcpError('skill_not_found', 'not found'),
+        ];
+        const { dir, cleanup } = makeTmpSkillDir(
+            ['---', 'name: my-skill', 'description: d', '---', 'body'].join('\n'),
+            { [SKILL_SIDECAR]: JSON.stringify({ identifier: 'my-skill', doc_id: 42, head_revision_id: 716, role: null }) },
+        );
+        const restoreExit = patchProcessExit();
+        try {
+            let caughtExit: ProcessExitError | null = null;
+            try { await skillPushWithConfig(dir, {}, stubConfig()); }
+            catch (e) { if (e instanceof ProcessExitError) caughtExit = e; else throw e; }
+            expect(caughtExit?.code).toBe(0);
+            const sidecar = JSON.parse(fs.readFileSync(path.join(dir, SKILL_SIDECAR), 'utf8'));
+            // Cleared, not left at the stale 716 — a future edit must not send it as base_version_id.
+            expect(sidecar.head_revision_id).toBeNull();
+        } finally { restoreExit(); cleanup(); }
+    });
 });
 
 // ---------------------------------------------------------------------------
@@ -1053,6 +1155,38 @@ describe('recursive plugin push', () => {
         } finally {
             console.log = origLog;
             restoreExit();
+            cleanup();
+        }
+    });
+
+    it('plugin mode: excludes a sidecar/.sa-state nested inside a per-skill dir (skills/<name>/) from that skill\'s references', async () => {
+        responseQueue = [makeMcpSuccess({ skill_doc_id: 'doc-a', reference_doc_ids: {} })];
+
+        const { dir, cleanup } = makePluginDir({
+            skills: [{ name: 'a', description: 'Skill A' }],
+        });
+
+        try {
+            const skillDir = path.join(dir, 'skills', 'a');
+            fs.writeFileSync(path.join(skillDir, 'real-reference.md'), 'a real reference', 'utf8');
+            fs.writeFileSync(path.join(skillDir, SKILL_SIDECAR), JSON.stringify({ identifier: 'a', doc_id: 1, head_revision_id: 1, role: null }), 'utf8');
+            fs.mkdirSync(path.join(skillDir, '.sa-state'));
+            fs.writeFileSync(path.join(skillDir, '.sa-state', 'cache.json'), '{"secret":"local-state"}', 'utf8');
+
+            const restoreExit = patchProcessExit();
+            let caughtExit: ProcessExitError | null = null;
+            try {
+                await skillPushWithConfig(dir, {}, stubConfig());
+            } catch (e) {
+                if (e instanceof ProcessExitError) caughtExit = e;
+                else throw e;
+            }
+            restoreExit();
+
+            expect(caughtExit?.code).toBe(0);
+            expect(allCaptures.length).toBe(1);
+            expect(allCaptures[0].body.params.arguments.references).toEqual({ 'real-reference.md': 'a real reference' });
+        } finally {
             cleanup();
         }
     });

--- a/tests/skill-push.test.ts
+++ b/tests/skill-push.test.ts
@@ -14,6 +14,7 @@ import { describe, expect, it, beforeAll, afterAll, beforeEach } from 'vitest';
 import { parseSkillFile, readReferences, skillPushWithConfig, pushParsedSkill, parseCommandFile } from '../src/commands/skill-push';
 import type { SkillPushOptions } from '../src/commands/skill-push';
 import type { Config } from '../src/utils/config';
+import { SKILL_SIDECAR } from '../src/commands/skill-pull';
 
 // ---------------------------------------------------------------------------
 // Stub MCP server — records the last request and returns a canned response
@@ -653,6 +654,95 @@ describe('skillPushWithConfig — idempotent upsert', () => {
             expect(logs.join('')).toContain('created skill');
             expect(logs.join('')).toContain('1 refs');
         } finally { console.log = origLog; restoreExit(); cleanup(); }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Drift guard: base_version_id (task B3)
+// ---------------------------------------------------------------------------
+
+describe('skillPushWithConfig — drift guard via base_version_id', () => {
+    it('sends the sidecar head_revision_id as base_version_id on the edit request', async () => {
+        responseQueue = [
+            makeMcpError('name_collision', 'A skill with this name already exists.'),
+            makeMcpSuccess({ version_id: 717, head_revision_id: 717, body_blob_sha: 'cafe' }),
+        ];
+        const { dir, cleanup } = makeTmpSkillDir(
+            ['---', 'name: my-skill', 'description: d', '---', 'body'].join('\n'),
+            { [SKILL_SIDECAR]: JSON.stringify({ identifier: 'my-skill', doc_id: 42, head_revision_id: 716, role: null }) },
+        );
+        const restoreExit = patchProcessExit();
+        try {
+            let caughtExit: ProcessExitError | null = null;
+            try { await skillPushWithConfig(dir, {}, stubConfig()); }
+            catch (e) { if (e instanceof ProcessExitError) caughtExit = e; else throw e; }
+            expect(caughtExit?.code).toBe(0);
+            expect(allCaptures.length).toBe(2);
+            expect(allCaptures[1].body.params.arguments.base_version_id).toBe(716);
+        } finally { restoreExit(); cleanup(); }
+    });
+
+    it('on concurrent_edit, exits 1 and prints a drift message naming --force', async () => {
+        responseQueue = [
+            makeMcpError('name_collision', 'A skill with this name already exists.'),
+            makeMcpError('concurrent_edit', 'The document was modified by another write since your base_version_id. Re-read the document and retry.'),
+        ];
+        const { dir, cleanup } = makeTmpSkillDir(
+            ['---', 'name: my-skill', 'description: d', '---', 'body'].join('\n'),
+            { [SKILL_SIDECAR]: JSON.stringify({ identifier: 'my-skill', doc_id: 42, head_revision_id: 716, role: null }) },
+        );
+        const restoreExit = patchProcessExit();
+        const { lines: stderrLines, restore: restoreStderr } = captureStderr();
+        try {
+            let caughtExit: ProcessExitError | null = null;
+            try { await skillPushWithConfig(dir, {}, stubConfig()); }
+            catch (e) { if (e instanceof ProcessExitError) caughtExit = e; else throw e; }
+            expect(caughtExit?.code).toBe(1);
+            const out = stderrLines.join('');
+            expect(out).toContain('--force');
+        } finally { restoreStderr(); restoreExit(); cleanup(); }
+    });
+
+    it('--force skips sending base_version_id and pushes through even when the sidecar is behind', async () => {
+        responseQueue = [
+            makeMcpError('name_collision', 'A skill with this name already exists.'),
+            makeMcpSuccess({ version_id: 900, head_revision_id: 900, body_blob_sha: 'beef' }),
+        ];
+        const { dir, cleanup } = makeTmpSkillDir(
+            ['---', 'name: my-skill', 'description: d', '---', 'body'].join('\n'),
+            { [SKILL_SIDECAR]: JSON.stringify({ identifier: 'my-skill', doc_id: 42, head_revision_id: 716, role: null }) },
+        );
+        const restoreExit = patchProcessExit();
+        try {
+            let caughtExit: ProcessExitError | null = null;
+            try { await skillPushWithConfig(dir, { force: true }, stubConfig()); }
+            catch (e) { if (e instanceof ProcessExitError) caughtExit = e; else throw e; }
+            expect(caughtExit?.code).toBe(0);
+            expect(allCaptures.length).toBe(2);
+            expect(allCaptures[1].body.params.arguments).not.toHaveProperty('base_version_id');
+        } finally { restoreExit(); cleanup(); }
+    });
+
+    it('refreshes the sidecar head_revision_id from the edit response after a successful guarded edit', async () => {
+        responseQueue = [
+            makeMcpError('name_collision', 'A skill with this name already exists.'),
+            makeMcpSuccess({ version_id: 717, head_revision_id: 717, body_blob_sha: 'cafe' }),
+        ];
+        const { dir, cleanup } = makeTmpSkillDir(
+            ['---', 'name: my-skill', 'description: d', '---', 'body'].join('\n'),
+            { [SKILL_SIDECAR]: JSON.stringify({ identifier: 'my-skill', doc_id: 42, head_revision_id: 716, role: null }) },
+        );
+        const restoreExit = patchProcessExit();
+        try {
+            let caughtExit: ProcessExitError | null = null;
+            try { await skillPushWithConfig(dir, {}, stubConfig()); }
+            catch (e) { if (e instanceof ProcessExitError) caughtExit = e; else throw e; }
+            expect(caughtExit?.code).toBe(0);
+            const sidecar = JSON.parse(fs.readFileSync(path.join(dir, SKILL_SIDECAR), 'utf8'));
+            expect(sidecar.head_revision_id).toBe(717);
+            expect(sidecar.identifier).toBe('my-skill');
+            expect(sidecar.doc_id).toBe(42);
+        } finally { restoreExit(); cleanup(); }
     });
 });
 

--- a/tests/skill-run.test.ts
+++ b/tests/skill-run.test.ts
@@ -74,6 +74,21 @@ describe('assembleEnv', () => {
         expect(warnings.join('\n')).toContain('PATH');
     });
 
+    it('rejects reserved names from resolved crew vars with a warning, same as env-file vars', () => {
+        const { env, warnings } = assembleEnv({
+            resolved: { SOLIDACTIONS_API_TOKEN: 'evil-from-crew', PATH: '/evil-from-crew', OK_VAR: 'fine' },
+            fileVars: {},
+            storageScope: null,
+            dir: '/tmp/skill',
+            config,
+        });
+        expect(env.SOLIDACTIONS_API_TOKEN).toBe('test-api-key'); // framework wins, not the crew-resolved value
+        expect(env.PATH).toBeUndefined(); // not injected by assembleEnv (process.env merge happens at spawn)
+        expect(env.OK_VAR).toBe('fine');
+        expect(warnings.join('\n')).toContain('SOLIDACTIONS_API_TOKEN');
+        expect(warnings.join('\n')).toContain('PATH');
+    });
+
     it('injects STATE_DIR only for storage.scope=crew and SHARED_DIR only for workspace', () => {
         const crew = assembleEnv({ resolved: {}, fileVars: {}, storageScope: 'crew', dir: '/tmp/skill', config });
         expect(crew.env.SOLIDACTIONS_STATE_DIR).toBe(path.join('/tmp/skill', '.sa-state'));

--- a/tests/skill-run.test.ts
+++ b/tests/skill-run.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Tests for `solidactions skill run <dir> -- <command...>`.
+ *
+ * Test-double policy: no mock/spy/stub libraries. Unit tests exercise the
+ * exported pure helpers directly. The integration case spawns the real built
+ * CLI binary (dist/index.js) as a subprocess against a real in-process HTTP
+ * server (Node's http.createServer) standing in for the SolidActions API —
+ * matching the pattern in tests/flag-consistency.test.ts.
+ *
+ * Two adaptations from a naive "call skillRunWithConfig in-process" test:
+ *
+ * 1. Spawn the built binary, don't call the function in-process. Production
+ *    code runs the user's command with `stdio: 'inherit'` (real-time
+ *    streaming + interactive stdin, matching the MCP exec_skill UX).
+ *    `inherit` hands the grandchild the parent's raw file descriptor,
+ *    bypassing `process.stdout.write` entirely — an in-process call can't
+ *    capture it via a JS-level monkeypatch. Spawning the CLI as a subprocess
+ *    of the *test* makes the fd chain capturable: the grandchild inherits
+ *    the CLI process's fds, which are the test's own pipes.
+ * 2. Use async `spawn`, not `spawnSync`, to launch the CLI. `spawnSync`
+ *    blocks the calling process's event loop until the child exits — but
+ *    the stub HTTP server lives in this same test process, so the CLI
+ *    child's request back to it would never be accepted while the test is
+ *    blocked inside `spawnSync`. Confirmed by direct repro: nesting
+ *    spawnSync(CLI) -> [CLI does an async HTTP GET to the test's own
+ *    in-process server] -> spawnSync(grandchild) deadlocks every time.
+ */
+import * as fs from 'fs';
+import * as http from 'http';
+import * as os from 'os';
+import * as path from 'path';
+import * as childProcess from 'child_process';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { parseEnvFile, assembleEnv } from '../src/commands/skill-run';
+import { Config } from '../src/utils/config';
+
+const config = { host: 'https://sa.test', apiKey: 'test-api-key', workspaceId: 'ws-123' } as Config;
+
+describe('parseEnvFile', () => {
+    it('parses KEY=VALUE lines, ignores comments/blanks, strips simple quotes', () => {
+        const parsed = parseEnvFile('# comment\n\nFOO=bar\nQUOTED="a b"\nEQ=a=b\n');
+        expect(parsed).toEqual({ FOO: 'bar', QUOTED: 'a b', EQ: 'a=b' });
+    });
+});
+
+describe('assembleEnv', () => {
+    it('layers resolved < fileVars < framework vars and warns on shadows', () => {
+        const { env, warnings } = assembleEnv({
+            resolved: { REGION: 'us-east-1', SHARED: 'from-platform' },
+            fileVars: { SHARED: 'from-file', LOCAL_ONLY: 'x' },
+            storageScope: null,
+            dir: '/tmp/skill',
+            config,
+        });
+        expect(env.SHARED).toBe('from-file');
+        expect(warnings.join('\n')).toContain('SHARED');
+        expect(env.SOLIDACTIONS_API_URL).toBe('https://sa.test/api/v1');
+        expect(env.SOLIDACTIONS_API_TOKEN).toBe('test-api-key');
+        expect(env.SOLIDACTIONS_WORKSPACE_ID).toBe('ws-123');
+    });
+
+    it('rejects reserved names from the env file with a warning', () => {
+        const { env, warnings } = assembleEnv({
+            resolved: {},
+            fileVars: { SOLIDACTIONS_API_TOKEN: 'evil', PATH: '/evil', OK_VAR: 'fine' },
+            storageScope: null,
+            dir: '/tmp/skill',
+            config,
+        });
+        expect(env.SOLIDACTIONS_API_TOKEN).toBe('test-api-key'); // framework wins
+        expect(env.PATH).toBeUndefined(); // not injected by assembleEnv (process.env merge happens at spawn)
+        expect(env.OK_VAR).toBe('fine');
+        expect(warnings.join('\n')).toContain('SOLIDACTIONS_API_TOKEN');
+        expect(warnings.join('\n')).toContain('PATH');
+    });
+
+    it('injects STATE_DIR only for storage.scope=crew and SHARED_DIR only for workspace', () => {
+        const crew = assembleEnv({ resolved: {}, fileVars: {}, storageScope: 'crew', dir: '/tmp/skill', config });
+        expect(crew.env.SOLIDACTIONS_STATE_DIR).toBe(path.join('/tmp/skill', '.sa-state'));
+        expect(crew.env.SOLIDACTIONS_SHARED_DIR).toBeUndefined();
+
+        const ws = assembleEnv({ resolved: {}, fileVars: {}, storageScope: 'workspace', dir: '/tmp/skill', config });
+        expect(ws.env.SOLIDACTIONS_SHARED_DIR).toContain(path.join('.solidactions', 'shared', 'ws-123'));
+        expect(ws.env.SOLIDACTIONS_STATE_DIR).toBeUndefined();
+
+        const none = assembleEnv({ resolved: {}, fileVars: {}, storageScope: null, dir: '/tmp/skill', config });
+        expect(none.env.SOLIDACTIONS_STATE_DIR).toBeUndefined();
+        expect(none.env.SOLIDACTIONS_SHARED_DIR).toBeUndefined();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: real HTTP server + real built CLI subprocess
+// ---------------------------------------------------------------------------
+
+const CLI_BINARY = path.resolve(__dirname, '../dist/index.js');
+
+describe('solidactions skill run — integration', () => {
+    let stubServer: http.Server;
+    let stubPort: number;
+
+    beforeAll(async () => {
+        if (!fs.existsSync(CLI_BINARY)) {
+            throw new Error(`CLI not built — run \`npm run build\` first (expected: ${CLI_BINARY})`);
+        }
+
+        stubServer = http.createServer((req, res) => {
+            if (req.url === '/api/v1/crews') {
+                // fetchCrews() in src/utils/crew.ts reads response.data?.data.
+                res.writeHead(200, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ data: [{ id: 7, name: 'my-crew' }] }));
+                return;
+            }
+            if (req.url?.startsWith('/api/v1/crews/7/variables/resolve')) {
+                res.writeHead(200, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ env: { PROBE: 'resolved' }, skipped_secrets: ['HIDDEN'] }));
+                return;
+            }
+            res.writeHead(404, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ message: 'not found' }));
+        });
+
+        await new Promise<void>((resolve) => {
+            stubServer.listen(0, '127.0.0.1', () => {
+                stubPort = (stubServer.address() as { port: number }).port;
+                resolve();
+            });
+        });
+    });
+
+    afterAll(() => {
+        return new Promise<void>((resolve, reject) => {
+            stubServer.close((err) => (err ? reject(err) : resolve()));
+        });
+    });
+
+    it('resolves crew variables by name via GET /api/v1/crews, fetches env for the given environment, and injects them into the child process env, warning about skipped secrets', async () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sa-skill-run-test-'));
+        fs.writeFileSync(path.join(dir, 'SKILL.md'), '---\nname: probe\ndescription: test skill\n---\n\nbody\n');
+
+        try {
+            const result = await new Promise<{ stdout: string; stderr: string; status: number | null }>((resolve, reject) => {
+                const child = childProcess.spawn(
+                    process.execPath,
+                    [
+                        CLI_BINARY, 'skill', 'run', dir,
+                        '--crew', 'my-crew',
+                        '--environment', 'dev',
+                        '--',
+                        'node', '-e', 'console.log("PROBE="+process.env.PROBE)',
+                    ],
+                    {
+                        env: {
+                            ...process.env,
+                            SOLIDACTIONS_HOST: `http://127.0.0.1:${stubPort}`,
+                            SOLIDACTIONS_API_KEY: 'test-api-key',
+                            SOLIDACTIONS_WORKSPACE_ID: 'ws-123',
+                        },
+                    },
+                );
+                let stdout = '';
+                let stderr = '';
+                child.stdout.on('data', (chunk) => { stdout += chunk; });
+                child.stderr.on('data', (chunk) => { stderr += chunk; });
+                const timer = setTimeout(() => {
+                    child.kill();
+                    reject(new Error(`CLI timed out. stdout so far: ${stdout} stderr so far: ${stderr}`));
+                }, 15_000);
+                child.on('close', (status) => {
+                    clearTimeout(timer);
+                    resolve({ stdout, stderr, status });
+                });
+                child.on('error', (err) => {
+                    clearTimeout(timer);
+                    reject(err);
+                });
+            });
+
+            expect(result.status).toBe(0);
+            expect(result.stdout).toContain('PROBE=resolved');
+            expect(result.stderr).toContain('HIDDEN');
+            expect(result.stderr).toContain('env:reveal');
+        } finally {
+            fs.rmSync(dir, { recursive: true, force: true });
+        }
+    }, 20_000);
+});

--- a/tests/skill-run.test.ts
+++ b/tests/skill-run.test.ts
@@ -128,7 +128,7 @@ describe('solidactions skill run — integration', () => {
             }
             if (req.url?.startsWith('/api/v1/crews/7/variables/resolve')) {
                 res.writeHead(200, { 'Content-Type': 'application/json' });
-                res.end(JSON.stringify({ env: { PROBE: 'resolved' }, skipped_secrets: ['HIDDEN'] }));
+                res.end(JSON.stringify({ variables: { PROBE: 'resolved' }, skipped_secrets: ['HIDDEN'] }));
                 return;
             }
             res.writeHead(404, { 'Content-Type': 'application/json' });


### PR DESCRIPTION
The CLI half of the crew local-dev design (app spec: `docs/superpowers/specs/2026-07-08-crew-local-dev-and-secrets-design.md`; app counterpart PR to follow from `feat/crew-vars-resolve`).

## What's new

- **`skill run <dir> [--crew] [--environment dev] [--env-file] -- <command...>`** — run a skill script locally with crew variables fetched at runtime from `GET /api/v1/crews/{id}/variables/resolve`. Secret values arrive only when the API key holds `env:reveal` (skipped names are printed with the remedy). Env-file overlays with reserved-name rejection; `storage.scope`-gated `SOLIDACTIONS_STATE_DIR`/`SHARED_DIR`; framework vars unshadowable; child exit code passthrough.
- **`skill exec <name> [--role] [--in-crew] [--environment] -- <command...>`** — the post-push smoke: runs the command against the deployed skill in its real sandbox via `exec_skill`. Default environment `production` (server default) vs `skill run`'s `dev` — deliberate, cross-referenced in both helps.
- **`dev` secrets fix** — requests `reveal=true` and falls back gracefully on missing `env:reveal`, so workflows needing real keys can finally run locally.
- **Drift guard** — `skill pull` records a `.solidactions-skill.json` provenance sidecar (`head_revision_id`); `skill push` sends it as `base_version_id` and turns `concurrent_edit` into an actionable message; `--force` overrides. Sidecar and `.sa-state/` are excluded from pushed references.

## Verification

- 479/479 vitest green (real local HTTP responders, no mocks), tsc strict clean.
- Live e2e smoke against a dev stack + real Daytona sandbox: endpoint tiering (3 token tiers), pull→run→push(drift+--force)→exec loop, dev secrets both tiers — all passing.
- Final whole-branch review verdict: ready to merge (its one Critical — sidecar/.sa-state upload leak — is fixed in this branch with wire-level tests).

Requires the app-side resolve endpoint (feat/crew-vars-resolve) for `skill run --crew`; all other commands work against current production APIs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)