### PR TITLE
docs pull + drift-guarded docs push: the docs half of the local project loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,11 +163,13 @@ Manage docs in SA-Docs (the app's built-in documentation vault). `push` is drift
 
 | Command | Key Flags | Description |
 |---------|-----------|-------------|
-| `docs pull <folder> [dest]` | `-y`, `--json` | Download a Docs folder tree (markdown + media) to `dest` (defaults to `./<last-segment>/`); writes a `.solidactions-docs.json` revision manifest used by `push`'s drift guard. Falls back to fetching a single doc if `folder` is a doc path, not a folder |
-| `docs push <dir>` | `--on-conflict`, `--type`, `--folder`, `--dry-run`, `--force`, `--json` | Recursively upload a local markdown tree. Manifest-tracked files (from a prior `pull`) are written with a `base_revision` guard and reported separately as written/drifted; `--force` skips the guard. `--dry-run` previews without writing |
+| `docs pull <folder> [dest]` | `-y`, `--overwrite`, `--json` | Download a Docs folder tree (markdown + media) to `dest` (defaults to `./<last-segment>/`); writes a `.solidactions-docs.json` revision manifest (including a `body_sha256` content hash per file) used by `push`'s drift guard. Falls back to fetching a single doc if `folder` is a doc path, not a folder |
+| `docs push <dir>` | `--on-conflict`, `--type`, `--folder`, `--dry-run`, `--force`, `--json` | Recursively upload a local markdown tree. Manifest-tracked files (from a prior `pull`) are written with a `base_revision` guard and reported separately as written/drifted/unchanged; files whose content hash still matches the last pull are skipped as unchanged (no write, no revision bump). `--force` skips the drift guard (unchanged files are still skipped). `--dry-run` previews without writing |
 | `docs upload <files...>` | `--folder`, `--title` | Upload one or more media files to SA-Docs (requires a token with the "docs" ability); `--title` only valid for a single file |
 
 Deletions don't propagate: a doc removed on the server still exists locally after a re-pull, and an untracked `push` can re-create it — remove the local file yourself.
+
+**`docs pull --overwrite` is destructive.** If any manifest-tracked file's local content no longer matches the `body_sha256` recorded at the last pull (i.e. you've edited it and haven't pushed yet), a plain `docs pull` — even with `-y`/`--yes` — refuses with exit 1, naming every modified file, rather than silently discarding your edits. `-y`/`--yes` only bypasses the generic "destination is not empty" prompt; it does not cover locally-modified tracked files. Pass `--overwrite` to discard those local changes and re-pull server content anyway (it also implies `--yes`).
 
 ### workspace
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,16 @@ Manage agent skills on the crews SOP surface. `push` is an idempotent upsert (cr
 |---------|-----------|-------------|
 | `role push <dir>` | `--dry-run`, `--json` | Push a role definition (create or update) |
 
+### docs
+
+Manage docs in SA-Docs (the app's built-in documentation vault). `push` is drift-guarded for files previously pulled: a tracked file whose server revision has moved since the pull fails with `re-pull to merge, or pass --force to overwrite` rather than silently clobbering it; untracked files always go through the existing bulk-create path.
+
+| Command | Key Flags | Description |
+|---------|-----------|-------------|
+| `docs pull <folder> [dest]` | `-y`, `--json` | Download a Docs folder tree (markdown + media) to `dest` (defaults to `./<last-segment>/`); writes a `.solidactions-docs.json` revision manifest used by `push`'s drift guard. Falls back to fetching a single doc if `folder` is a doc path, not a folder |
+| `docs push <dir>` | `--on-conflict`, `--type`, `--folder`, `--dry-run`, `--force`, `--json` | Recursively upload a local markdown tree. Manifest-tracked files (from a prior `pull`) are written with a `base_revision` guard and reported separately as written/drifted; `--force` skips the guard. `--dry-run` previews without writing |
+| `docs upload <files...>` | `--folder`, `--title` | Upload one or more media files to SA-Docs (requires a token with the "docs" ability); `--title` only valid for a single file |
+
 ### workspace
 
 | Command | Description |

--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ Manage docs in SA-Docs (the app's built-in documentation vault). `push` is drift
 | `docs push <dir>` | `--on-conflict`, `--type`, `--folder`, `--dry-run`, `--force`, `--json` | Recursively upload a local markdown tree. Manifest-tracked files (from a prior `pull`) are written with a `base_revision` guard and reported separately as written/drifted; `--force` skips the guard. `--dry-run` previews without writing |
 | `docs upload <files...>` | `--folder`, `--title` | Upload one or more media files to SA-Docs (requires a token with the "docs" ability); `--title` only valid for a single file |
 
+Deletions don't propagate: a doc removed on the server still exists locally after a re-pull, and an untracked `push` can re-create it — remove the local file yourself.
+
 ### workspace
 
 | Command | Description |

--- a/src/commands/docs-pull.ts
+++ b/src/commands/docs-pull.ts
@@ -8,18 +8,30 @@
  * (<dest>/.solidactions-docs.json) recording id/title/current_revision_id
  * per file for later diffing.
  *
- * Media handling (docs whose body references binary assets) arrives in a
- * later task — every doc here is written as markdown with manifest
- * `media: false`.
+ * Media docs (blob-backed, empty body) are two-stage classified: a
+ * candidate filter on the bulk_read row's properties, then an authoritative
+ * confirm against `GET /api/v1/docs/{id}/media` — a 404 `media_not_found`
+ * means the candidate was a false positive and it's written as markdown
+ * like any other doc.
  */
 
 import fs from 'fs';
 import path from 'path';
+import axios from 'axios';
 import chalk from 'chalk';
 import prompts from 'prompts';
 import { Config } from '../utils/config';
-import { requireConfigWithWorkspace } from '../utils/api';
+import { getApiHeaders, requireConfigWithWorkspace } from '../utils/api';
 import { callDocsTool } from '../utils/mcp';
+
+/** Extension appended to a media file's sanitized title when the title itself has none. */
+const MIME_EXTENSIONS: Record<string, string> = {
+    'image/png': '.png',
+    'image/jpeg': '.jpg',
+    'image/gif': '.gif',
+    'image/webp': '.webp',
+    'application/pdf': '.pdf',
+};
 
 export const DOCS_MANIFEST = '.solidactions-docs.json';
 
@@ -64,6 +76,59 @@ interface DocRow {
 interface FetchedDoc extends DocRow {
     body: string;
     current_revision_id: number | null;
+    properties: Record<string, unknown>;
+}
+
+/**
+ * A doc is a media *candidate* when the bulk_read row carries blob metadata
+ * and an empty body. This is a cheap pre-filter, not authoritative — the
+ * media endpoint confirm can still return a false positive (see
+ * `resolveMedia`).
+ */
+function isMediaCandidate(doc: FetchedDoc): boolean {
+    const props = doc.properties;
+    return Boolean(props.blob_sha && props.mime && props.size) && doc.body === '';
+}
+
+interface MediaResolution {
+    isMedia: boolean;
+    mime?: string;
+    /** Downloaded bytes, or null if the signed-URL download failed (still `media: true`). */
+    bytes?: Buffer | null;
+    warning?: string;
+}
+
+/**
+ * Authoritatively confirm a media candidate against `GET /api/v1/docs/{id}/media`
+ * and, if confirmed, download the returned signed URL (no auth headers — it's
+ * a pre-signed R2 URL). Returns `{ isMedia: false }` for the false-positive
+ * 404 `media_not_found` case, in which the caller falls back to the D1
+ * markdown write path.
+ */
+async function resolveMedia(config: Config, doc: FetchedDoc): Promise<MediaResolution> {
+    const confirm = await axios.get(`${config.host}/api/v1/docs/${doc.id}/media`, {
+        headers: getApiHeaders(config),
+        validateStatus: () => true,
+    });
+
+    if (confirm.status === 404 && confirm.data?.code === 'media_not_found') {
+        return { isMedia: false };
+    }
+
+    if (confirm.status !== 200) {
+        const code = confirm.data?.code ?? 'unknown_error';
+        const message = confirm.data?.message ?? 'media confirm request failed';
+        process.stderr.write(chalk.red(`error: ${code}: ${message}\n`));
+        process.exit(1);
+    }
+
+    const { url, mime } = confirm.data;
+    const download = await axios.get(url, { responseType: 'arraybuffer', validateStatus: () => true });
+    if (download.status !== 200) {
+        return { isMedia: true, mime, bytes: null, warning: `warn: failed to download media for doc ${doc.id} (${doc.title}): HTTP ${download.status}` };
+    }
+
+    return { isMedia: true, mime, bytes: Buffer.from(download.data) };
 }
 
 /** The last non-empty path segment of a '/'-separated folder path. */
@@ -134,6 +199,7 @@ async function fetchBodies(config: Config, rows: DocRow[]): Promise<FetchedDoc[]
                 ...original,
                 body: row.body ?? '',
                 current_revision_id: row.current_revision_id ?? null,
+                properties: row.properties ?? {},
             });
         }
     }
@@ -144,12 +210,14 @@ async function fetchBodies(config: Config, rows: DocRow[]): Promise<FetchedDoc[]
 /**
  * Write every fetched doc to disk under `destination`, tracking sanitized
  * filename collisions per directory (suffix "-2", "-3", ... before the
- * extension). Returns the manifest docs map and the ordered list of written
- * files (for --json output).
+ * extension). Returns the manifest docs map, the ordered list of written
+ * files (for --json output), and any non-fatal warnings (e.g. a media
+ * signed-URL download that failed).
  */
-function writeDocs(destination: string, docs: FetchedDoc[]): { manifestDocs: DocsManifest['docs']; files: Array<{ path: string; action: 'written' }> } {
+async function writeDocs(destination: string, docs: FetchedDoc[], config: Config): Promise<{ manifestDocs: DocsManifest['docs']; files: Array<{ path: string; action: 'written' }>; warnings: string[] }> {
     const manifestDocs: DocsManifest['docs'] = {};
     const files: Array<{ path: string; action: 'written' }> = [];
+    const warnings: string[] = [];
     const usedNamesByDir = new Map<string, Set<string>>();
 
     for (const doc of docs) {
@@ -163,30 +231,55 @@ function writeDocs(destination: string, docs: FetchedDoc[]): { manifestDocs: Doc
             usedNamesByDir.set(dirRel, used);
         }
 
+        const media = isMediaCandidate(doc) ? await resolveMedia(config, doc) : { isMedia: false as const };
+        if (media.warning) warnings.push(media.warning);
+
         const sanitized = sanitizeTitle(doc.title);
-        let candidate = sanitized;
+        let base = sanitized;
+        let ext = '.md';
+        if (media.isMedia) {
+            const titleExt = path.extname(sanitized);
+            if (titleExt) {
+                base = sanitized.slice(0, -titleExt.length);
+                ext = titleExt;
+            } else {
+                base = sanitized;
+                ext = (media.mime && MIME_EXTENSIONS[media.mime]) ?? '';
+            }
+        }
+
+        let candidate = base;
         let suffix = 2;
-        while (used.has(candidate)) {
-            candidate = `${sanitized}-${suffix}`;
+        while (used.has(`${candidate}${ext}`)) {
+            candidate = `${base}-${suffix}`;
             suffix++;
         }
-        used.add(candidate);
+        used.add(`${candidate}${ext}`);
 
-        const fileName = `${candidate}.md`;
+        const fileName = `${candidate}${ext}`;
         const relPath = dirRel ? `${dirRel}/${fileName}` : fileName;
 
-        fs.writeFileSync(path.join(dirAbs, fileName), doc.body, 'utf8');
+        if (media.isMedia) {
+            if (media.bytes) {
+                fs.writeFileSync(path.join(dirAbs, fileName), media.bytes);
+                files.push({ path: relPath, action: 'written' });
+            }
+            // Download failure: warning already recorded above; skip the write but
+            // still record the manifest entry below so the doc isn't silently lost.
+        } else {
+            fs.writeFileSync(path.join(dirAbs, fileName), doc.body, 'utf8');
+            files.push({ path: relPath, action: 'written' });
+        }
 
         manifestDocs[relPath] = {
             id: doc.id,
             title: doc.title,
             current_revision_id: doc.current_revision_id,
-            media: false,
+            media: media.isMedia,
         };
-        files.push({ path: relPath, action: 'written' });
     }
 
-    return { manifestDocs, files };
+    return { manifestDocs, files, warnings };
 }
 
 /**
@@ -248,9 +341,10 @@ export async function docsPullWithConfig(
             relative: '',
             body: data.body ?? '',
             current_revision_id: data.current_revision_id ?? null,
+            properties: data.properties ?? {},
         }];
 
-        report(destination, folderPath, fetched, options);
+        await report(destination, folderPath, fetched, options, config);
         return;
     } else {
         process.stderr.write(chalk.red(`error: ${listResult.code}: ${listResult.message}\n`));
@@ -259,16 +353,20 @@ export async function docsPullWithConfig(
     }
 
     const fetched = await fetchBodies(config, rows);
-    report(destination, folderPath, fetched, options);
+    await report(destination, folderPath, fetched, options, config);
 }
 
 /** Write the docs + manifest to disk and print the result (chalk lines or --json). */
-function report(destination: string, folderPath: string, fetched: FetchedDoc[], options: DocsPullOptions): void {
+async function report(destination: string, folderPath: string, fetched: FetchedDoc[], options: DocsPullOptions, config: Config): Promise<void> {
     fs.mkdirSync(destination, { recursive: true });
-    const { manifestDocs, files } = writeDocs(destination, fetched);
+    const { manifestDocs, files, warnings } = await writeDocs(destination, fetched, config);
 
     const manifest: DocsManifest = { folder_path: folderPath, docs: manifestDocs };
     fs.writeFileSync(path.join(destination, DOCS_MANIFEST), `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+
+    for (const warning of warnings) {
+        process.stderr.write(chalk.yellow(`${warning}\n`));
+    }
 
     if (options.json) {
         console.log(JSON.stringify({ manifest, files }));

--- a/src/commands/docs-pull.ts
+++ b/src/commands/docs-pull.ts
@@ -58,6 +58,12 @@ export interface DocsManifest {
 export interface DocsPullOptions {
     yes?: boolean;
     json?: boolean;
+    /**
+     * Discard unpushed local changes detected against the destination's
+     * `.solidactions-docs.json` manifest (body_sha256 mismatch) and proceed.
+     * Implies the generic non-empty-destination confirmation — no prompt.
+     */
+    overwrite?: boolean;
 }
 
 const CHUNK_SIZE = 50;
@@ -158,6 +164,42 @@ async function resolveMedia(config: Config, doc: FetchedDoc): Promise<MediaResol
 /** sha256 hex digest of the given bytes/string, as written to disk. */
 export function sha256Hex(data: string | Buffer): string {
     return crypto.createHash('sha256').update(data).digest('hex');
+}
+
+/**
+ * Read `<destination>/.solidactions-docs.json`. Absent or unparseable → null,
+ * meaning the destination isn't manifest-tracked (nothing to protect).
+ */
+function readExistingManifest(destination: string): DocsManifest | null {
+    const manifestPath = path.join(destination, DOCS_MANIFEST);
+    if (!fs.existsSync(manifestPath)) {
+        return null;
+    }
+    try {
+        return JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as DocsManifest;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Compare each manifest-tracked file against its recorded `body_sha256` to
+ * find unpushed local edits. An entry without a hash (old manifest) or whose
+ * file is missing locally is never reported as modified — graceful
+ * degradation to "no detection" rather than a false refusal.
+ */
+function detectLocalModifications(destination: string, manifest: DocsManifest): string[] {
+    const modified: string[] = [];
+    for (const [relPath, entry] of Object.entries(manifest.docs)) {
+        if (entry.body_sha256 == null) continue;
+        const absPath = path.join(destination, relPath);
+        if (!fs.existsSync(absPath)) continue;
+        const currentHash = sha256Hex(fs.readFileSync(absPath));
+        if (currentHash !== entry.body_sha256) {
+            modified.push(relPath);
+        }
+    }
+    return modified;
 }
 
 /** The last non-empty path segment of a '/'-separated folder path. */
@@ -361,8 +403,26 @@ export async function docsPullWithConfig(
             process.stderr.write(chalk.red(`error: destination "${destination}" exists and is not a directory.\n`));
             process.exit(1);
         }
+        // Unpushed-local-changes protection: before any writes or network I/O, compare
+        // manifest-tracked files against their pull-time body_sha256. --overwrite is the
+        // only way past a refusal; plain --yes still only covers the generic non-empty
+        // confirmation below.
+        const existingManifest = readExistingManifest(destination);
+        if (existingManifest && !options.overwrite) {
+            const modified = detectLocalModifications(destination, existingManifest);
+            if (modified.length > 0) {
+                const noun = modified.length === 1 ? 'file has' : 'files have';
+                process.stderr.write(chalk.red(`${modified.length} ${noun} unpushed local changes:\n`));
+                for (const file of modified) {
+                    process.stderr.write(chalk.red(`  ${file}\n`));
+                }
+                process.stderr.write(chalk.red('push your changes first, or pass --overwrite to discard them.\n'));
+                process.exit(1);
+            }
+        }
+
         const entries = fs.readdirSync(destination);
-        if (entries.length > 0 && !options.yes) {
+        if (entries.length > 0 && !options.yes && !options.overwrite) {
             console.log(chalk.yellow(`Destination "${destination}" is not empty (${entries.length} items).`));
             console.log(chalk.yellow('Pulling will overwrite existing files.'));
             const response = await prompts({

--- a/src/commands/docs-pull.ts
+++ b/src/commands/docs-pull.ts
@@ -58,10 +58,24 @@ const UNSAFE_CHARS = /[/\\:*?"<>|\x00-\x1f]/g;
 
 /**
  * Replace filesystem-unsafe characters (/ \ : * ? " < > | and control chars)
+ * with underscores so a server-provided name (doc title or folder name) is
+ * safe to use as a single filesystem path segment. Also neutralizes bare
+ * `.` and `..` segments (which would otherwise resolve to the current or
+ * parent directory — a path-traversal risk for folder names in particular).
+ */
+export function sanitizeSegment(name: string): string {
+    const replaced = name.replace(UNSAFE_CHARS, '_');
+    if (replaced === '.') return '_';
+    if (replaced === '..') return '__';
+    return replaced;
+}
+
+/**
+ * Replace filesystem-unsafe characters (/ \ : * ? " < > | and control chars)
  * in a doc title with underscores so it can be used as a file basename.
  */
 export function sanitizeTitle(title: string): string {
-    return title.replace(UNSAFE_CHARS, '_');
+    return sanitizeSegment(title);
 }
 
 /** Row collected during the BFS list walk, before bodies are fetched. */
@@ -160,7 +174,8 @@ async function listTree(config: Config, folderPath: string): Promise<{ ok: true;
         first = false;
 
         for (const folder of result.data?.folders ?? []) {
-            const childRelative = relative ? `${relative}/${folder.name}` : folder.name;
+            const safeName = sanitizeSegment(folder.name);
+            const childRelative = relative ? `${relative}/${safeName}` : safeName;
             queue.push({ folder_path: folder.folder_path, relative: childRelative });
         }
         for (const doc of result.data?.docs ?? []) {
@@ -171,12 +186,22 @@ async function listTree(config: Config, folderPath: string): Promise<{ ok: true;
     return { ok: true, rows };
 }
 
-/** Fetch bodies + revisions for every collected row via bulk_read, chunked at CHUNK_SIZE ids. */
-async function fetchBodies(config: Config, rows: DocRow[]): Promise<FetchedDoc[]> {
+/** The bulk_read row status that means "body/revision were returned successfully". */
+const BULK_READ_OK_STATUS = 'found';
+
+/**
+ * Fetch bodies + revisions for every collected row via bulk_read, chunked at
+ * CHUNK_SIZE ids. A row whose status isn't `BULK_READ_OK_STATUS` (e.g. a
+ * server-side `error` or `not_found`), or a requested id absent from the
+ * response entirely, is soft-skipped: a warning naming the doc, no file
+ * written, no manifest entry — mirroring the media download soft-skip.
+ */
+async function fetchBodies(config: Config, rows: DocRow[]): Promise<{ fetched: FetchedDoc[]; warnings: string[] }> {
     const byId = new Map<number, DocRow>();
     for (const row of rows) byId.set(row.id, row);
 
     const fetched: FetchedDoc[] = [];
+    const warnings: string[] = [];
     for (let i = 0; i < rows.length; i += CHUNK_SIZE) {
         const chunk = rows.slice(i, i + CHUNK_SIZE);
         const result = await callDocsTool(config, 'docs_vault', {
@@ -192,9 +217,17 @@ async function fetchBodies(config: Config, rows: DocRow[]): Promise<FetchedDoc[]
         }
 
         const resultRows = result.data?.results ?? [];
+        const seenIds = new Set<number>();
         for (const row of resultRows) {
             const original = byId.get(row.id);
             if (!original) continue;
+            seenIds.add(row.id);
+
+            if (row.status !== BULK_READ_OK_STATUS) {
+                warnings.push(`warn: skipping doc ${row.id} (${original.title}): bulk_read returned status "${row.status ?? 'unknown'}"`);
+                continue;
+            }
+
             fetched.push({
                 ...original,
                 body: row.body ?? '',
@@ -202,9 +235,15 @@ async function fetchBodies(config: Config, rows: DocRow[]): Promise<FetchedDoc[]
                 properties: row.properties ?? {},
             });
         }
+
+        for (const requested of chunk) {
+            if (!seenIds.has(requested.id)) {
+                warnings.push(`warn: skipping doc ${requested.id} (${requested.title}): missing from bulk_read results`);
+            }
+        }
     }
 
-    return fetched;
+    return { fetched, warnings };
 }
 
 /**
@@ -297,6 +336,10 @@ export async function docsPullWithConfig(
 
     // Overwrite-confirm: warn + confirm on a non-empty destination before any network I/O.
     if (fs.existsSync(destination)) {
+        if (!fs.statSync(destination).isDirectory()) {
+            process.stderr.write(chalk.red(`error: destination "${destination}" exists and is not a directory.\n`));
+            process.exit(1);
+        }
         const entries = fs.readdirSync(destination);
         if (entries.length > 0 && !options.yes) {
             console.log(chalk.yellow(`Destination "${destination}" is not empty (${entries.length} items).`));
@@ -344,7 +387,7 @@ export async function docsPullWithConfig(
             properties: data.properties ?? {},
         }];
 
-        await report(destination, folderPath, fetched, options, config);
+        await report(destination, folderPath, fetched, options, config, []);
         return;
     } else {
         process.stderr.write(chalk.red(`error: ${listResult.code}: ${listResult.message}\n`));
@@ -352,19 +395,19 @@ export async function docsPullWithConfig(
         return;
     }
 
-    const fetched = await fetchBodies(config, rows);
-    await report(destination, folderPath, fetched, options, config);
+    const { fetched, warnings: fetchWarnings } = await fetchBodies(config, rows);
+    await report(destination, folderPath, fetched, options, config, fetchWarnings);
 }
 
 /** Write the docs + manifest to disk and print the result (chalk lines or --json). */
-async function report(destination: string, folderPath: string, fetched: FetchedDoc[], options: DocsPullOptions, config: Config): Promise<void> {
+async function report(destination: string, folderPath: string, fetched: FetchedDoc[], options: DocsPullOptions, config: Config, extraWarnings: string[]): Promise<void> {
     fs.mkdirSync(destination, { recursive: true });
     const { manifestDocs, files, warnings } = await writeDocs(destination, fetched, config);
 
     const manifest: DocsManifest = { folder_path: folderPath, docs: manifestDocs };
     fs.writeFileSync(path.join(destination, DOCS_MANIFEST), `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
 
-    for (const warning of warnings) {
+    for (const warning of [...extraWarnings, ...warnings]) {
         process.stderr.write(chalk.yellow(`${warning}\n`));
     }
 

--- a/src/commands/docs-pull.ts
+++ b/src/commands/docs-pull.ts
@@ -1,0 +1,291 @@
+/**
+ * solidactions docs pull <folder> [dest]
+ *
+ * Downloads a Docs folder tree from SA-Docs into a local markdown tree (the
+ * inverse of `docs push`): BFS-walks the folder via `docs_vault list`,
+ * bulk-fetches doc bodies via `docs_vault bulk_read`, and writes each doc as
+ * <dest>/<relative-folder>/<sanitized-title>.md plus a revision manifest
+ * (<dest>/.solidactions-docs.json) recording id/title/current_revision_id
+ * per file for later diffing.
+ *
+ * Media handling (docs whose body references binary assets) arrives in a
+ * later task — every doc here is written as markdown with manifest
+ * `media: false`.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import chalk from 'chalk';
+import prompts from 'prompts';
+import { Config } from '../utils/config';
+import { requireConfigWithWorkspace } from '../utils/api';
+import { callDocsTool } from '../utils/mcp';
+
+export const DOCS_MANIFEST = '.solidactions-docs.json';
+
+export interface DocsManifest {
+    folder_path: string;
+    docs: Record<string, {
+        id: number;
+        title: string;
+        current_revision_id: number | null;
+        media: boolean;
+    }>;
+}
+
+export interface DocsPullOptions {
+    yes?: boolean;
+    json?: boolean;
+}
+
+const CHUNK_SIZE = 50;
+
+/** Characters that are unsafe as filesystem path segments, plus control chars. */
+// eslint-disable-next-line no-control-regex
+const UNSAFE_CHARS = /[/\\:*?"<>|\x00-\x1f]/g;
+
+/**
+ * Replace filesystem-unsafe characters (/ \ : * ? " < > | and control chars)
+ * in a doc title with underscores so it can be used as a file basename.
+ */
+export function sanitizeTitle(title: string): string {
+    return title.replace(UNSAFE_CHARS, '_');
+}
+
+/** Row collected during the BFS list walk, before bodies are fetched. */
+interface DocRow {
+    id: number;
+    title: string;
+    /** Relative folder path from the pull root, '' for the root itself, using '/' separators. */
+    relative: string;
+}
+
+/** Row after bulk_read/read has filled in body + revision. */
+interface FetchedDoc extends DocRow {
+    body: string;
+    current_revision_id: number | null;
+}
+
+/** The last non-empty path segment of a '/'-separated folder path. */
+function lastSegment(folderPath: string): string {
+    const segments = folderPath.split('/').filter(Boolean);
+    return segments[segments.length - 1] ?? folderPath;
+}
+
+/**
+ * BFS-walk `folderPath` via `docs_vault list`, collecting every doc row with
+ * its relative folder path. Returns null (with the list error message
+ * already known to the caller) if the root list call fails.
+ */
+async function listTree(config: Config, folderPath: string): Promise<{ ok: true; rows: DocRow[] } | { ok: false; isRoot: boolean; code: string; message: string }> {
+    const rows: DocRow[] = [];
+    const queue: Array<{ folder_path: string; relative: string }> = [{ folder_path: folderPath, relative: '' }];
+    let first = true;
+
+    while (queue.length > 0) {
+        const { folder_path, relative } = queue.shift()!;
+        const result = await callDocsTool(config, 'docs_vault', { action: 'list', folder_path });
+
+        if (!result.ok) {
+            // A subfolder returned by the server itself failed to list is surfaced the
+            // same way as a root failure — only the root failure triggers the
+            // single-doc fallback (isRoot distinguishes the two).
+            return { ok: false, isRoot: first, code: result.data?.code ?? 'unknown_error', message: result.data?.message ?? 'MCP returned an error with no message' };
+        }
+        first = false;
+
+        for (const folder of result.data?.folders ?? []) {
+            const childRelative = relative ? `${relative}/${folder.name}` : folder.name;
+            queue.push({ folder_path: folder.folder_path, relative: childRelative });
+        }
+        for (const doc of result.data?.docs ?? []) {
+            rows.push({ id: doc.id, title: doc.title, relative });
+        }
+    }
+
+    return { ok: true, rows };
+}
+
+/** Fetch bodies + revisions for every collected row via bulk_read, chunked at CHUNK_SIZE ids. */
+async function fetchBodies(config: Config, rows: DocRow[]): Promise<FetchedDoc[]> {
+    const byId = new Map<number, DocRow>();
+    for (const row of rows) byId.set(row.id, row);
+
+    const fetched: FetchedDoc[] = [];
+    for (let i = 0; i < rows.length; i += CHUNK_SIZE) {
+        const chunk = rows.slice(i, i + CHUNK_SIZE);
+        const result = await callDocsTool(config, 'docs_vault', {
+            action: 'bulk_read',
+            items: chunk.map((r) => ({ id: r.id })),
+        });
+
+        if (!result.ok) {
+            const code = result.data?.code ?? 'unknown_error';
+            const message = result.data?.message ?? 'MCP returned an error with no message';
+            process.stderr.write(chalk.red(`error: ${code}: ${message}\n`));
+            process.exit(1);
+        }
+
+        const resultRows = result.data?.results ?? [];
+        for (const row of resultRows) {
+            const original = byId.get(row.id);
+            if (!original) continue;
+            fetched.push({
+                ...original,
+                body: row.body ?? '',
+                current_revision_id: row.current_revision_id ?? null,
+            });
+        }
+    }
+
+    return fetched;
+}
+
+/**
+ * Write every fetched doc to disk under `destination`, tracking sanitized
+ * filename collisions per directory (suffix " -2", " -3", ... before the
+ * extension). Returns the manifest docs map and the ordered list of written
+ * files (for --json output).
+ */
+function writeDocs(destination: string, docs: FetchedDoc[]): { manifestDocs: DocsManifest['docs']; files: Array<{ path: string; action: 'written' }> } {
+    const manifestDocs: DocsManifest['docs'] = {};
+    const files: Array<{ path: string; action: 'written' }> = [];
+    const usedNamesByDir = new Map<string, Set<string>>();
+
+    for (const doc of docs) {
+        const dirRel = doc.relative;
+        const dirAbs = dirRel ? path.join(destination, ...dirRel.split('/')) : destination;
+        fs.mkdirSync(dirAbs, { recursive: true });
+
+        let used = usedNamesByDir.get(dirRel);
+        if (!used) {
+            used = new Set();
+            usedNamesByDir.set(dirRel, used);
+        }
+
+        const sanitized = sanitizeTitle(doc.title);
+        let candidate = sanitized;
+        let suffix = 2;
+        while (used.has(candidate)) {
+            candidate = `${sanitized} -${suffix}`;
+            suffix++;
+        }
+        used.add(candidate);
+
+        const fileName = `${candidate}.md`;
+        const relPath = dirRel ? `${dirRel}/${fileName}` : fileName;
+
+        fs.writeFileSync(path.join(dirAbs, fileName), doc.body, 'utf8');
+
+        manifestDocs[relPath] = {
+            id: doc.id,
+            title: doc.title,
+            current_revision_id: doc.current_revision_id,
+            media: false,
+        };
+        files.push({ path: relPath, action: 'written' });
+    }
+
+    return { manifestDocs, files };
+}
+
+/**
+ * Core implementation — accepts an injected config so tests can point at a
+ * stub server without touching the filesystem config.
+ */
+export async function docsPullWithConfig(
+    folderPath: string,
+    dest: string | undefined,
+    options: DocsPullOptions,
+    config: Config,
+): Promise<void> {
+    const destInput = dest ?? `./${lastSegment(folderPath)}`;
+    const destination = path.resolve(destInput);
+
+    // Overwrite-confirm: warn + confirm on a non-empty destination before any network I/O.
+    if (fs.existsSync(destination)) {
+        const entries = fs.readdirSync(destination);
+        if (entries.length > 0 && !options.yes) {
+            console.log(chalk.yellow(`Destination "${destination}" is not empty (${entries.length} items).`));
+            console.log(chalk.yellow('Pulling will overwrite existing files.'));
+            const response = await prompts({
+                type: 'confirm',
+                name: 'proceed',
+                message: 'Continue?',
+                initial: false,
+            });
+            if (!response.proceed) {
+                console.log(chalk.gray('Cancelled.'));
+                process.exit(0);
+            }
+        }
+    }
+
+    let rows: DocRow[];
+
+    const listResult = await listTree(config, folderPath);
+    if (listResult.ok) {
+        rows = listResult.rows;
+    } else if (listResult.isRoot && listResult.code === 'folder_path_not_found') {
+        // Single-doc fallback: the target might be a doc path, not a folder.
+        const dir = path.dirname(folderPath);
+        const title = path.basename(folderPath);
+        const readArgs: Record<string, unknown> = { action: 'read', path: dir === '.' ? { title } : { folder_path: dir, title } };
+        const readResult = await callDocsTool(config, 'docs_vault', readArgs);
+
+        if (!readResult.ok) {
+            const readCode = readResult.data?.code ?? 'unknown_error';
+            const readMessage = readResult.data?.message ?? 'MCP returned an error with no message';
+            process.stderr.write(chalk.red(`error: ${listResult.code}: ${listResult.message}\n`));
+            process.stderr.write(chalk.red(`error: ${readCode}: ${readMessage}\n`));
+            process.exit(1);
+        }
+
+        const data = readResult.data;
+        const fetched: FetchedDoc[] = [{
+            id: data.id,
+            title: data.title,
+            relative: '',
+            body: data.body ?? '',
+            current_revision_id: data.current_revision_id ?? null,
+        }];
+
+        report(destination, folderPath, fetched, options);
+        return;
+    } else {
+        process.stderr.write(chalk.red(`error: ${listResult.code}: ${listResult.message}\n`));
+        process.exit(1);
+        return;
+    }
+
+    const fetched = await fetchBodies(config, rows);
+    report(destination, folderPath, fetched, options);
+}
+
+/** Write the docs + manifest to disk and print the result (chalk lines or --json). */
+function report(destination: string, folderPath: string, fetched: FetchedDoc[], options: DocsPullOptions): void {
+    fs.mkdirSync(destination, { recursive: true });
+    const { manifestDocs, files } = writeDocs(destination, fetched);
+
+    const manifest: DocsManifest = { folder_path: folderPath, docs: manifestDocs };
+    fs.writeFileSync(path.join(destination, DOCS_MANIFEST), `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+
+    if (options.json) {
+        console.log(JSON.stringify({ manifest, files }));
+        process.exit(0);
+    }
+
+    console.log(chalk.green(`pulled ${files.length} doc${files.length === 1 ? '' : 's'} → ${destination}`));
+    for (const file of files) {
+        console.log(chalk.gray(`  ${file.path}`));
+    }
+    process.exit(0);
+}
+
+/**
+ * Entry point called from index.ts.
+ */
+export async function docsPull(folder: string, dest: string | undefined, options: DocsPullOptions): Promise<void> {
+    const config = await requireConfigWithWorkspace();
+    await docsPullWithConfig(folder, dest, options, config);
+}

--- a/src/commands/docs-pull.ts
+++ b/src/commands/docs-pull.ts
@@ -143,7 +143,7 @@ async function fetchBodies(config: Config, rows: DocRow[]): Promise<FetchedDoc[]
 
 /**
  * Write every fetched doc to disk under `destination`, tracking sanitized
- * filename collisions per directory (suffix " -2", " -3", ... before the
+ * filename collisions per directory (suffix "-2", "-3", ... before the
  * extension). Returns the manifest docs map and the ordered list of written
  * files (for --json output).
  */
@@ -167,7 +167,7 @@ function writeDocs(destination: string, docs: FetchedDoc[]): { manifestDocs: Doc
         let candidate = sanitized;
         let suffix = 2;
         while (used.has(candidate)) {
-            candidate = `${sanitized} -${suffix}`;
+            candidate = `${sanitized}-${suffix}`;
             suffix++;
         }
         used.add(candidate);

--- a/src/commands/docs-pull.ts
+++ b/src/commands/docs-pull.ts
@@ -17,6 +17,7 @@
 
 import fs from 'fs';
 import path from 'path';
+import crypto from 'crypto';
 import axios from 'axios';
 import chalk from 'chalk';
 import prompts from 'prompts';
@@ -42,6 +43,15 @@ export interface DocsManifest {
         title: string;
         current_revision_id: number | null;
         media: boolean;
+        /**
+         * sha256 (hex) of the exact bytes written for this file at pull time
+         * (markdown body string, or downloaded media bytes). `null` when a
+         * media download soft-failed (no bytes to hash). Manifests written
+         * before this field existed simply omit it — callers must treat a
+         * missing/undefined value the same as "no hash available", never as
+         * a match.
+         */
+        body_sha256?: string | null;
     }>;
 }
 
@@ -143,6 +153,11 @@ async function resolveMedia(config: Config, doc: FetchedDoc): Promise<MediaResol
     }
 
     return { isMedia: true, mime, bytes: Buffer.from(download.data) };
+}
+
+/** sha256 hex digest of the given bytes/string, as written to disk. */
+export function sha256Hex(data: string | Buffer): string {
+    return crypto.createHash('sha256').update(data).digest('hex');
 }
 
 /** The last non-empty path segment of a '/'-separated folder path. */
@@ -298,16 +313,21 @@ async function writeDocs(destination: string, docs: FetchedDoc[], config: Config
         const fileName = `${candidate}${ext}`;
         const relPath = dirRel ? `${dirRel}/${fileName}` : fileName;
 
+        let bodySha256: string | null;
         if (media.isMedia) {
             if (media.bytes) {
                 fs.writeFileSync(path.join(dirAbs, fileName), media.bytes);
                 files.push({ path: relPath, action: 'written' });
+                bodySha256 = sha256Hex(media.bytes);
+            } else {
+                // Download failure: warning already recorded above; skip the write but
+                // still record the manifest entry below so the doc isn't silently lost.
+                bodySha256 = null;
             }
-            // Download failure: warning already recorded above; skip the write but
-            // still record the manifest entry below so the doc isn't silently lost.
         } else {
             fs.writeFileSync(path.join(dirAbs, fileName), doc.body, 'utf8');
             files.push({ path: relPath, action: 'written' });
+            bodySha256 = sha256Hex(doc.body);
         }
 
         manifestDocs[relPath] = {
@@ -315,6 +335,7 @@ async function writeDocs(destination: string, docs: FetchedDoc[], config: Config
             title: doc.title,
             current_revision_id: doc.current_revision_id,
             media: media.isMedia,
+            body_sha256: bodySha256,
         };
     }
 

--- a/src/commands/docs-push.ts
+++ b/src/commands/docs-push.ts
@@ -105,6 +105,7 @@ function readManifest(absDir: string): DocsManifest | null {
     try {
         return JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as DocsManifest;
     } catch {
+        process.stderr.write(chalk.yellow(`warn: ${DOCS_MANIFEST} exists but could not be parsed — all files will be treated as untracked\n`));
         return null;
     }
 }
@@ -229,7 +230,6 @@ export async function docsPushWithConfig(
     const trackedWritten: TrackedWritten[] = [];
     const trackedDrifted: TrackedDrifted[] = [];
     const trackedPlanned: TrackedPlanned[] = [];
-    let manifestChanged = false;
 
     for (const { absPath, relPath } of trackedFiles) {
         const entry = manifest!.docs[relPath];
@@ -269,8 +269,11 @@ export async function docsPushWithConfig(
         }
 
         entry.current_revision_id = data?.current_revision_id ?? entry.current_revision_id;
-        manifestChanged = true;
         trackedWritten.push({ file: relPath, id: entry.id, current_revision_id: entry.current_revision_id });
+
+        // Persist immediately so a later failure (another tracked write, or an
+        // untracked bulk_create error) never loses this file's refreshed revision.
+        fs.writeFileSync(path.join(absDir, DOCS_MANIFEST), `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
     }
 
     const items: DocItem[] = untrackedFiles.map((f) => fileToItem(f, absDir));
@@ -348,11 +351,6 @@ export async function docsPushWithConfig(
             missing: r.property_validation!.missing ?? [],
             invalid: r.property_validation!.invalid ?? [],
         }));
-
-    // Rewrite the manifest on disk if any tracked entry's revision changed.
-    if (manifest && manifestChanged) {
-        fs.writeFileSync(path.join(absDir, DOCS_MANIFEST), `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
-    }
 
     const exitCode = trackedDrifted.length > 0 ? 1 : 0;
 

--- a/src/commands/docs-push.ts
+++ b/src/commands/docs-push.ts
@@ -14,6 +14,7 @@ import chalk from 'chalk';
 import { Config } from '../utils/config';
 import { requireConfigWithWorkspace } from '../utils/api';
 import { callDocsTool } from '../utils/mcp';
+import { DOCS_MANIFEST, DocsManifest } from './docs-pull';
 
 export interface DocsPushOptions {
     onConflict?: 'skip' | 'overwrite' | 'rename';
@@ -22,6 +23,8 @@ export interface DocsPushOptions {
     folder?: string;
     dryRun?: boolean;
     json?: boolean;
+    /** Overwrite tracked docs without a base_revision guard, ignoring server-side drift. */
+    force?: boolean;
 }
 
 const CHUNK_SIZE = 50;
@@ -69,6 +72,36 @@ interface PendingItem {
 
 interface ResultRow extends BulkCreateResultRow {
     file: string;
+}
+
+interface TrackedWritten {
+    file: string;
+    id: number;
+    current_revision_id: number | null;
+}
+
+interface TrackedDrifted {
+    file: string;
+    /** The revision the server is currently at. */
+    their: number | null;
+    /** The revision our manifest thought was current (what we sent as base_revision). */
+    base: number | null;
+}
+
+/**
+ * Read `<absDir>/.solidactions-docs.json`. Absent or unparseable → null,
+ * meaning nothing under `absDir` is guarded (sidecar convention from D1/D2).
+ */
+function readManifest(absDir: string): DocsManifest | null {
+    const manifestPath = path.join(absDir, DOCS_MANIFEST);
+    if (!fs.existsSync(manifestPath)) {
+        return null;
+    }
+    try {
+        return JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as DocsManifest;
+    } catch {
+        return null;
+    }
 }
 
 /**
@@ -173,7 +206,61 @@ export async function docsPushWithConfig(
         process.exit(1);
     }
 
-    const items: DocItem[] = allFiles.map((f) => fileToItem(f, absDir));
+    // Partition into tracked (relative path present in the pull manifest) vs. untracked.
+    // A missing/unparseable manifest means nothing is tracked — everything is untracked,
+    // matching the existing (pre-drift-guard) bulk_create behavior byte-for-byte.
+    const manifest = readManifest(absDir);
+    const trackedFiles: Array<{ absPath: string; relPath: string }> = [];
+    const untrackedFiles: string[] = [];
+    for (const f of allFiles) {
+        const relPath = path.relative(absDir, f).split(path.sep).join('/');
+        if (manifest?.docs[relPath]) {
+            trackedFiles.push({ absPath: f, relPath });
+        } else {
+            untrackedFiles.push(f);
+        }
+    }
+
+    const trackedWritten: TrackedWritten[] = [];
+    const trackedDrifted: TrackedDrifted[] = [];
+    let manifestChanged = false;
+
+    for (const { absPath, relPath } of trackedFiles) {
+        const entry = manifest!.docs[relPath];
+        const body = fs.readFileSync(absPath, 'utf8');
+
+        const editArgs: Record<string, unknown> = { action: 'write', id: entry.id, body };
+        if (!options.force && entry.current_revision_id !== null) {
+            editArgs.base_revision = entry.current_revision_id;
+        }
+
+        let mcpResult: Awaited<ReturnType<typeof callDocsTool>>;
+        try {
+            mcpResult = await callDocsTool(config, 'docs_edit', editArgs);
+        } catch (e: any) {
+            process.stderr.write(chalk.red(`error: ${e.message}\n`));
+            process.exit(1);
+        }
+
+        if (!mcpResult.ok) {
+            const code = mcpResult.data?.code ?? 'unknown_error';
+            const message = mcpResult.data?.message ?? 'MCP returned an error with no message';
+            process.stderr.write(chalk.red(`error: ${code}: ${message}\n`));
+            process.exit(1);
+        }
+
+        const data = mcpResult.data;
+        if (data?.stale === true || data?.code === 'stale_revision') {
+            trackedDrifted.push({ file: relPath, their: data.current_revision_id ?? null, base: entry.current_revision_id });
+            continue;
+        }
+
+        entry.current_revision_id = data?.current_revision_id ?? entry.current_revision_id;
+        manifestChanged = true;
+        trackedWritten.push({ file: relPath, id: entry.id, current_revision_id: entry.current_revision_id });
+    }
+
+    const items: DocItem[] = untrackedFiles.map((f) => fileToItem(f, absDir));
 
     // Chunk into groups of CHUNK_SIZE
     const chunks: DocItem[][] = [];
@@ -249,17 +336,32 @@ export async function docsPushWithConfig(
             invalid: r.property_validation!.invalid ?? [],
         }));
 
+    // Rewrite the manifest on disk if any tracked entry's revision changed.
+    if (manifest && manifestChanged) {
+        fs.writeFileSync(path.join(absDir, DOCS_MANIFEST), `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+    }
+
+    const exitCode = trackedDrifted.length > 0 ? 1 : 0;
+
     // --json: output single JSON object
     if (options.json) {
         console.log(JSON.stringify({
             summary: mergedSummary,
             pending: pendingItems,
             results: allResultRows,
+            tracked: { written: trackedWritten, drifted: trackedDrifted },
         }));
-        process.exit(0);
+        process.exit(exitCode);
     }
 
     // Human-readable output
+    if (trackedWritten.length > 0 || trackedDrifted.length > 0) {
+        console.log(chalk.green(`tracked: ${trackedWritten.length} written, ${trackedDrifted.length} drifted`));
+        for (const w of trackedWritten) {
+            console.log(chalk.gray(`  ${w.file}`));
+        }
+    }
+
     const summaryLine = formatSummaryLine(mergedSummary, !!options.dryRun);
     if (options.dryRun) {
         console.log(chalk.cyan(`[dry-run preview] ${summaryLine}`));
@@ -280,7 +382,15 @@ export async function docsPushWithConfig(
         }
     }
 
-    process.exit(0);
+    if (trackedDrifted.length > 0) {
+        process.stderr.write(chalk.red(`\ndrift: ${trackedDrifted.length} tracked doc${trackedDrifted.length === 1 ? '' : 's'} changed on the server since the last pull:\n`));
+        for (const d of trackedDrifted) {
+            process.stderr.write(chalk.red(`  ${d.file} (local base_revision ${d.base}, server now at ${d.their})\n`));
+        }
+        process.stderr.write(chalk.red('re-pull to merge, or pass --force to overwrite\n'));
+    }
+
+    process.exit(exitCode);
 }
 
 /**

--- a/src/commands/docs-push.ts
+++ b/src/commands/docs-push.ts
@@ -14,7 +14,7 @@ import chalk from 'chalk';
 import { Config } from '../utils/config';
 import { requireConfigWithWorkspace } from '../utils/api';
 import { callDocsTool } from '../utils/mcp';
-import { DOCS_MANIFEST, DocsManifest } from './docs-pull';
+import { DOCS_MANIFEST, DocsManifest, sha256Hex } from './docs-pull';
 
 export interface DocsPushOptions {
     onConflict?: 'skip' | 'overwrite' | 'rename';
@@ -89,6 +89,11 @@ interface TrackedDrifted {
 }
 
 interface TrackedPlanned {
+    file: string;
+    id: number;
+}
+
+interface TrackedUnchanged {
     file: string;
     id: number;
 }
@@ -230,17 +235,26 @@ export async function docsPushWithConfig(
     const trackedWritten: TrackedWritten[] = [];
     const trackedDrifted: TrackedDrifted[] = [];
     const trackedPlanned: TrackedPlanned[] = [];
+    const trackedUnchanged: TrackedUnchanged[] = [];
 
     for (const { absPath, relPath } of trackedFiles) {
         const entry = manifest!.docs[relPath];
+        const body = fs.readFileSync(absPath, 'utf8');
+        const bodyHash = sha256Hex(body);
+
+        // Skip-unchanged applies regardless of --force or --dry-run: force answers
+        // drift, not staleness, and an old manifest lacking body_sha256 (undefined)
+        // never matches, so it always falls through to a write (graceful degradation).
+        if (entry.body_sha256 != null && entry.body_sha256 === bodyHash) {
+            trackedUnchanged.push({ file: relPath, id: entry.id });
+            continue;
+        }
 
         // --dry-run must never live-write: preview the tracked doc instead of calling docs_edit.
         if (options.dryRun) {
             trackedPlanned.push({ file: relPath, id: entry.id });
             continue;
         }
-
-        const body = fs.readFileSync(absPath, 'utf8');
 
         const editArgs: Record<string, unknown> = { action: 'write', id: entry.id, body };
         if (!options.force && entry.current_revision_id !== null) {
@@ -269,6 +283,7 @@ export async function docsPushWithConfig(
         }
 
         entry.current_revision_id = data?.current_revision_id ?? entry.current_revision_id;
+        entry.body_sha256 = bodyHash;
         trackedWritten.push({ file: relPath, id: entry.id, current_revision_id: entry.current_revision_id });
 
         // Persist immediately so a later failure (another tracked write, or an
@@ -360,7 +375,7 @@ export async function docsPushWithConfig(
             summary: mergedSummary,
             pending: pendingItems,
             results: allResultRows,
-            tracked: { written: trackedWritten, drifted: trackedDrifted, planned: trackedPlanned },
+            tracked: { written: trackedWritten, drifted: trackedDrifted, planned: trackedPlanned, unchanged: trackedUnchanged },
         }));
         process.exit(exitCode);
     }
@@ -373,8 +388,14 @@ export async function docsPushWithConfig(
                 console.log(chalk.gray(`  ${p.file}`));
             }
         }
-    } else if (trackedWritten.length > 0 || trackedDrifted.length > 0) {
-        console.log(chalk.green(`tracked: ${trackedWritten.length} written, ${trackedDrifted.length} drifted`));
+        if (trackedUnchanged.length > 0) {
+            console.log(chalk.gray(`tracked: ${trackedUnchanged.length} planned unchanged (skip)`));
+            for (const u of trackedUnchanged) {
+                console.log(chalk.gray(`  ${u.file}`));
+            }
+        }
+    } else if (trackedWritten.length > 0 || trackedDrifted.length > 0 || trackedUnchanged.length > 0) {
+        console.log(chalk.green(`tracked: ${trackedWritten.length} written, ${trackedDrifted.length} drifted, ${trackedUnchanged.length} unchanged`));
         for (const w of trackedWritten) {
             console.log(chalk.gray(`  ${w.file}`));
         }

--- a/src/commands/docs-push.ts
+++ b/src/commands/docs-push.ts
@@ -88,6 +88,11 @@ interface TrackedDrifted {
     base: number | null;
 }
 
+interface TrackedPlanned {
+    file: string;
+    id: number;
+}
+
 /**
  * Read `<absDir>/.solidactions-docs.json`. Absent or unparseable → null,
  * meaning nothing under `absDir` is guarded (sidecar convention from D1/D2).
@@ -223,10 +228,18 @@ export async function docsPushWithConfig(
 
     const trackedWritten: TrackedWritten[] = [];
     const trackedDrifted: TrackedDrifted[] = [];
+    const trackedPlanned: TrackedPlanned[] = [];
     let manifestChanged = false;
 
     for (const { absPath, relPath } of trackedFiles) {
         const entry = manifest!.docs[relPath];
+
+        // --dry-run must never live-write: preview the tracked doc instead of calling docs_edit.
+        if (options.dryRun) {
+            trackedPlanned.push({ file: relPath, id: entry.id });
+            continue;
+        }
+
         const body = fs.readFileSync(absPath, 'utf8');
 
         const editArgs: Record<string, unknown> = { action: 'write', id: entry.id, body };
@@ -349,13 +362,20 @@ export async function docsPushWithConfig(
             summary: mergedSummary,
             pending: pendingItems,
             results: allResultRows,
-            tracked: { written: trackedWritten, drifted: trackedDrifted },
+            tracked: { written: trackedWritten, drifted: trackedDrifted, planned: trackedPlanned },
         }));
         process.exit(exitCode);
     }
 
     // Human-readable output
-    if (trackedWritten.length > 0 || trackedDrifted.length > 0) {
+    if (options.dryRun) {
+        if (trackedPlanned.length > 0) {
+            console.log(chalk.cyan(`tracked: ${trackedPlanned.length} planned write`));
+            for (const p of trackedPlanned) {
+                console.log(chalk.gray(`  ${p.file}`));
+            }
+        }
+    } else if (trackedWritten.length > 0 || trackedDrifted.length > 0) {
         console.log(chalk.green(`tracked: ${trackedWritten.length} written, ${trackedDrifted.length} drifted`));
         for (const w of trackedWritten) {
             console.log(chalk.gray(`  ${w.file}`));

--- a/src/index.ts
+++ b/src/index.ts
@@ -646,9 +646,10 @@ docs
     .option('--type <slug>', 'Doc-type slug to apply to all uploaded docs')
     .option('--folder <base>', 'Nest the whole upload under this base folder path in SA-Docs')
     .option('--dry-run', 'Preview what would be created without writing')
+    .option('--force', 'Overwrite tracked docs (from a prior docs pull) without a base-revision drift guard')
     .option('--json', 'Output result as JSON')
     .action(async (dir, options) => {
-        await docsPush(dir, { onConflict: options.onConflict, type: options.type, folder: options.folder, dryRun: options.dryRun, json: options.json });
+        await docsPush(dir, { onConflict: options.onConflict, type: options.type, folder: options.folder, dryRun: options.dryRun, force: options.force, json: options.json });
     });
 
 docs

--- a/src/index.ts
+++ b/src/index.ts
@@ -658,6 +658,7 @@ docs
     .argument('<folder>', 'Docs folder path (or a single doc path)')
     .argument('[dest]', 'Destination directory (defaults to ./<last-segment>/)')
     .option('-y, --yes', 'Overwrite a non-empty destination without confirmation')
+    .option('--overwrite', 'DESTRUCTIVE: discard unpushed local changes (tracked files whose content no longer matches the last pull) and overwrite them; implies --yes')
     .option('--json', 'Machine-readable output')
     .action(async (folder, dest, options) => {
         await docsPull(folder, dest, options);

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,7 @@ import { skillView } from './commands/skill-view';
 import { skillDelete } from './commands/skill-delete';
 import { rolePush } from './commands/role-push';
 import { docsPush } from './commands/docs-push';
+import { docsPull } from './commands/docs-pull';
 import { docsUpload } from './commands/docs-upload';
 import { crewEnvSet } from './commands/crew-env-set';
 import { crewEnvList } from './commands/crew-env-list';
@@ -648,6 +649,17 @@ docs
     .option('--json', 'Output result as JSON')
     .action(async (dir, options) => {
         await docsPush(dir, { onConflict: options.onConflict, type: options.type, folder: options.folder, dryRun: options.dryRun, json: options.json });
+    });
+
+docs
+    .command('pull')
+    .description('Download a Docs folder tree to a local directory for editing (inverse of push)')
+    .argument('<folder>', 'Docs folder path (or a single doc path)')
+    .argument('[dest]', 'Destination directory (defaults to ./<last-segment>/)')
+    .option('-y, --yes', 'Overwrite a non-empty destination without confirmation')
+    .option('--json', 'Machine-readable output')
+    .action(async (folder, dest, options) => {
+        await docsPull(folder, dest, options);
     });
 
 docs

--- a/tests/docs-pull.test.ts
+++ b/tests/docs-pull.test.ts
@@ -361,14 +361,14 @@ describe('docsPullWithConfig — title collisions', () => {
             const code = await runExpectingExit(() => docsPullWithConfig('root', dest, {}, stubConfig()));
             expect(code).toBe(0);
 
-            // Same-folder collision: "Same.md" and "Same -2.md"
+            // Same-folder collision: "Same.md" and "Same-2.md"
             expect(fs.readFileSync(path.join(dest, 'Same.md'), 'utf8')).toBe('one');
-            expect(fs.readFileSync(path.join(dest, 'Same -2.md'), 'utf8')).toBe('two');
+            expect(fs.readFileSync(path.join(dest, 'Same-2.md'), 'utf8')).toBe('two');
             // Different folder: no suffix needed
             expect(fs.readFileSync(path.join(dest, 'sub', 'Same.md'), 'utf8')).toBe('three');
 
             const manifest = readManifest(dest);
-            expect(Object.keys(manifest.docs).sort()).toEqual(['Same -2.md', 'Same.md', 'sub/Same.md'].sort());
+            expect(Object.keys(manifest.docs).sort()).toEqual(['Same-2.md', 'Same.md', 'sub/Same.md'].sort());
         } finally {
             restoreExit();
             restoreStdout();

--- a/tests/docs-pull.test.ts
+++ b/tests/docs-pull.test.ts
@@ -247,8 +247,8 @@ describe('docsPullWithConfig — folder tree', () => {
                 expect(ids).toEqual([1, 2]);
                 return makeMcpSuccess({
                     results: [
-                        { index: 0, status: 'ok', id: 1, title: 'brief', folder_path: 'marketing/fb-campaign', current_revision_id: 10, properties: {}, body: '# Brief' },
-                        { index: 1, status: 'ok', id: 2, title: 'ad-a', folder_path: 'marketing/fb-campaign/ads', current_revision_id: 20, properties: {}, body: '# Ad A' },
+                        { index: 0, status: 'found', id: 1, title: 'brief', folder_path: 'marketing/fb-campaign', current_revision_id: 10, properties: {}, body: '# Brief' },
+                        { index: 1, status: 'found', id: 2, title: 'ad-a', folder_path: 'marketing/fb-campaign/ads', current_revision_id: 20, properties: {}, body: '# Ad A' },
                     ],
                 });
             },
@@ -300,7 +300,7 @@ describe('docsPullWithConfig — folder tree', () => {
                 expect(items.length).toBeLessThanOrEqual(50);
                 return makeMcpSuccess({
                     results: items.map((it: any, i: number) => ({
-                        index: i, status: 'ok', id: it.id, title: `doc-${it.id}`,
+                        index: i, status: 'found', id: it.id, title: `doc-${it.id}`,
                         folder_path: 'many', current_revision_id: it.id * 10, properties: {}, body: `body-${it.id}`,
                     })),
                 });
@@ -309,7 +309,7 @@ describe('docsPullWithConfig — folder tree', () => {
                 const items = body.params.arguments.items;
                 return makeMcpSuccess({
                     results: items.map((it: any, i: number) => ({
-                        index: i, status: 'ok', id: it.id, title: `doc-${it.id}`,
+                        index: i, status: 'found', id: it.id, title: `doc-${it.id}`,
                         folder_path: 'many', current_revision_id: it.id * 10, properties: {}, body: `body-${it.id}`,
                     })),
                 });
@@ -367,9 +367,9 @@ describe('docsPullWithConfig — title collisions', () => {
                 expect(ids).toEqual([1, 2, 3]);
                 return makeMcpSuccess({
                     results: [
-                        { index: 0, status: 'ok', id: 1, title: 'Same', folder_path: 'root', current_revision_id: 1, properties: {}, body: 'one' },
-                        { index: 1, status: 'ok', id: 2, title: 'Same', folder_path: 'root', current_revision_id: 2, properties: {}, body: 'two' },
-                        { index: 2, status: 'ok', id: 3, title: 'Same', folder_path: 'root/sub', current_revision_id: 3, properties: {}, body: 'three' },
+                        { index: 0, status: 'found', id: 1, title: 'Same', folder_path: 'root', current_revision_id: 1, properties: {}, body: 'one' },
+                        { index: 1, status: 'found', id: 2, title: 'Same', folder_path: 'root', current_revision_id: 2, properties: {}, body: 'two' },
+                        { index: 2, status: 'found', id: 3, title: 'Same', folder_path: 'root/sub', current_revision_id: 3, properties: {}, body: 'three' },
                     ],
                 });
             },
@@ -566,7 +566,7 @@ describe('docsPullWithConfig — overwrite confirm', () => {
         responseQueue = [
             makeMcpSuccess({ folders: [], docs: [{ id: 1, title: 'brief', properties: {} }] }),
             makeMcpSuccess({
-                results: [{ index: 0, status: 'ok', id: 1, title: 'brief', folder_path: 'marketing/fb-campaign', current_revision_id: 10, properties: {}, body: '# Brief' }],
+                results: [{ index: 0, status: 'found', id: 1, title: 'brief', folder_path: 'marketing/fb-campaign', current_revision_id: 10, properties: {}, body: '# Brief' }],
             }),
         ];
 
@@ -596,7 +596,7 @@ describe('docsPullWithConfig — --json', () => {
         responseQueue = [
             makeMcpSuccess({ folders: [], docs: [{ id: 1, title: 'brief', properties: {} }] }),
             makeMcpSuccess({
-                results: [{ index: 0, status: 'ok', id: 1, title: 'brief', folder_path: 'marketing/fb-campaign', current_revision_id: 10, properties: {}, body: '# Brief' }],
+                results: [{ index: 0, status: 'found', id: 1, title: 'brief', folder_path: 'marketing/fb-campaign', current_revision_id: 10, properties: {}, body: '# Brief' }],
             }),
         ];
 
@@ -635,7 +635,7 @@ describe('docsPullWithConfig — default destination', () => {
         responseQueue = [
             makeMcpSuccess({ folders: [], docs: [{ id: 1, title: 'brief', properties: {} }] }),
             makeMcpSuccess({
-                results: [{ index: 0, status: 'ok', id: 1, title: 'brief', folder_path: 'marketing/fb-campaign', current_revision_id: 10, properties: {}, body: '# Brief' }],
+                results: [{ index: 0, status: 'found', id: 1, title: 'brief', folder_path: 'marketing/fb-campaign', current_revision_id: 10, properties: {}, body: '# Brief' }],
             }),
         ];
 
@@ -673,7 +673,7 @@ describe('docsPullWithConfig — media docs', () => {
             }),
             makeMcpSuccess({
                 results: [{
-                    index: 0, status: 'ok', id: 7, title: 'hero.png', folder_path: '', current_revision_id: 9,
+                    index: 0, status: 'found', id: 7, title: 'hero.png', folder_path: '', current_revision_id: 9,
                     properties: { blob_sha: 'abc', mime: 'image/png', size: 3 }, body: '',
                 }],
             }),
@@ -720,7 +720,7 @@ describe('docsPullWithConfig — media docs', () => {
             }),
             makeMcpSuccess({
                 results: [{
-                    index: 0, status: 'ok', id: 8, title: 'fake', folder_path: '', current_revision_id: 11,
+                    index: 0, status: 'found', id: 8, title: 'fake', folder_path: '', current_revision_id: 11,
                     properties: { blob_sha: 'abc', mime: 'image/png', size: 3 }, body: '',
                 }],
             }),
@@ -760,7 +760,7 @@ describe('docsPullWithConfig — media docs', () => {
             }),
             makeMcpSuccess({
                 results: [{
-                    index: 0, status: 'ok', id: 9, title: 'hero', folder_path: '', current_revision_id: 12,
+                    index: 0, status: 'found', id: 9, title: 'hero', folder_path: '', current_revision_id: 12,
                     properties: { blob_sha: 'abc', mime: 'image/png', size: 3 }, body: '',
                 }],
             }),
@@ -797,7 +797,7 @@ describe('docsPullWithConfig — media docs', () => {
             }),
             makeMcpSuccess({
                 results: [{
-                    index: 0, status: 'ok', id: 11, title: 'lost.png', folder_path: '', current_revision_id: 14,
+                    index: 0, status: 'found', id: 11, title: 'lost.png', folder_path: '', current_revision_id: 14,
                     properties: { blob_sha: 'abc', mime: 'image/png', size: 3 }, body: '',
                 }],
             }),
@@ -839,7 +839,7 @@ describe('docsPullWithConfig — media docs', () => {
             }),
             makeMcpSuccess({
                 results: [{
-                    index: 0, status: 'ok', id: 10, title: 'broken', folder_path: '', current_revision_id: 13,
+                    index: 0, status: 'found', id: 10, title: 'broken', folder_path: '', current_revision_id: 13,
                     properties: { blob_sha: 'abc', mime: 'image/png', size: 3 }, body: '',
                 }],
             }),
@@ -858,6 +858,139 @@ describe('docsPullWithConfig — media docs', () => {
             expect(code).toBe(1);
             expect(stderrLines.join('')).toContain('internal_error');
             expect(fs.existsSync(path.join(dest, 'broken.md'))).toBe(false);
+        } finally {
+            restoreExit();
+            restoreStderr();
+            cleanup();
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// bulk_read row-status guard
+// ---------------------------------------------------------------------------
+
+describe('docsPullWithConfig — bulk_read row-status guard', () => {
+    it('a non-ok status row and a row missing from results are both warned + skipped; the ok row still pulls', async () => {
+        responseQueue = [
+            makeMcpSuccess({
+                folders: [],
+                docs: [
+                    { id: 1, title: 'good', properties: {} },
+                    { id: 2, title: 'broken', properties: {} },
+                    { id: 3, title: 'ghost', properties: {} },
+                ],
+            }),
+            (body: any) => {
+                const ids = body.params.arguments.items.map((i: any) => i.id);
+                expect(ids).toEqual([1, 2, 3]);
+                return makeMcpSuccess({
+                    results: [
+                        { index: 0, status: 'found', id: 1, title: 'good', folder_path: 'root', current_revision_id: 1, properties: {}, body: 'ok body' },
+                        { index: 1, status: 'error', id: 2, title: 'broken', folder_path: 'root', error: 'boom' },
+                        // id 3 ("ghost") is entirely absent from results.
+                    ],
+                });
+            },
+        ];
+
+        const { dir: tmpDest, cleanup } = makeTmpDir();
+        const dest = path.join(tmpDest, 'out');
+        const restoreExit = patchProcessExit();
+        const { restore: restoreStdout } = captureStdout();
+        const { lines: stderrLines, restore: restoreStderr } = captureStderr();
+
+        try {
+            const code = await runExpectingExit(() => docsPullWithConfig('root', dest, {}, stubConfig()));
+            expect(code).toBe(0);
+
+            expect(fs.readFileSync(path.join(dest, 'good.md'), 'utf8')).toBe('ok body');
+            expect(fs.existsSync(path.join(dest, 'broken.md'))).toBe(false);
+            expect(fs.existsSync(path.join(dest, 'ghost.md'))).toBe(false);
+
+            const manifest = readManifest(dest);
+            expect(Object.keys(manifest.docs)).toEqual(['good.md']);
+
+            const err = stderrLines.join('');
+            expect(err).toContain('broken');
+            expect(err).toContain('ghost');
+        } finally {
+            restoreExit();
+            restoreStdout();
+            restoreStderr();
+            cleanup();
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Folder-name path traversal (sanitizeSegment)
+// ---------------------------------------------------------------------------
+
+describe('docsPullWithConfig — folder-name path traversal', () => {
+    it('a folder named ".." is sanitized so the doc inside it lands under the destination', async () => {
+        responseQueue = [
+            makeMcpSuccess({
+                folders: [{ id: 100, name: '..', parent_folder_id: 1, folder_path: 'evil/..' }],
+                docs: [],
+            }),
+            makeMcpSuccess({
+                folders: [],
+                docs: [{ id: 1, title: 'gotcha', properties: {} }],
+            }),
+            makeMcpSuccess({
+                results: [
+                    { index: 0, status: 'found', id: 1, title: 'gotcha', folder_path: 'evil/..', current_revision_id: 1, properties: {}, body: 'x' },
+                ],
+            }),
+        ];
+
+        const { dir: tmpDest, cleanup } = makeTmpDir();
+        const dest = path.join(tmpDest, 'out');
+        const restoreExit = patchProcessExit();
+        const { restore: restoreStdout } = captureStdout();
+
+        try {
+            const code = await runExpectingExit(() => docsPullWithConfig('evil', dest, {}, stubConfig()));
+            expect(code).toBe(0);
+
+            const manifest = readManifest(dest);
+            const relPaths = Object.keys(manifest.docs);
+            expect(relPaths.length).toBe(1);
+
+            const writtenAbs = path.resolve(dest, relPaths[0]);
+            expect(writtenAbs.startsWith(dest + path.sep)).toBe(true);
+            expect(fs.existsSync(writtenAbs)).toBe(true);
+
+            // Nothing was written outside the destination directory.
+            const outsidePath = path.resolve(dest, '..', 'gotcha.md');
+            expect(fs.existsSync(outsidePath)).toBe(false);
+        } finally {
+            restoreExit();
+            restoreStdout();
+            cleanup();
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Destination resolves to an existing file
+// ---------------------------------------------------------------------------
+
+describe('docsPullWithConfig — destination is a file', () => {
+    it('exits 1 with a clear error instead of throwing ENOTDIR', async () => {
+        const { dir: tmpDest, cleanup } = makeTmpDir();
+        const dest = path.join(tmpDest, 'not-a-dir');
+        fs.writeFileSync(dest, 'i am a file', 'utf8');
+
+        const restoreExit = patchProcessExit();
+        const { lines: stderrLines, restore: restoreStderr } = captureStderr();
+
+        try {
+            const code = await runExpectingExit(() => docsPullWithConfig('marketing/fb-campaign', dest, {}, stubConfig()));
+            expect(code).toBe(1);
+            expect(stderrLines.join('')).toMatch(/not a directory/i);
+            expect(allCaptures.length).toBe(0);
         } finally {
             restoreExit();
             restoreStderr();

--- a/tests/docs-pull.test.ts
+++ b/tests/docs-pull.test.ts
@@ -10,11 +10,17 @@ import * as fs from 'fs';
 import * as http from 'http';
 import * as os from 'os';
 import * as path from 'path';
+import * as crypto from 'crypto';
 import prompts from 'prompts';
 import { describe, expect, it, beforeAll, afterAll, beforeEach } from 'vitest';
 import { docsPullWithConfig, sanitizeTitle, DOCS_MANIFEST } from '../src/commands/docs-pull';
 import type { DocsManifest } from '../src/commands/docs-pull';
 import type { Config } from '../src/utils/config';
+
+/** sha256 hex digest, for asserting manifest body_sha256 values in tests. */
+function sha256Hex(data: string | Buffer): string {
+    return crypto.createHash('sha256').update(data).digest('hex');
+}
 
 // ---------------------------------------------------------------------------
 // Stub MCP server
@@ -269,8 +275,8 @@ describe('docsPullWithConfig — folder tree', () => {
             expect(fs.readFileSync(path.join(dest, 'ads', 'ad-a.md'), 'utf8')).toBe('# Ad A');
 
             const manifest = readManifest(dest);
-            expect(manifest.docs['brief.md']).toEqual({ id: 1, title: 'brief', current_revision_id: 10, media: false });
-            expect(manifest.docs['ads/ad-a.md']).toEqual({ id: 2, title: 'ad-a', current_revision_id: 20, media: false });
+            expect(manifest.docs['brief.md']).toEqual({ id: 1, title: 'brief', current_revision_id: 10, media: false, body_sha256: sha256Hex('# Brief') });
+            expect(manifest.docs['ads/ad-a.md']).toEqual({ id: 2, title: 'ad-a', current_revision_id: 20, media: false, body_sha256: sha256Hex('# Ad A') });
             expect(manifest.folder_path).toBe('marketing/fb-campaign');
 
             // Manifest file itself is pretty-printed with a trailing newline
@@ -431,7 +437,7 @@ describe('docsPullWithConfig — single-doc fallback', () => {
             expect(fs.readFileSync(path.join(dest, 'solo.md'), 'utf8')).toBe('x');
             const manifest = readManifest(dest);
             expect(Object.keys(manifest.docs).length).toBe(1);
-            expect(manifest.docs['solo.md']).toEqual({ id: 5, title: 'solo', current_revision_id: 3, media: false });
+            expect(manifest.docs['solo.md']).toEqual({ id: 5, title: 'solo', current_revision_id: 3, media: false, body_sha256: sha256Hex('x') });
 
             expect(allCaptures.length).toBe(2);
         } finally {
@@ -617,7 +623,7 @@ describe('docsPullWithConfig — --json', () => {
             expect(parsed).toHaveProperty('manifest');
             expect(parsed).toHaveProperty('files');
             expect(parsed.files).toEqual([{ path: 'brief.md', action: 'written' }]);
-            expect(parsed.manifest.docs['brief.md']).toEqual({ id: 1, title: 'brief', current_revision_id: 10, media: false });
+            expect(parsed.manifest.docs['brief.md']).toEqual({ id: 1, title: 'brief', current_revision_id: 10, media: false, body_sha256: sha256Hex('# Brief') });
         } finally {
             restoreExit();
             restoreStdout();
@@ -696,7 +702,7 @@ describe('docsPullWithConfig — media docs', () => {
             expect(fs.readFileSync(path.join(dest, 'hero.png'))).toEqual(stubBytes);
 
             const manifest = readManifest(dest);
-            expect(manifest.docs['hero.png']).toEqual({ id: 7, title: 'hero.png', current_revision_id: 9, media: true });
+            expect(manifest.docs['hero.png']).toEqual({ id: 7, title: 'hero.png', current_revision_id: 9, media: true, body_sha256: sha256Hex(stubBytes) });
 
             const confirmCall = allCaptures.find((c) => c.path === '/api/v1/docs/7/media');
             expect(confirmCall).toBeDefined();
@@ -741,7 +747,7 @@ describe('docsPullWithConfig — media docs', () => {
             expect(fs.readFileSync(path.join(dest, 'fake.md'), 'utf8')).toBe('');
 
             const manifest = readManifest(dest);
-            expect(manifest.docs['fake.md']).toEqual({ id: 8, title: 'fake', current_revision_id: 11, media: false });
+            expect(manifest.docs['fake.md']).toEqual({ id: 8, title: 'fake', current_revision_id: 11, media: false, body_sha256: sha256Hex('') });
 
             // No signed-URL download was attempted.
             expect(allCaptures.find((c) => c.path?.startsWith('/blob/'))).toBeUndefined();
@@ -781,7 +787,7 @@ describe('docsPullWithConfig — media docs', () => {
 
             expect(fs.existsSync(path.join(dest, 'hero.png'))).toBe(true);
             const manifest = readManifest(dest);
-            expect(manifest.docs['hero.png']).toEqual({ id: 9, title: 'hero', current_revision_id: 12, media: true });
+            expect(manifest.docs['hero.png']).toEqual({ id: 9, title: 'hero', current_revision_id: 12, media: true, body_sha256: sha256Hex(Buffer.from([9, 9, 9])) });
         } finally {
             restoreExit();
             restoreStdout();
@@ -820,7 +826,7 @@ describe('docsPullWithConfig — media docs', () => {
             expect(fs.existsSync(path.join(dest, 'lost.png'))).toBe(false);
 
             const manifest = readManifest(dest);
-            expect(manifest.docs['lost.png']).toEqual({ id: 11, title: 'lost.png', current_revision_id: 14, media: true });
+            expect(manifest.docs['lost.png']).toEqual({ id: 11, title: 'lost.png', current_revision_id: 14, media: true, body_sha256: null });
 
             expect(stderrLines.join('')).toContain('lost.png');
         } finally {
@@ -861,6 +867,58 @@ describe('docsPullWithConfig — media docs', () => {
         } finally {
             restoreExit();
             restoreStderr();
+            cleanup();
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Content hashes — body_sha256 recorded per manifest entry
+// ---------------------------------------------------------------------------
+
+describe('docsPullWithConfig — content hashes', () => {
+    it('records body_sha256 as the sha256 hex of the exact bytes written, for both a markdown doc and a media doc', async () => {
+        const mdBody = '# Hashed Doc\n\nSome content.';
+        const mediaBytes = Buffer.from([10, 20, 30, 40]);
+
+        responseQueue = [
+            makeMcpSuccess({
+                folders: [],
+                docs: [
+                    { id: 1, title: 'hashed-doc', properties: {} },
+                    { id: 2, title: 'hashed.png', properties: { blob_sha: 'abc', mime: 'image/png', size: mediaBytes.length } },
+                ],
+            }),
+            makeMcpSuccess({
+                results: [
+                    { index: 0, status: 'found', id: 1, title: 'hashed-doc', folder_path: '', current_revision_id: 1, properties: {}, body: mdBody },
+                    {
+                        index: 1, status: 'found', id: 2, title: 'hashed.png', folder_path: '', current_revision_id: 2,
+                        properties: { blob_sha: 'abc', mime: 'image/png', size: mediaBytes.length }, body: '',
+                    },
+                ],
+            }),
+        ];
+        mediaResponseQueue = [
+            { status: 200, body: { url: `http://127.0.0.1:${stubPort}/blob/2`, mime: 'image/png', size: mediaBytes.length } },
+        ];
+        blobResponseQueue = [{ status: 200, bytes: mediaBytes }];
+
+        const { dir: tmpDest, cleanup } = makeTmpDir();
+        const dest = path.join(tmpDest, 'out');
+        const restoreExit = patchProcessExit();
+        const { restore: restoreStdout } = captureStdout();
+
+        try {
+            const code = await runExpectingExit(() => docsPullWithConfig('hash-tree', dest, {}, stubConfig()));
+            expect(code).toBe(0);
+
+            const manifest = readManifest(dest);
+            expect(manifest.docs['hashed-doc.md'].body_sha256).toBe(sha256Hex(mdBody));
+            expect(manifest.docs['hashed.png'].body_sha256).toBe(sha256Hex(mediaBytes));
+        } finally {
+            restoreExit();
+            restoreStdout();
             cleanup();
         }
     });

--- a/tests/docs-pull.test.ts
+++ b/tests/docs-pull.test.ts
@@ -789,6 +789,48 @@ describe('docsPullWithConfig — media docs', () => {
         }
     });
 
+    it('confirmed media whose signed-URL download fails: soft-skips the write, keeps the manifest entry, warns', async () => {
+        responseQueue = [
+            makeMcpSuccess({
+                folders: [],
+                docs: [{ id: 11, title: 'lost.png', properties: { blob_sha: 'abc', mime: 'image/png', size: 3 } }],
+            }),
+            makeMcpSuccess({
+                results: [{
+                    index: 0, status: 'ok', id: 11, title: 'lost.png', folder_path: '', current_revision_id: 14,
+                    properties: { blob_sha: 'abc', mime: 'image/png', size: 3 }, body: '',
+                }],
+            }),
+        ];
+        mediaResponseQueue = [
+            { status: 200, body: { url: `http://127.0.0.1:${stubPort}/blob/11`, mime: 'image/png', size: 3 } },
+        ];
+        blobResponseQueue = [{ status: 500, bytes: Buffer.alloc(0) }];
+
+        const { dir: tmpDest, cleanup } = makeTmpDir();
+        const dest = path.join(tmpDest, 'out');
+        const restoreExit = patchProcessExit();
+        const { restore: restoreStdout } = captureStdout();
+        const { lines: stderrLines, restore: restoreStderr } = captureStderr();
+
+        try {
+            const code = await runExpectingExit(() => docsPullWithConfig('media', dest, {}, stubConfig()));
+            expect(code).toBe(0);
+
+            expect(fs.existsSync(path.join(dest, 'lost.png'))).toBe(false);
+
+            const manifest = readManifest(dest);
+            expect(manifest.docs['lost.png']).toEqual({ id: 11, title: 'lost.png', current_revision_id: 14, media: true });
+
+            expect(stderrLines.join('')).toContain('lost.png');
+        } finally {
+            restoreExit();
+            restoreStdout();
+            restoreStderr();
+            cleanup();
+        }
+    });
+
     it('exits 1 on an unexpected media-confirm error (not the documented 404 media_not_found false positive)', async () => {
         responseQueue = [
             makeMcpSuccess({

--- a/tests/docs-pull.test.ts
+++ b/tests/docs-pull.test.ts
@@ -1,0 +1,638 @@
+/**
+ * Tests for `solidactions docs pull <folder> [dest]`
+ *
+ * Uses a real in-process HTTP server (Node's http.createServer) to stub the
+ * unified /mcp endpoint. No mock/spy/stub libraries — follows the pattern in
+ * tests/docs-push.test.ts.
+ */
+
+import * as fs from 'fs';
+import * as http from 'http';
+import * as os from 'os';
+import * as path from 'path';
+import prompts from 'prompts';
+import { describe, expect, it, beforeAll, afterAll, beforeEach } from 'vitest';
+import { docsPullWithConfig, sanitizeTitle, DOCS_MANIFEST } from '../src/commands/docs-pull';
+import type { DocsManifest } from '../src/commands/docs-pull';
+import type { Config } from '../src/utils/config';
+
+// ---------------------------------------------------------------------------
+// Stub MCP server
+// ---------------------------------------------------------------------------
+
+interface CapturedRequest {
+    method: string | undefined;
+    path: string | undefined;
+    headers: http.IncomingHttpHeaders;
+    body: any;
+}
+
+let stubServer: http.Server;
+let stubPort: number;
+let allCaptures: CapturedRequest[] = [];
+
+/** Build a canned MCP success response wrapping toolData. */
+function makeMcpSuccess(toolData: object): string {
+    return JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        result: {
+            isError: false,
+            content: [{ type: 'text', text: JSON.stringify(toolData) }],
+        },
+    });
+}
+
+/** Build a canned MCP error response (isError envelope). */
+function makeMcpError(code: string, message: string): string {
+    return JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        result: {
+            isError: true,
+            content: [{ type: 'text', text: JSON.stringify({ code, message }) }],
+        },
+    });
+}
+
+let responseQueue: Array<string | ((body: any) => string)> = [];
+
+function nextResponseBody(body: any): string {
+    const entry = responseQueue.length > 0 ? responseQueue.shift()! : null;
+    if (entry === null) {
+        // Default: empty list result
+        return makeMcpSuccess({ folders: [], docs: [] });
+    }
+    if (typeof entry === 'function') return entry(body);
+    return entry;
+}
+
+beforeAll(async () => {
+    stubServer = http.createServer((req, res) => {
+        let rawBody = '';
+        req.on('data', (chunk) => { rawBody += chunk; });
+        req.on('end', () => {
+            let parsedBody: any = null;
+            try { parsedBody = JSON.parse(rawBody); } catch { /* ignore */ }
+
+            const capture: CapturedRequest = {
+                method: req.method,
+                path: req.url,
+                headers: req.headers,
+                body: parsedBody,
+            };
+
+            allCaptures.push(capture);
+
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(nextResponseBody(parsedBody));
+        });
+    });
+
+    await new Promise<void>((resolve) => {
+        stubServer.listen(0, '127.0.0.1', () => {
+            stubPort = (stubServer.address() as { port: number }).port;
+            resolve();
+        });
+    });
+});
+
+afterAll(() => {
+    return new Promise<void>((resolve, reject) => {
+        stubServer.close((err) => (err ? reject(err) : resolve()));
+    });
+});
+
+beforeEach(() => {
+    allCaptures = [];
+    responseQueue = [];
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a Config that points at the stub server. */
+function stubConfig(workspaceId = 'ws-test-uuid'): Config {
+    return {
+        host: `http://127.0.0.1:${stubPort}`,
+        apiKey: 'test-api-key',
+        workspaceId,
+    };
+}
+
+/** Sentinel thrown by the patched process.exit so execution stops. */
+class ProcessExitError extends Error {
+    constructor(public readonly code: number | undefined) {
+        super(`process.exit(${code})`);
+    }
+}
+
+/** Patch process.exit to throw ProcessExitError so tests can catch it. */
+function patchProcessExit(): () => void {
+    const orig = process.exit.bind(process);
+    (process as any).exit = (code?: number) => { throw new ProcessExitError(code); };
+    return () => { (process as any).exit = orig; };
+}
+
+/** Patch process.stderr.write to capture output. */
+function captureStderr(): { lines: string[]; restore: () => void } {
+    const lines: string[] = [];
+    const orig = process.stderr.write.bind(process.stderr);
+    (process.stderr as any).write = (chunk: string) => { lines.push(String(chunk)); return true; };
+    return { lines, restore: () => { (process.stderr as any).write = orig; } };
+}
+
+/** Patch console.log to capture output lines. */
+function captureStdout(): { lines: string[]; restore: () => void } {
+    const lines: string[] = [];
+    const orig = console.log;
+    console.log = (m?: any) => { lines.push(String(m ?? '')); };
+    return { lines, restore: () => { console.log = orig; } };
+}
+
+/** Run fn, expecting it to call process.exit; returns the captured exit code. */
+async function runExpectingExit(fn: () => Promise<void>): Promise<number | undefined> {
+    try {
+        await fn();
+    } catch (e) {
+        if (e instanceof ProcessExitError) return e.code;
+        throw e;
+    }
+    return undefined;
+}
+
+function makeTmpDir(): { dir: string; cleanup: () => void } {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sa-docs-pull-test-'));
+    return { dir, cleanup: () => fs.rmSync(dir, { recursive: true, force: true }) };
+}
+
+function readManifest(dest: string): DocsManifest {
+    const raw = fs.readFileSync(path.join(dest, DOCS_MANIFEST), 'utf8');
+    return JSON.parse(raw);
+}
+
+// ---------------------------------------------------------------------------
+// Unit: sanitizeTitle
+// ---------------------------------------------------------------------------
+
+describe('sanitizeTitle', () => {
+    it('replaces filesystem-unsafe characters with underscores', () => {
+        expect(sanitizeTitle('a/b:c')).toBe('a_b_c');
+    });
+
+    it('replaces all reserved characters and control chars', () => {
+        expect(sanitizeTitle('a*b?c"d<e>f|g')).toBe('a_b_c_d_e_f_g');
+        expect(sanitizeTitle('x\\y')).toBe('x_y');
+        expect(sanitizeTitle('ctrl\x01char')).toBe('ctrl_char');
+    });
+
+    it('leaves already-safe titles unchanged', () => {
+        expect(sanitizeTitle('My Doc Title')).toBe('My Doc Title');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: BFS folder tree pull
+// ---------------------------------------------------------------------------
+
+describe('docsPullWithConfig — folder tree', () => {
+    it('BFS-walks a folder tree, writes files + manifest with ids/revisions', async () => {
+        responseQueue = [
+            // list on marketing/fb-campaign -> one subfolder (ads) + root doc "brief"
+            (body: any) => {
+                expect(body.params.arguments.action).toBe('list');
+                expect(body.params.arguments.folder_path).toBe('marketing/fb-campaign');
+                return makeMcpSuccess({
+                    folders: [{ id: 100, name: 'ads', parent_folder_id: 1, folder_path: 'marketing/fb-campaign/ads' }],
+                    docs: [{ id: 1, title: 'brief', properties: {}, folder_id: 1, updated_at: '2026-01-01' }],
+                });
+            },
+            // list on marketing/fb-campaign/ads -> one doc "ad-a"
+            (body: any) => {
+                expect(body.params.arguments.action).toBe('list');
+                expect(body.params.arguments.folder_path).toBe('marketing/fb-campaign/ads');
+                return makeMcpSuccess({
+                    folders: [],
+                    docs: [{ id: 2, title: 'ad-a', properties: {}, folder_id: 100, updated_at: '2026-01-01' }],
+                });
+            },
+            // bulk_read for ids [1, 2]
+            (body: any) => {
+                expect(body.params.arguments.action).toBe('bulk_read');
+                const ids = body.params.arguments.items.map((i: any) => i.id);
+                expect(ids).toEqual([1, 2]);
+                return makeMcpSuccess({
+                    results: [
+                        { index: 0, status: 'ok', id: 1, title: 'brief', folder_path: 'marketing/fb-campaign', current_revision_id: 10, properties: {}, body: '# Brief' },
+                        { index: 1, status: 'ok', id: 2, title: 'ad-a', folder_path: 'marketing/fb-campaign/ads', current_revision_id: 20, properties: {}, body: '# Ad A' },
+                    ],
+                });
+            },
+        ];
+
+        const { dir: tmpDest, cleanup } = makeTmpDir();
+        const dest = path.join(tmpDest, 'out');
+        const restoreExit = patchProcessExit();
+        const { restore: restoreStdout } = captureStdout();
+
+        try {
+            const code = await runExpectingExit(() =>
+                docsPullWithConfig('marketing/fb-campaign', dest, {}, stubConfig()),
+            );
+            expect(code).toBe(0);
+
+            expect(fs.readFileSync(path.join(dest, 'brief.md'), 'utf8')).toBe('# Brief');
+            expect(fs.readFileSync(path.join(dest, 'ads', 'ad-a.md'), 'utf8')).toBe('# Ad A');
+
+            const manifest = readManifest(dest);
+            expect(manifest.docs['brief.md']).toEqual({ id: 1, title: 'brief', current_revision_id: 10, media: false });
+            expect(manifest.docs['ads/ad-a.md']).toEqual({ id: 2, title: 'ad-a', current_revision_id: 20, media: false });
+            expect(manifest.folder_path).toBe('marketing/fb-campaign');
+
+            // Manifest file itself is pretty-printed with a trailing newline
+            const raw = fs.readFileSync(path.join(dest, DOCS_MANIFEST), 'utf8');
+            expect(raw.endsWith('\n')).toBe(true);
+            expect(raw).toContain('\n  ');
+
+            // All requests hit /mcp with docs_vault
+            expect(allCaptures.length).toBe(3);
+            for (const cap of allCaptures) {
+                expect(cap.path).toBe('/mcp');
+                expect(cap.body.params.name).toBe('docs_vault');
+            }
+        } finally {
+            restoreExit();
+            restoreStdout();
+            cleanup();
+        }
+    });
+
+    it('bulk_read is chunked at 50 ids per call', async () => {
+        const docs = Array.from({ length: 60 }, (_, i) => ({ id: i + 1, title: `doc-${i + 1}`, properties: {} }));
+        responseQueue = [
+            makeMcpSuccess({ folders: [], docs }),
+            (body: any) => {
+                const items = body.params.arguments.items;
+                expect(items.length).toBeLessThanOrEqual(50);
+                return makeMcpSuccess({
+                    results: items.map((it: any, i: number) => ({
+                        index: i, status: 'ok', id: it.id, title: `doc-${it.id}`,
+                        folder_path: 'many', current_revision_id: it.id * 10, properties: {}, body: `body-${it.id}`,
+                    })),
+                });
+            },
+            (body: any) => {
+                const items = body.params.arguments.items;
+                return makeMcpSuccess({
+                    results: items.map((it: any, i: number) => ({
+                        index: i, status: 'ok', id: it.id, title: `doc-${it.id}`,
+                        folder_path: 'many', current_revision_id: it.id * 10, properties: {}, body: `body-${it.id}`,
+                    })),
+                });
+            },
+        ];
+
+        const { dir: tmpDest, cleanup } = makeTmpDir();
+        const dest = path.join(tmpDest, 'out');
+        const restoreExit = patchProcessExit();
+        const { restore: restoreStdout } = captureStdout();
+
+        try {
+            const code = await runExpectingExit(() => docsPullWithConfig('many', dest, {}, stubConfig()));
+            expect(code).toBe(0);
+
+            // 1 list call + 2 bulk_read calls (50 + 10)
+            expect(allCaptures.length).toBe(3);
+            const bulkCalls = allCaptures.slice(1);
+            expect(bulkCalls[0].body.params.arguments.items.length).toBe(50);
+            expect(bulkCalls[1].body.params.arguments.items.length).toBe(10);
+
+            const manifest = readManifest(dest);
+            expect(Object.keys(manifest.docs).length).toBe(60);
+        } finally {
+            restoreExit();
+            restoreStdout();
+            cleanup();
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Unit/integration: collision suffixing
+// ---------------------------------------------------------------------------
+
+describe('docsPullWithConfig — title collisions', () => {
+    it('two docs titled "Same" in different folders get no suffix; same folder gets -2', async () => {
+        responseQueue = [
+            // root list: one subfolder "sub" + one root doc "Same"
+            makeMcpSuccess({
+                folders: [{ id: 10, name: 'sub', parent_folder_id: 1, folder_path: 'root/sub' }],
+                docs: [
+                    { id: 1, title: 'Same', properties: {} },
+                    { id: 2, title: 'Same', properties: {} },
+                ],
+            }),
+            // sub list: one doc "Same"
+            makeMcpSuccess({
+                folders: [],
+                docs: [{ id: 3, title: 'Same', properties: {} }],
+            }),
+            // bulk_read for [1, 2, 3]
+            (body: any) => {
+                const ids = body.params.arguments.items.map((i: any) => i.id);
+                expect(ids).toEqual([1, 2, 3]);
+                return makeMcpSuccess({
+                    results: [
+                        { index: 0, status: 'ok', id: 1, title: 'Same', folder_path: 'root', current_revision_id: 1, properties: {}, body: 'one' },
+                        { index: 1, status: 'ok', id: 2, title: 'Same', folder_path: 'root', current_revision_id: 2, properties: {}, body: 'two' },
+                        { index: 2, status: 'ok', id: 3, title: 'Same', folder_path: 'root/sub', current_revision_id: 3, properties: {}, body: 'three' },
+                    ],
+                });
+            },
+        ];
+
+        const { dir: tmpDest, cleanup } = makeTmpDir();
+        const dest = path.join(tmpDest, 'out');
+        const restoreExit = patchProcessExit();
+        const { restore: restoreStdout } = captureStdout();
+
+        try {
+            const code = await runExpectingExit(() => docsPullWithConfig('root', dest, {}, stubConfig()));
+            expect(code).toBe(0);
+
+            // Same-folder collision: "Same.md" and "Same -2.md"
+            expect(fs.readFileSync(path.join(dest, 'Same.md'), 'utf8')).toBe('one');
+            expect(fs.readFileSync(path.join(dest, 'Same -2.md'), 'utf8')).toBe('two');
+            // Different folder: no suffix needed
+            expect(fs.readFileSync(path.join(dest, 'sub', 'Same.md'), 'utf8')).toBe('three');
+
+            const manifest = readManifest(dest);
+            expect(Object.keys(manifest.docs).sort()).toEqual(['Same -2.md', 'Same.md', 'sub/Same.md'].sort());
+        } finally {
+            restoreExit();
+            restoreStdout();
+            cleanup();
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Single-doc fallback
+// ---------------------------------------------------------------------------
+
+describe('docsPullWithConfig — single-doc fallback', () => {
+    it('falls back to a single read when list 404s with folder_path_not_found', async () => {
+        responseQueue = [
+            (body: any) => {
+                expect(body.params.arguments.action).toBe('list');
+                expect(body.params.arguments.folder_path).toBe('notes/solo');
+                return makeMcpError('folder_path_not_found', 'No folder at that path');
+            },
+            (body: any) => {
+                expect(body.params.arguments.action).toBe('read');
+                expect(body.params.arguments.path).toEqual({ folder_path: 'notes', title: 'solo' });
+                return makeMcpSuccess({ id: 5, title: 'solo', body: 'x', current_revision_id: 3, folder_path: 'notes' });
+            },
+        ];
+
+        const { dir: tmpDest, cleanup } = makeTmpDir();
+        const dest = path.join(tmpDest, 'out');
+        const restoreExit = patchProcessExit();
+        const { restore: restoreStdout } = captureStdout();
+
+        try {
+            const code = await runExpectingExit(() => docsPullWithConfig('notes/solo', dest, {}, stubConfig()));
+            expect(code).toBe(0);
+
+            expect(fs.readFileSync(path.join(dest, 'solo.md'), 'utf8')).toBe('x');
+            const manifest = readManifest(dest);
+            expect(Object.keys(manifest.docs).length).toBe(1);
+            expect(manifest.docs['solo.md']).toEqual({ id: 5, title: 'solo', current_revision_id: 3, media: false });
+
+            expect(allCaptures.length).toBe(2);
+        } finally {
+            restoreExit();
+            restoreStdout();
+            cleanup();
+        }
+    });
+
+    it('omits path.folder_path when the target is a root-level doc', async () => {
+        responseQueue = [
+            (body: any) => {
+                expect(body.params.arguments.folder_path).toBe('solo');
+                return makeMcpError('folder_path_not_found', 'No folder at that path');
+            },
+            (body: any) => {
+                expect(body.params.arguments.path).toEqual({ title: 'solo' });
+                return makeMcpSuccess({ id: 5, title: 'solo', body: 'x', current_revision_id: 3 });
+            },
+        ];
+
+        const { dir: tmpDest, cleanup } = makeTmpDir();
+        const dest = path.join(tmpDest, 'out');
+        const restoreExit = patchProcessExit();
+        const { restore: restoreStdout } = captureStdout();
+
+        try {
+            const code = await runExpectingExit(() => docsPullWithConfig('solo', dest, {}, stubConfig()));
+            expect(code).toBe(0);
+            expect(fs.readFileSync(path.join(dest, 'solo.md'), 'utf8')).toBe('x');
+        } finally {
+            restoreExit();
+            restoreStdout();
+            cleanup();
+        }
+    });
+
+    it('exits 1 with both errors when list 404s and the read fallback also fails', async () => {
+        responseQueue = [
+            makeMcpError('folder_path_not_found', 'No folder at that path'),
+            makeMcpError('doc_not_found', 'No doc at that path either'),
+        ];
+
+        const { dir: tmpDest, cleanup } = makeTmpDir();
+        const dest = path.join(tmpDest, 'out');
+        const restoreExit = patchProcessExit();
+        const { lines: stderrLines, restore: restoreStderr } = captureStderr();
+
+        try {
+            const code = await runExpectingExit(() => docsPullWithConfig('notes/ghost', dest, {}, stubConfig()));
+            expect(code).not.toBe(0);
+            const out = stderrLines.join('');
+            expect(out).toContain('folder_path_not_found');
+            expect(out).toContain('doc_not_found');
+            expect(fs.existsSync(dest)).toBe(false);
+        } finally {
+            restoreExit();
+            restoreStderr();
+            cleanup();
+        }
+    });
+
+    it('exits 1 immediately (no fallback attempted) when list fails with a different error code', async () => {
+        responseQueue = [
+            makeMcpError('permission_denied', 'not allowed'),
+        ];
+
+        const { dir: tmpDest, cleanup } = makeTmpDir();
+        const dest = path.join(tmpDest, 'out');
+        const restoreExit = patchProcessExit();
+        const { lines: stderrLines, restore: restoreStderr } = captureStderr();
+
+        try {
+            const code = await runExpectingExit(() => docsPullWithConfig('marketing/fb-campaign', dest, {}, stubConfig()));
+            expect(code).not.toBe(0);
+            expect(allCaptures.length).toBe(1);
+            expect(stderrLines.join('')).toContain('permission_denied');
+        } finally {
+            restoreExit();
+            restoreStderr();
+            cleanup();
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Overwrite confirmation
+// ---------------------------------------------------------------------------
+
+describe('docsPullWithConfig — overwrite confirm', () => {
+    it('non-empty dest without --yes: declining the prompt exits 0 and writes nothing', async () => {
+        const { dir: tmpDest, cleanup } = makeTmpDir();
+        const dest = path.join(tmpDest, 'out');
+        fs.mkdirSync(dest, { recursive: true });
+        fs.writeFileSync(path.join(dest, 'existing.txt'), 'hi', 'utf8');
+
+        responseQueue = [
+            makeMcpSuccess({
+                folders: [],
+                docs: [{ id: 1, title: 'brief', properties: {} }],
+            }),
+        ];
+
+        const restoreExit = patchProcessExit();
+        const { lines: logLines, restore: restoreStdout } = captureStdout();
+
+        try {
+            prompts.inject([false]);
+            const code = await runExpectingExit(() => docsPullWithConfig('marketing/fb-campaign', dest, {}, stubConfig()));
+            expect(code).toBe(0);
+
+            // No MCP calls at all — confirmation happens before any network I/O
+            expect(allCaptures.length).toBe(0);
+            // Existing file untouched, no manifest written
+            expect(fs.existsSync(path.join(dest, 'existing.txt'))).toBe(true);
+            expect(fs.existsSync(path.join(dest, DOCS_MANIFEST))).toBe(false);
+            expect(fs.existsSync(path.join(dest, 'brief.md'))).toBe(false);
+            expect(logLines.join('\n')).toContain('Cancelled');
+        } finally {
+            restoreExit();
+            restoreStdout();
+            cleanup();
+        }
+    });
+
+    it('--yes bypasses the confirmation on a non-empty dest', async () => {
+        const { dir: tmpDest, cleanup } = makeTmpDir();
+        const dest = path.join(tmpDest, 'out');
+        fs.mkdirSync(dest, { recursive: true });
+        fs.writeFileSync(path.join(dest, 'existing.txt'), 'hi', 'utf8');
+
+        responseQueue = [
+            makeMcpSuccess({ folders: [], docs: [{ id: 1, title: 'brief', properties: {} }] }),
+            makeMcpSuccess({
+                results: [{ index: 0, status: 'ok', id: 1, title: 'brief', folder_path: 'marketing/fb-campaign', current_revision_id: 10, properties: {}, body: '# Brief' }],
+            }),
+        ];
+
+        const restoreExit = patchProcessExit();
+        const { restore: restoreStdout } = captureStdout();
+
+        try {
+            const code = await runExpectingExit(() =>
+                docsPullWithConfig('marketing/fb-campaign', dest, { yes: true }, stubConfig()),
+            );
+            expect(code).toBe(0);
+            expect(fs.readFileSync(path.join(dest, 'brief.md'), 'utf8')).toBe('# Brief');
+        } finally {
+            restoreExit();
+            restoreStdout();
+            cleanup();
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// --json output
+// ---------------------------------------------------------------------------
+
+describe('docsPullWithConfig — --json', () => {
+    it('prints {manifest, files} JSON instead of chalk lines', async () => {
+        responseQueue = [
+            makeMcpSuccess({ folders: [], docs: [{ id: 1, title: 'brief', properties: {} }] }),
+            makeMcpSuccess({
+                results: [{ index: 0, status: 'ok', id: 1, title: 'brief', folder_path: 'marketing/fb-campaign', current_revision_id: 10, properties: {}, body: '# Brief' }],
+            }),
+        ];
+
+        const { dir: tmpDest, cleanup } = makeTmpDir();
+        const dest = path.join(tmpDest, 'out');
+        const restoreExit = patchProcessExit();
+        const { lines: logLines, restore: restoreStdout } = captureStdout();
+
+        try {
+            const code = await runExpectingExit(() =>
+                docsPullWithConfig('marketing/fb-campaign', dest, { json: true }, stubConfig()),
+            );
+            expect(code).toBe(0);
+
+            const jsonLine = logLines.find((l) => l.trim().startsWith('{'));
+            expect(jsonLine).toBeDefined();
+            const parsed = JSON.parse(jsonLine!);
+            expect(parsed).toHaveProperty('manifest');
+            expect(parsed).toHaveProperty('files');
+            expect(parsed.files).toEqual([{ path: 'brief.md', action: 'written' }]);
+            expect(parsed.manifest.docs['brief.md']).toEqual({ id: 1, title: 'brief', current_revision_id: 10, media: false });
+        } finally {
+            restoreExit();
+            restoreStdout();
+            cleanup();
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Default destination
+// ---------------------------------------------------------------------------
+
+describe('docsPullWithConfig — default destination', () => {
+    it('defaults dest to ./<last-path-segment>/ when dest is omitted', async () => {
+        responseQueue = [
+            makeMcpSuccess({ folders: [], docs: [{ id: 1, title: 'brief', properties: {} }] }),
+            makeMcpSuccess({
+                results: [{ index: 0, status: 'ok', id: 1, title: 'brief', folder_path: 'marketing/fb-campaign', current_revision_id: 10, properties: {}, body: '# Brief' }],
+            }),
+        ];
+
+        const restoreExit = patchProcessExit();
+        const { restore: restoreStdout } = captureStdout();
+        const originalCwd = process.cwd();
+        const { dir: tmpDest, cleanup } = makeTmpDir();
+        process.chdir(tmpDest);
+
+        try {
+            const code = await runExpectingExit(() =>
+                docsPullWithConfig('marketing/fb-campaign', undefined, {}, stubConfig()),
+            );
+            expect(code).toBe(0);
+            expect(fs.readFileSync(path.join(tmpDest, 'fb-campaign', 'brief.md'), 'utf8')).toBe('# Brief');
+        } finally {
+            process.chdir(originalCwd);
+            restoreExit();
+            restoreStdout();
+            cleanup();
+        }
+    });
+});

--- a/tests/docs-pull.test.ts
+++ b/tests/docs-pull.test.ts
@@ -594,6 +594,148 @@ describe('docsPullWithConfig — overwrite confirm', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Unpushed local changes — pull overwrite protection + --overwrite
+// ---------------------------------------------------------------------------
+
+describe('docsPullWithConfig — unpushed local changes', () => {
+    function writeManifest(dest: string, docs: DocsManifest['docs'], folderPath = 'marketing/docs'): void {
+        const manifest: DocsManifest = { folder_path: folderPath, docs };
+        fs.mkdirSync(dest, { recursive: true });
+        fs.writeFileSync(path.join(dest, DOCS_MANIFEST), JSON.stringify(manifest, null, 2), 'utf8');
+    }
+
+    it('refuses (exit 1) when a tracked file has unpushed local changes, even with --yes; names the file and points at --overwrite', async () => {
+        const { dir: tmpDest, cleanup } = makeTmpDir();
+        const dest = path.join(tmpDest, 'out');
+        writeManifest(dest, {
+            'doc.md': { id: 1, title: 'doc', current_revision_id: 10, media: false, body_sha256: sha256Hex('# Original') },
+        });
+        fs.writeFileSync(path.join(dest, 'doc.md'), 'local edits, unpushed', 'utf8');
+
+        const restoreExit = patchProcessExit();
+        const { lines: stderrLines, restore: restoreStderr } = captureStderr();
+
+        try {
+            const code = await runExpectingExit(() =>
+                docsPullWithConfig('marketing/docs', dest, { yes: true }, stubConfig()),
+            );
+            expect(code).toBe(1);
+
+            const err = stderrLines.join('');
+            expect(err).toContain('doc.md');
+            expect(err).toContain('unpushed local changes');
+            expect(err).toContain('--overwrite');
+
+            // Nothing written, no network calls.
+            expect(fs.readFileSync(path.join(dest, 'doc.md'), 'utf8')).toBe('local edits, unpushed');
+            expect(allCaptures.length).toBe(0);
+        } finally {
+            restoreExit();
+            restoreStderr();
+            cleanup();
+        }
+    });
+
+    it('--overwrite proceeds without a prompt and replaces the locally-modified file with server content', async () => {
+        const { dir: tmpDest, cleanup } = makeTmpDir();
+        const dest = path.join(tmpDest, 'out');
+        writeManifest(dest, {
+            'doc.md': { id: 1, title: 'doc', current_revision_id: 10, media: false, body_sha256: sha256Hex('# Original') },
+        });
+        fs.writeFileSync(path.join(dest, 'doc.md'), 'local edits, unpushed', 'utf8');
+
+        responseQueue = [
+            makeMcpSuccess({ folders: [], docs: [{ id: 1, title: 'doc', properties: {} }] }),
+            makeMcpSuccess({
+                results: [{ index: 0, status: 'found', id: 1, title: 'doc', folder_path: 'marketing/docs', current_revision_id: 99, properties: {}, body: '# Server Content' }],
+            }),
+        ];
+
+        const restoreExit = patchProcessExit();
+        const { restore: restoreStdout } = captureStdout();
+
+        try {
+            // No prompt injected: prompts() would throw/hang if the code tried to prompt.
+            const code = await runExpectingExit(() =>
+                docsPullWithConfig('marketing/docs', dest, { overwrite: true }, stubConfig()),
+            );
+            expect(code).toBe(0);
+            expect(fs.readFileSync(path.join(dest, 'doc.md'), 'utf8')).toBe('# Server Content');
+
+            const manifest = readManifest(dest);
+            expect(manifest.docs['doc.md'].body_sha256).toBe(sha256Hex('# Server Content'));
+        } finally {
+            restoreExit();
+            restoreStdout();
+            cleanup();
+        }
+    });
+
+    it('unmodified tracked files (hash matches) + --yes: proceeds silently, no refusal', async () => {
+        const { dir: tmpDest, cleanup } = makeTmpDir();
+        const dest = path.join(tmpDest, 'out');
+        writeManifest(dest, {
+            'doc.md': { id: 1, title: 'doc', current_revision_id: 10, media: false, body_sha256: sha256Hex('# Original') },
+        });
+        fs.writeFileSync(path.join(dest, 'doc.md'), '# Original', 'utf8');
+
+        responseQueue = [
+            makeMcpSuccess({ folders: [], docs: [{ id: 1, title: 'doc', properties: {} }] }),
+            makeMcpSuccess({
+                results: [{ index: 0, status: 'found', id: 1, title: 'doc', folder_path: 'marketing/docs', current_revision_id: 11, properties: {}, body: '# Original updated' }],
+            }),
+        ];
+
+        const restoreExit = patchProcessExit();
+        const { restore: restoreStdout } = captureStdout();
+
+        try {
+            const code = await runExpectingExit(() =>
+                docsPullWithConfig('marketing/docs', dest, { yes: true }, stubConfig()),
+            );
+            expect(code).toBe(0);
+            expect(fs.readFileSync(path.join(dest, 'doc.md'), 'utf8')).toBe('# Original updated');
+        } finally {
+            restoreExit();
+            restoreStdout();
+            cleanup();
+        }
+    });
+
+    it('old manifest entries without body_sha256 never trigger a refusal (graceful degradation)', async () => {
+        const { dir: tmpDest, cleanup } = makeTmpDir();
+        const dest = path.join(tmpDest, 'out');
+        writeManifest(dest, {
+            // Old manifest shape: no body_sha256 field at all.
+            'doc.md': { id: 1, title: 'doc', current_revision_id: 10, media: false },
+        });
+        fs.writeFileSync(path.join(dest, 'doc.md'), 'arbitrary local content, no hash to compare against', 'utf8');
+
+        responseQueue = [
+            makeMcpSuccess({ folders: [], docs: [{ id: 1, title: 'doc', properties: {} }] }),
+            makeMcpSuccess({
+                results: [{ index: 0, status: 'found', id: 1, title: 'doc', folder_path: 'marketing/docs', current_revision_id: 12, properties: {}, body: '# Fresh Pull' }],
+            }),
+        ];
+
+        const restoreExit = patchProcessExit();
+        const { restore: restoreStdout } = captureStdout();
+
+        try {
+            const code = await runExpectingExit(() =>
+                docsPullWithConfig('marketing/docs', dest, { yes: true }, stubConfig()),
+            );
+            expect(code).toBe(0);
+            expect(fs.readFileSync(path.join(dest, 'doc.md'), 'utf8')).toBe('# Fresh Pull');
+        } finally {
+            restoreExit();
+            restoreStdout();
+            cleanup();
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
 // --json output
 // ---------------------------------------------------------------------------
 

--- a/tests/docs-pull.test.ts
+++ b/tests/docs-pull.test.ts
@@ -67,11 +67,18 @@ function nextResponseBody(body: any): string {
     return entry;
 }
 
+/** Queue of canned responses for `GET /api/v1/docs/{id}/media`. */
+let mediaResponseQueue: Array<{ status: number; body: object }> = [];
+
+/** Queue of canned responses for the plain `GET /blob/...` signed-URL stand-in. */
+let blobResponseQueue: Array<{ status: number; bytes: Buffer }> = [];
+
 beforeAll(async () => {
     stubServer = http.createServer((req, res) => {
-        let rawBody = '';
-        req.on('data', (chunk) => { rawBody += chunk; });
+        const chunks: Buffer[] = [];
+        req.on('data', (chunk) => { chunks.push(chunk); });
         req.on('end', () => {
+            const rawBody = Buffer.concat(chunks).toString('utf8');
             let parsedBody: any = null;
             try { parsedBody = JSON.parse(rawBody); } catch { /* ignore */ }
 
@@ -83,6 +90,20 @@ beforeAll(async () => {
             };
 
             allCaptures.push(capture);
+
+            if (req.url?.startsWith('/blob/')) {
+                const entry = blobResponseQueue.shift() ?? { status: 200, bytes: Buffer.alloc(0) };
+                res.writeHead(entry.status, { 'Content-Type': 'application/octet-stream' });
+                res.end(entry.bytes);
+                return;
+            }
+
+            if (req.url?.startsWith('/api/v1/docs/') && req.url.endsWith('/media')) {
+                const entry = mediaResponseQueue.shift() ?? { status: 404, body: { code: 'media_not_found', message: 'no media' } };
+                res.writeHead(entry.status, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify(entry.body));
+                return;
+            }
 
             res.writeHead(200, { 'Content-Type': 'application/json' });
             res.end(nextResponseBody(parsedBody));
@@ -106,6 +127,8 @@ afterAll(() => {
 beforeEach(() => {
     allCaptures = [];
     responseQueue = [];
+    mediaResponseQueue = [];
+    blobResponseQueue = [];
 });
 
 // ---------------------------------------------------------------------------
@@ -632,6 +655,170 @@ describe('docsPullWithConfig — default destination', () => {
             process.chdir(originalCwd);
             restoreExit();
             restoreStdout();
+            cleanup();
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Media docs
+// ---------------------------------------------------------------------------
+
+describe('docsPullWithConfig — media docs', () => {
+    it('downloads a media candidate confirmed by the media endpoint: bytes on disk, media: true, auth on confirm only', async () => {
+        responseQueue = [
+            makeMcpSuccess({
+                folders: [],
+                docs: [{ id: 7, title: 'hero.png', properties: { blob_sha: 'abc', mime: 'image/png', size: 3 } }],
+            }),
+            makeMcpSuccess({
+                results: [{
+                    index: 0, status: 'ok', id: 7, title: 'hero.png', folder_path: '', current_revision_id: 9,
+                    properties: { blob_sha: 'abc', mime: 'image/png', size: 3 }, body: '',
+                }],
+            }),
+        ];
+        mediaResponseQueue = [
+            { status: 200, body: { url: `http://127.0.0.1:${stubPort}/blob/7`, mime: 'image/png', size: 3 } },
+        ];
+        const stubBytes = Buffer.from([1, 2, 3]);
+        blobResponseQueue = [{ status: 200, bytes: stubBytes }];
+
+        const { dir: tmpDest, cleanup } = makeTmpDir();
+        const dest = path.join(tmpDest, 'out');
+        const restoreExit = patchProcessExit();
+        const { restore: restoreStdout } = captureStdout();
+
+        try {
+            const code = await runExpectingExit(() => docsPullWithConfig('media', dest, {}, stubConfig()));
+            expect(code).toBe(0);
+
+            expect(fs.readFileSync(path.join(dest, 'hero.png'))).toEqual(stubBytes);
+
+            const manifest = readManifest(dest);
+            expect(manifest.docs['hero.png']).toEqual({ id: 7, title: 'hero.png', current_revision_id: 9, media: true });
+
+            const confirmCall = allCaptures.find((c) => c.path === '/api/v1/docs/7/media');
+            expect(confirmCall).toBeDefined();
+            expect(confirmCall!.headers.authorization).toBe('Bearer test-api-key');
+
+            const blobCall = allCaptures.find((c) => c.path === '/blob/7');
+            expect(blobCall).toBeDefined();
+            expect(blobCall!.headers.authorization).toBeUndefined();
+        } finally {
+            restoreExit();
+            restoreStdout();
+            cleanup();
+        }
+    });
+
+    it('false positive: candidate properties but media endpoint 404s media_not_found — falls back to writing the body as .md, media: false', async () => {
+        responseQueue = [
+            makeMcpSuccess({
+                folders: [],
+                docs: [{ id: 8, title: 'fake', properties: { blob_sha: 'abc', mime: 'image/png', size: 3 } }],
+            }),
+            makeMcpSuccess({
+                results: [{
+                    index: 0, status: 'ok', id: 8, title: 'fake', folder_path: '', current_revision_id: 11,
+                    properties: { blob_sha: 'abc', mime: 'image/png', size: 3 }, body: '',
+                }],
+            }),
+        ];
+        mediaResponseQueue = [
+            { status: 404, body: { code: 'media_not_found', message: 'no media for this doc' } },
+        ];
+
+        const { dir: tmpDest, cleanup } = makeTmpDir();
+        const dest = path.join(tmpDest, 'out');
+        const restoreExit = patchProcessExit();
+        const { restore: restoreStdout } = captureStdout();
+
+        try {
+            const code = await runExpectingExit(() => docsPullWithConfig('media', dest, {}, stubConfig()));
+            expect(code).toBe(0);
+
+            expect(fs.readFileSync(path.join(dest, 'fake.md'), 'utf8')).toBe('');
+
+            const manifest = readManifest(dest);
+            expect(manifest.docs['fake.md']).toEqual({ id: 8, title: 'fake', current_revision_id: 11, media: false });
+
+            // No signed-URL download was attempted.
+            expect(allCaptures.find((c) => c.path?.startsWith('/blob/'))).toBeUndefined();
+        } finally {
+            restoreExit();
+            restoreStdout();
+            cleanup();
+        }
+    });
+
+    it('derives the file extension from mime when the title has none', async () => {
+        responseQueue = [
+            makeMcpSuccess({
+                folders: [],
+                docs: [{ id: 9, title: 'hero', properties: { blob_sha: 'abc', mime: 'image/png', size: 3 } }],
+            }),
+            makeMcpSuccess({
+                results: [{
+                    index: 0, status: 'ok', id: 9, title: 'hero', folder_path: '', current_revision_id: 12,
+                    properties: { blob_sha: 'abc', mime: 'image/png', size: 3 }, body: '',
+                }],
+            }),
+        ];
+        mediaResponseQueue = [
+            { status: 200, body: { url: `http://127.0.0.1:${stubPort}/blob/9`, mime: 'image/png', size: 3 } },
+        ];
+        blobResponseQueue = [{ status: 200, bytes: Buffer.from([9, 9, 9]) }];
+
+        const { dir: tmpDest, cleanup } = makeTmpDir();
+        const dest = path.join(tmpDest, 'out');
+        const restoreExit = patchProcessExit();
+        const { restore: restoreStdout } = captureStdout();
+
+        try {
+            const code = await runExpectingExit(() => docsPullWithConfig('media', dest, {}, stubConfig()));
+            expect(code).toBe(0);
+
+            expect(fs.existsSync(path.join(dest, 'hero.png'))).toBe(true);
+            const manifest = readManifest(dest);
+            expect(manifest.docs['hero.png']).toEqual({ id: 9, title: 'hero', current_revision_id: 12, media: true });
+        } finally {
+            restoreExit();
+            restoreStdout();
+            cleanup();
+        }
+    });
+
+    it('exits 1 on an unexpected media-confirm error (not the documented 404 media_not_found false positive)', async () => {
+        responseQueue = [
+            makeMcpSuccess({
+                folders: [],
+                docs: [{ id: 10, title: 'broken', properties: { blob_sha: 'abc', mime: 'image/png', size: 3 } }],
+            }),
+            makeMcpSuccess({
+                results: [{
+                    index: 0, status: 'ok', id: 10, title: 'broken', folder_path: '', current_revision_id: 13,
+                    properties: { blob_sha: 'abc', mime: 'image/png', size: 3 }, body: '',
+                }],
+            }),
+        ];
+        mediaResponseQueue = [
+            { status: 500, body: { code: 'internal_error', message: 'boom' } },
+        ];
+
+        const { dir: tmpDest, cleanup } = makeTmpDir();
+        const dest = path.join(tmpDest, 'out');
+        const restoreExit = patchProcessExit();
+        const { lines: stderrLines, restore: restoreStderr } = captureStderr();
+
+        try {
+            const code = await runExpectingExit(() => docsPullWithConfig('media', dest, {}, stubConfig()));
+            expect(code).toBe(1);
+            expect(stderrLines.join('')).toContain('internal_error');
+            expect(fs.existsSync(path.join(dest, 'broken.md'))).toBe(false);
+        } finally {
+            restoreExit();
+            restoreStderr();
             cleanup();
         }
     });

--- a/tests/docs-pull.test.ts
+++ b/tests/docs-pull.test.ts
@@ -636,6 +636,39 @@ describe('docsPullWithConfig — unpushed local changes', () => {
         }
     });
 
+    it('refuses (exit 1) when a tracked MEDIA file has unpushed local changes (binary bytes differ from body_sha256) — coverage: detection is extension-agnostic, no code change needed', async () => {
+        const { dir: tmpDest, cleanup } = makeTmpDir();
+        const dest = path.join(tmpDest, 'out');
+        const originalBytes = Buffer.from([1, 2, 3, 4]);
+        writeManifest(dest, {
+            'hero.png': { id: 7, title: 'hero', current_revision_id: 10, media: true, body_sha256: sha256Hex(originalBytes) },
+        });
+        fs.writeFileSync(path.join(dest, 'hero.png'), Buffer.from([9, 9, 9, 9]));
+
+        const restoreExit = patchProcessExit();
+        const { lines: stderrLines, restore: restoreStderr } = captureStderr();
+
+        try {
+            const code = await runExpectingExit(() =>
+                docsPullWithConfig('marketing/docs', dest, { yes: true }, stubConfig()),
+            );
+            expect(code).toBe(1);
+
+            const err = stderrLines.join('');
+            expect(err).toContain('hero.png');
+            expect(err).toContain('unpushed local changes');
+            expect(err).toContain('--overwrite');
+
+            // Nothing written, no network calls.
+            expect(fs.readFileSync(path.join(dest, 'hero.png'))).toEqual(Buffer.from([9, 9, 9, 9]));
+            expect(allCaptures.length).toBe(0);
+        } finally {
+            restoreExit();
+            restoreStderr();
+            cleanup();
+        }
+    });
+
     it('--overwrite proceeds without a prompt and replaces the locally-modified file with server content', async () => {
         const { dir: tmpDest, cleanup } = makeTmpDir();
         const dest = path.join(tmpDest, 'out');

--- a/tests/docs-push.test.ts
+++ b/tests/docs-push.test.ts
@@ -14,7 +14,7 @@ import { describe, expect, it, beforeAll, afterAll, beforeEach } from 'vitest';
 import { docsPushWithConfig } from '../src/commands/docs-push';
 import type { DocsPushOptions } from '../src/commands/docs-push';
 import type { Config } from '../src/utils/config';
-import { DOCS_MANIFEST } from '../src/commands/docs-pull';
+import { DOCS_MANIFEST, sha256Hex } from '../src/commands/docs-pull';
 import type { DocsManifest } from '../src/commands/docs-pull';
 
 // ---------------------------------------------------------------------------
@@ -1238,6 +1238,243 @@ describe('docsPushWithConfig — unparseable manifest', () => {
             restoreExit();
             restoreStdout();
             restoreStderr();
+            cleanup();
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: content hashes — skip-unchanged tracked files
+// ---------------------------------------------------------------------------
+
+describe('docsPushWithConfig — content hash skip-unchanged', () => {
+    function manifestFile(docs: DocsManifest['docs']): string {
+        return JSON.stringify({ folder_path: '/some/folder', docs }, null, 2);
+    }
+
+    it('skips a tracked file whose content hash matches the manifest (zero docs_edit calls, reported as unchanged) while writing a changed one', async () => {
+        const unchangedContent = '# A\n\nUnchanged content.';
+        const changedContent = '# B\n\nNew content, differs from manifest hash.';
+        const { dir, cleanup } = makeTmpDocsDir({
+            'a.md': unchangedContent,
+            'b.md': changedContent,
+            [DOCS_MANIFEST]: manifestFile({
+                'a.md': { id: 1, title: 'a', current_revision_id: 10, media: false, body_sha256: sha256Hex(unchangedContent) },
+                'b.md': { id: 2, title: 'b', current_revision_id: 20, media: false, body_sha256: sha256Hex('# B\n\nOld content.') },
+            }),
+        });
+
+        responseQueue = [makeMcpSuccess({ id: 2, current_revision_id: 21 })];
+
+        const restoreExit = patchProcessExit();
+        const { restore: restoreStdout } = captureStdout();
+
+        try {
+            let caughtExit: ProcessExitError | null = null;
+            try {
+                await docsPushWithConfig(dir, { onConflict: 'skip', json: true }, stubConfig());
+            } catch (e) {
+                if (e instanceof ProcessExitError) caughtExit = e;
+                else throw e;
+            }
+
+            expect(caughtExit?.code).toBe(0);
+
+            // Exactly one docs_edit call, for the changed file only.
+            const editCalls = allCaptures.filter((c) => c.body.params.name === 'docs_edit');
+            expect(editCalls.length).toBe(1);
+            expect(editCalls[0].body.params.arguments.id).toBe(2);
+            expect(editCalls[0].body.params.arguments.body).toBe(changedContent);
+        } finally {
+            restoreExit();
+            restoreStdout();
+            cleanup();
+        }
+    });
+
+    it('reports the unchanged file in tracked.unchanged and the written file in tracked.written via --json', async () => {
+        const unchangedContent = '# A\n\nUnchanged content.';
+        const changedContent = '# B\n\nNew content.';
+        const { dir, cleanup } = makeTmpDocsDir({
+            'a.md': unchangedContent,
+            'b.md': changedContent,
+            [DOCS_MANIFEST]: manifestFile({
+                'a.md': { id: 1, title: 'a', current_revision_id: 10, media: false, body_sha256: sha256Hex(unchangedContent) },
+                'b.md': { id: 2, title: 'b', current_revision_id: 20, media: false, body_sha256: sha256Hex('# B\n\nOld.') },
+            }),
+        });
+
+        responseQueue = [makeMcpSuccess({ id: 2, current_revision_id: 21 })];
+
+        const restoreExit = patchProcessExit();
+        const { lines: logLines, restore: restoreStdout } = captureStdout();
+
+        try {
+            let caughtExit: ProcessExitError | null = null;
+            try {
+                await docsPushWithConfig(dir, { onConflict: 'skip', json: true }, stubConfig());
+            } catch (e) {
+                if (e instanceof ProcessExitError) caughtExit = e;
+                else throw e;
+            }
+
+            expect(caughtExit?.code).toBe(0);
+            const jsonLine = logLines.find((l) => l.trim().startsWith('{'));
+            const parsed = JSON.parse(jsonLine!);
+
+            expect(parsed.tracked.unchanged).toEqual([{ file: 'a.md', id: 1 }]);
+            expect(parsed.tracked.written).toEqual([{ file: 'b.md', id: 2, current_revision_id: 21 }]);
+        } finally {
+            restoreExit();
+            restoreStdout();
+            cleanup();
+        }
+    });
+
+    it('skip-unchanged applies even under --force (force answers drift, not staleness)', async () => {
+        const unchangedContent = '# A\n\nUnchanged content.';
+        const { dir, cleanup } = makeTmpDocsDir({
+            'a.md': unchangedContent,
+            [DOCS_MANIFEST]: manifestFile({
+                'a.md': { id: 1, title: 'a', current_revision_id: 10, media: false, body_sha256: sha256Hex(unchangedContent) },
+            }),
+        });
+
+        const restoreExit = patchProcessExit();
+        const { lines: logLines, restore: restoreStdout } = captureStdout();
+
+        try {
+            let caughtExit: ProcessExitError | null = null;
+            try {
+                await docsPushWithConfig(dir, { onConflict: 'skip', force: true, json: true }, stubConfig());
+            } catch (e) {
+                if (e instanceof ProcessExitError) caughtExit = e;
+                else throw e;
+            }
+
+            expect(caughtExit?.code).toBe(0);
+
+            const editCalls = allCaptures.filter((c) => c.body.params.name === 'docs_edit');
+            expect(editCalls.length).toBe(0);
+
+            const jsonLine = logLines.find((l) => l.trim().startsWith('{'));
+            const parsed = JSON.parse(jsonLine!);
+            expect(parsed.tracked.unchanged).toEqual([{ file: 'a.md', id: 1 }]);
+        } finally {
+            restoreExit();
+            restoreStdout();
+            cleanup();
+        }
+    });
+
+    it('a tracked entry from an old manifest (no body_sha256 field) is always written, never falsely reported unchanged', async () => {
+        const content = '# A\n\nSame content the manifest was pulled with.';
+        const { dir, cleanup } = makeTmpDocsDir({
+            'a.md': content,
+            [DOCS_MANIFEST]: manifestFile({
+                // No body_sha256 field at all — simulates a manifest from before this feature.
+                'a.md': { id: 1, title: 'a', current_revision_id: 10, media: false },
+            }),
+        });
+
+        responseQueue = [makeMcpSuccess({ id: 1, current_revision_id: 11 })];
+
+        const restoreExit = patchProcessExit();
+        const { lines: logLines, restore: restoreStdout } = captureStdout();
+
+        try {
+            let caughtExit: ProcessExitError | null = null;
+            try {
+                await docsPushWithConfig(dir, { onConflict: 'skip', json: true }, stubConfig());
+            } catch (e) {
+                if (e instanceof ProcessExitError) caughtExit = e;
+                else throw e;
+            }
+
+            expect(caughtExit?.code).toBe(0);
+
+            const editCalls = allCaptures.filter((c) => c.body.params.name === 'docs_edit');
+            expect(editCalls.length).toBe(1);
+            expect(editCalls[0].body.params.arguments.body).toBe(content);
+
+            const jsonLine = logLines.find((l) => l.trim().startsWith('{'));
+            const parsed = JSON.parse(jsonLine!);
+            expect(parsed.tracked.unchanged).toEqual([]);
+            expect(parsed.tracked.written).toEqual([{ file: 'a.md', id: 1, current_revision_id: 11 }]);
+        } finally {
+            restoreExit();
+            restoreStdout();
+            cleanup();
+        }
+    });
+
+    it('refreshes body_sha256 on disk (hash of the body just sent) after a successful tracked write', async () => {
+        const newContent = '# A\n\nBrand new content.';
+        const { dir, cleanup } = makeTmpDocsDir({
+            'a.md': newContent,
+            [DOCS_MANIFEST]: manifestFile({
+                'a.md': { id: 1, title: 'a', current_revision_id: 10, media: false, body_sha256: sha256Hex('# A\n\nOld content.') },
+            }),
+        });
+
+        responseQueue = [makeMcpSuccess({ id: 1, current_revision_id: 11 })];
+
+        const restoreExit = patchProcessExit();
+        const { restore: restoreStdout } = captureStdout();
+
+        try {
+            try {
+                await docsPushWithConfig(dir, { onConflict: 'skip' }, stubConfig());
+            } catch (e) {
+                if (!(e instanceof ProcessExitError)) throw e;
+            }
+
+            const manifest: DocsManifest = JSON.parse(fs.readFileSync(path.join(dir, DOCS_MANIFEST), 'utf8'));
+            expect(manifest.docs['a.md'].body_sha256).toBe(sha256Hex(newContent));
+            expect(manifest.docs['a.md'].current_revision_id).toBe(11);
+        } finally {
+            restoreExit();
+            restoreStdout();
+            cleanup();
+        }
+    });
+
+    it('--dry-run distinguishes would-write from would-skip (unchanged) without any docs_edit calls', async () => {
+        const unchangedContent = '# A\n\nUnchanged.';
+        const changedContent = '# B\n\nChanged.';
+        const { dir, cleanup } = makeTmpDocsDir({
+            'a.md': unchangedContent,
+            'b.md': changedContent,
+            [DOCS_MANIFEST]: manifestFile({
+                'a.md': { id: 1, title: 'a', current_revision_id: 10, media: false, body_sha256: sha256Hex(unchangedContent) },
+                'b.md': { id: 2, title: 'b', current_revision_id: 20, media: false, body_sha256: sha256Hex('# B\n\nOld.') },
+            }),
+        });
+
+        const restoreExit = patchProcessExit();
+        const { lines: logLines, restore: restoreStdout } = captureStdout();
+
+        try {
+            let caughtExit: ProcessExitError | null = null;
+            try {
+                await docsPushWithConfig(dir, { onConflict: 'skip', dryRun: true, json: true }, stubConfig());
+            } catch (e) {
+                if (e instanceof ProcessExitError) caughtExit = e;
+                else throw e;
+            }
+
+            expect(caughtExit?.code).toBe(0);
+
+            const editCalls = allCaptures.filter((c) => c.body.params.name === 'docs_edit');
+            expect(editCalls.length).toBe(0);
+
+            const jsonLine = logLines.find((l) => l.trim().startsWith('{'));
+            const parsed = JSON.parse(jsonLine!);
+            expect(parsed.tracked.unchanged).toEqual([{ file: 'a.md', id: 1 }]);
+            expect(parsed.tracked.planned).toEqual([{ file: 'b.md', id: 2 }]);
+        } finally {
+            restoreExit();
+            restoreStdout();
             cleanup();
         }
     });

--- a/tests/docs-push.test.ts
+++ b/tests/docs-push.test.ts
@@ -44,6 +44,18 @@ function makeMcpSuccess(toolData: object): string {
     });
 }
 
+/** Build a canned MCP error response (isError envelope). */
+function makeMcpError(code: string, message: string): string {
+    return JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        result: {
+            isError: true,
+            content: [{ type: 'text', text: JSON.stringify({ code, message }) }],
+        },
+    });
+}
+
 // Server state — a FIFO queue of canned responses; falls back to a default bulk_create success.
 function makeDefaultBulkSuccess(count: number): string {
     const results = Array.from({ length: count }, (_, i) => ({
@@ -1115,6 +1127,117 @@ describe('docsPushWithConfig — drift guard (tracked docs)', () => {
         } finally {
             restoreExit();
             restoreStdout();
+            cleanup();
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: incremental manifest refresh — a later failure must not lose an
+// earlier tracked write's already-persisted revision.
+// ---------------------------------------------------------------------------
+
+describe('docsPushWithConfig — incremental manifest refresh', () => {
+    function manifestFile(docs: DocsManifest['docs']): string {
+        return JSON.stringify({ folder_path: '/some/folder', docs }, null, 2);
+    }
+
+    it('persists the manifest after each successful tracked write, so a later write failure does not lose an earlier one', async () => {
+        const { dir, cleanup } = makeTmpDocsDir({
+            'a.md': '# A',
+            'b.md': '# B',
+            [DOCS_MANIFEST]: manifestFile({
+                'a.md': { id: 1, title: 'a', current_revision_id: 10, media: false },
+                'b.md': { id: 2, title: 'b', current_revision_id: 20, media: false },
+            }),
+        });
+
+        // First docs_edit call succeeds (bumping that doc's revision), the second
+        // fails with an MCP error — regardless of which tracked file (a or b) is
+        // processed first, since directory read order isn't guaranteed.
+        let callCount = 0;
+        const respond = (body: any) => {
+            callCount++;
+            if (callCount === 1) {
+                const id = body.params.arguments.id;
+                return makeMcpSuccess({ id, current_revision_id: id * 10 + 1 });
+            }
+            return makeMcpError('internal_error', 'boom');
+        };
+        responseQueue = [respond, respond];
+
+        const restoreExit = patchProcessExit();
+        const { restore: restoreStdout } = captureStdout();
+        const { restore: restoreStderr } = captureStderr();
+
+        try {
+            let caughtExit: ProcessExitError | null = null;
+            try {
+                await docsPushWithConfig(dir, { onConflict: 'skip' }, stubConfig());
+            } catch (e) {
+                if (e instanceof ProcessExitError) caughtExit = e;
+                else throw e;
+            }
+
+            expect(caughtExit?.code).toBe(1);
+
+            const manifest: DocsManifest = JSON.parse(fs.readFileSync(path.join(dir, DOCS_MANIFEST), 'utf8'));
+            const revisions = {
+                'a.md': manifest.docs['a.md'].current_revision_id,
+                'b.md': manifest.docs['b.md'].current_revision_id,
+            };
+
+            // Exactly one tracked file's revision advanced (the one written first,
+            // and persisted to disk immediately); the other's manifest entry is
+            // untouched at its original value.
+            const advanced = Object.entries(revisions).filter(([file, rev]) => {
+                const original = file === 'a.md' ? 10 : 20;
+                return rev !== original;
+            });
+            expect(advanced.length).toBe(1);
+        } finally {
+            restoreExit();
+            restoreStdout();
+            restoreStderr();
+            cleanup();
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: unparseable manifest warns once, downgrades everything to untracked
+// ---------------------------------------------------------------------------
+
+describe('docsPushWithConfig — unparseable manifest', () => {
+    it('warns on stderr when the manifest exists but fails to parse, and treats all files as untracked', async () => {
+        const { dir, cleanup } = makeTmpDocsDir({
+            'a.md': '# A',
+            [DOCS_MANIFEST]: '{ not valid json',
+        });
+
+        const restoreExit = patchProcessExit();
+        const { restore: restoreStdout } = captureStdout();
+        const { lines: stderrLines, restore: restoreStderr } = captureStderr();
+
+        try {
+            let caughtExit: ProcessExitError | null = null;
+            try {
+                await docsPushWithConfig(dir, { onConflict: 'skip' }, stubConfig());
+            } catch (e) {
+                if (e instanceof ProcessExitError) caughtExit = e;
+                else throw e;
+            }
+
+            expect(caughtExit?.code).toBe(0);
+            expect(stderrLines.join('')).toMatch(/could not be parsed/i);
+
+            // Everything went through bulk_create as untracked — no docs_edit call.
+            const editCalls = allCaptures.filter((c) => c.body.params.name === 'docs_edit');
+            expect(editCalls.length).toBe(0);
+        } finally {
+            restoreExit();
+            restoreStdout();
+            restoreStderr();
             cleanup();
         }
     });

--- a/tests/docs-push.test.ts
+++ b/tests/docs-push.test.ts
@@ -1052,4 +1052,70 @@ describe('docsPushWithConfig — drift guard (tracked docs)', () => {
             cleanup();
         }
     });
+
+    it('--dry-run never calls docs_edit for tracked files; only bulk_create (dry_run: true) runs for untracked, tracked file reported as planned, exits 0, manifest untouched', async () => {
+        const { dir, cleanup } = makeTmpDocsDir({
+            'a.md': '# A\n\nTracked content.',
+            'b.md': '# B\n\nUntracked content.',
+            [DOCS_MANIFEST]: manifestFile({
+                'a.md': { id: 1, title: 'a', current_revision_id: 10, media: false },
+            }),
+        });
+        const manifestBefore = fs.readFileSync(path.join(dir, DOCS_MANIFEST), 'utf8');
+
+        responseQueue = [(body: any) => {
+            const items = body?.params?.arguments?.items ?? [];
+            const results = items.map((_: any, i: number) => ({ index: i, status: 'planned', action: 'create' }));
+            return makeMcpSuccess({
+                results,
+                summary: { planned_create: items.length, planned_overwrite: 0, planned_skip: 0, planned_rename: 0, errors: 0, folders_created: 0 },
+            });
+        }];
+
+        const restoreExit = patchProcessExit();
+        const { lines: logLines, restore: restoreStdout } = captureStdout();
+
+        try {
+            let caughtExit: ProcessExitError | null = null;
+            try {
+                await docsPushWithConfig(dir, { onConflict: 'skip', dryRun: true, json: true }, stubConfig());
+            } catch (e) {
+                if (e instanceof ProcessExitError) caughtExit = e;
+                else throw e;
+            }
+
+            expect(caughtExit?.code).toBe(0);
+
+            // No docs_edit call was ever made for the tracked file.
+            const editCalls = allCaptures.filter((c) => c.body.params.name === 'docs_edit');
+            expect(editCalls.length).toBe(0);
+
+            // Only the untracked file went through bulk_create, with dry_run threaded.
+            const bulkCalls = allCaptures.filter(
+                (c) => c.body.params.name === 'docs_vault' && c.body.params.arguments.action === 'bulk_create',
+            );
+            expect(bulkCalls.length).toBe(1);
+            expect(bulkCalls[0].body.params.arguments.dry_run).toBe(true);
+            const items = bulkCalls[0].body.params.arguments.items;
+            expect(items.length).toBe(1);
+            expect(items[0].title).toBe('b');
+
+            // The tracked file is reported as a planned write in the JSON payload.
+            const jsonLine = logLines.find((l) => l.trim().startsWith('{'));
+            expect(jsonLine).toBeDefined();
+            const parsed = JSON.parse(jsonLine!);
+            expect(parsed.tracked).toHaveProperty('planned');
+            expect(parsed.tracked.planned).toEqual([{ file: 'a.md', id: 1 }]);
+            expect(parsed.tracked.written).toEqual([]);
+            expect(parsed.tracked.drifted).toEqual([]);
+
+            // The manifest file on disk is untouched.
+            const manifestAfter = fs.readFileSync(path.join(dir, DOCS_MANIFEST), 'utf8');
+            expect(manifestAfter).toBe(manifestBefore);
+        } finally {
+            restoreExit();
+            restoreStdout();
+            cleanup();
+        }
+    });
 });

--- a/tests/docs-push.test.ts
+++ b/tests/docs-push.test.ts
@@ -14,6 +14,8 @@ import { describe, expect, it, beforeAll, afterAll, beforeEach } from 'vitest';
 import { docsPushWithConfig } from '../src/commands/docs-push';
 import type { DocsPushOptions } from '../src/commands/docs-push';
 import type { Config } from '../src/utils/config';
+import { DOCS_MANIFEST } from '../src/commands/docs-pull';
+import type { DocsManifest } from '../src/commands/docs-pull';
 
 // ---------------------------------------------------------------------------
 // Stub MCP server
@@ -885,6 +887,165 @@ describe('docsPushWithConfig — --folder base', () => {
 
             expect(allCaptures.length).toBe(1);
             expect(allCaptures[0].body.params.arguments).not.toHaveProperty('folder_path');
+        } finally {
+            restoreExit();
+            restoreStdout();
+            cleanup();
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: drift guard — tracked docs (manifest-backed) use docs_edit write
+// ---------------------------------------------------------------------------
+
+describe('docsPushWithConfig — drift guard (tracked docs)', () => {
+    function manifestFile(docs: DocsManifest['docs']): string {
+        return JSON.stringify({ folder_path: '/some/folder', docs }, null, 2);
+    }
+
+    it('tracked file uses docs_edit write with base_revision from the manifest; untracked file still uses bulk_create', async () => {
+        const { dir, cleanup } = makeTmpDocsDir({
+            'a.md': '# A\n\nTracked content.',
+            'b.md': '# B\n\nUntracked content.',
+            [DOCS_MANIFEST]: manifestFile({
+                'a.md': { id: 1, title: 'a', current_revision_id: 10, media: false },
+            }),
+        });
+
+        responseQueue = [makeMcpSuccess({ id: 1, current_revision_id: 11 })];
+
+        const restoreExit = patchProcessExit();
+        const { restore: restoreStdout } = captureStdout();
+
+        try {
+            let caughtExit: ProcessExitError | null = null;
+            try {
+                await docsPushWithConfig(dir, { onConflict: 'skip' }, stubConfig());
+            } catch (e) {
+                if (e instanceof ProcessExitError) caughtExit = e;
+                else throw e;
+            }
+
+            expect(caughtExit?.code).toBe(0);
+
+            const editCalls = allCaptures.filter((c) => c.body.params.name === 'docs_edit');
+            expect(editCalls.length).toBe(1);
+            expect(editCalls[0].body.params.arguments.action).toBe('write');
+            expect(editCalls[0].body.params.arguments.id).toBe(1);
+            expect(editCalls[0].body.params.arguments.base_revision).toBe(10);
+            expect(editCalls[0].body.params.arguments.body).toBe('# A\n\nTracked content.');
+
+            const bulkCalls = allCaptures.filter(
+                (c) => c.body.params.name === 'docs_vault' && c.body.params.arguments.action === 'bulk_create',
+            );
+            expect(bulkCalls.length).toBe(1);
+            const items = bulkCalls[0].body.params.arguments.items;
+            expect(items.length).toBe(1);
+            expect(items[0].title).toBe('b');
+        } finally {
+            restoreExit();
+            restoreStdout();
+            cleanup();
+        }
+    });
+
+    it('a stale write response reports drift and exits 1, naming the file, both revisions, and --force', async () => {
+        const { dir, cleanup } = makeTmpDocsDir({
+            'a.md': '# A',
+            [DOCS_MANIFEST]: manifestFile({
+                'a.md': { id: 1, title: 'a', current_revision_id: 10, media: false },
+            }),
+        });
+
+        responseQueue = [makeMcpSuccess({
+            stale: true,
+            code: 'stale_revision',
+            current_revision_id: 12,
+            base_revision: 10,
+        })];
+
+        const restoreExit = patchProcessExit();
+        const { restore: restoreStdout } = captureStdout();
+        const { lines: stderrLines, restore: restoreStderr } = captureStderr();
+
+        try {
+            let caughtExit: ProcessExitError | null = null;
+            try {
+                await docsPushWithConfig(dir, { onConflict: 'skip' }, stubConfig());
+            } catch (e) {
+                if (e instanceof ProcessExitError) caughtExit = e;
+                else throw e;
+            }
+
+            expect(caughtExit?.code).toBe(1);
+            const err = stderrLines.join('\n');
+            expect(err).toContain('a.md');
+            expect(err).toContain('10');
+            expect(err).toContain('12');
+            expect(err.toLowerCase()).toContain('--force');
+            expect(err.toLowerCase()).toContain('re-pull');
+        } finally {
+            restoreExit();
+            restoreStdout();
+            restoreStderr();
+            cleanup();
+        }
+    });
+
+    it('--force omits base_revision entirely from the docs_edit write call', async () => {
+        const { dir, cleanup } = makeTmpDocsDir({
+            'a.md': '# A',
+            [DOCS_MANIFEST]: manifestFile({
+                'a.md': { id: 1, title: 'a', current_revision_id: 10, media: false },
+            }),
+        });
+
+        responseQueue = [makeMcpSuccess({ id: 1, current_revision_id: 11 })];
+
+        const restoreExit = patchProcessExit();
+        const { restore: restoreStdout } = captureStdout();
+
+        try {
+            try {
+                await docsPushWithConfig(dir, { onConflict: 'skip', force: true }, stubConfig());
+            } catch (e) {
+                if (!(e instanceof ProcessExitError)) throw e;
+            }
+
+            const editCalls = allCaptures.filter((c) => c.body.params.name === 'docs_edit');
+            expect(editCalls.length).toBe(1);
+            expect(editCalls[0].body.params.arguments).not.toHaveProperty('base_revision');
+        } finally {
+            restoreExit();
+            restoreStdout();
+            cleanup();
+        }
+    });
+
+    it('rewrites the manifest on disk with the new current_revision_id after a successful write', async () => {
+        const { dir, cleanup } = makeTmpDocsDir({
+            'a.md': '# A',
+            [DOCS_MANIFEST]: manifestFile({
+                'a.md': { id: 1, title: 'a', current_revision_id: 10, media: false },
+            }),
+        });
+
+        responseQueue = [makeMcpSuccess({ id: 1, current_revision_id: 11 })];
+
+        const restoreExit = patchProcessExit();
+        const { restore: restoreStdout } = captureStdout();
+
+        try {
+            try {
+                await docsPushWithConfig(dir, { onConflict: 'skip' }, stubConfig());
+            } catch (e) {
+                if (!(e instanceof ProcessExitError)) throw e;
+            }
+
+            const manifestRaw = fs.readFileSync(path.join(dir, DOCS_MANIFEST), 'utf8');
+            const manifest: DocsManifest = JSON.parse(manifestRaw);
+            expect(manifest.docs['a.md'].current_revision_id).toBe(11);
         } finally {
             restoreExit();
             restoreStdout();


### PR DESCRIPTION
Spec: `docs/superpowers/specs/2026-07-08-docs-pull-design.md` (app repo). CLI-only — the server read surface, media endpoints, and OCC all pre-exist.

## What's new

- **`docs pull <folder> [dest]`** — downloads a Docs folder tree: markdown bodies verbatim, media via the signed-URL endpoint (two-stage classification with the media endpoint as the authoritative check), single-doc fallback, title sanitization with collision suffixes, and a `.solidactions-docs.json` manifest (doc id + `current_revision_id` + `body_sha256` per file, written last for crash safety).
- **Drift-guarded `docs push`** — manifest-tracked `.md` files update via `docs_edit write` + `base_revision`; a concurrent remote edit surfaces as a per-file drift report ("re-pull to merge, or pass `--force` to overwrite") with exit 1; the manifest refreshes incrementally after each successful write. Untracked files keep the existing `bulk_create` pipeline byte-for-byte.
- **Content hashes** — push skips unchanged tracked files (true server-side no-op, no revision churn); pull refuses to overwrite unpushed local changes (files named) unless the explicitly destructive `--overwrite` is passed — plain `-y` can no longer discard local work.
- `--dry-run` previews tracked files without writing (a live-write bug here was caught and fixed during review).
- README docs for pull/push/upload.

## Verification

- 490/490 vitest green (real in-process HTTP responders, no mocks), tsc strict clean.
- Live e2e against a dev stack: push/pull round-trip byte-identical, media byte-identical through real R2, drift guard → `--force` → re-pull → clean, dry-run confirmed zero server-side revision bumps, unchanged-skip confirmed no-op.
- Cleanroom test: a zero-context agent completed pull → edit → push cold from `--help`, hit an injected concurrent edit, and the drift message correctly steered it to re-pull-and-merge instead of `--force` — both edits survived.
- Final whole-branch review across three waves: ready to merge (notable catches fixed in-branch: bulk_read row-status guard incl. the real wire status being `found`, path-segment sanitization for `..`-named server folders, incremental manifest refresh).

Independent of #66 (both branched off main); whichever merges second may need a trivial README/index.ts rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)