### PR TITLE
skill exec --target sandbox|host + skill dev: run stored crew skills locally without pulling

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,8 +150,8 @@ Manage agent skills on the crews SOP surface. `push` is an idempotent upsert (cr
 | `skill view <name>` | `--json` | Show one skill |
 | `skill pull <name> [dest]` | `--json` | Fetch a skill to a local folder for editing (inverse of push); writes a `.solidactions-skill.json` provenance sidecar used by `push`'s drift guard |
 | `skill delete <name>` | `--json` | Delete a skill (Admin only) |
-| `skill exec <name> --target sandbox -- <cmd>` | `--role <name>`, `--in-crew <crew>`, `--environment <env>` (default `production`) | Execute the server-stored skill in its server sandbox (post-push smoke; default env production) |
-| `skill exec <name> --target host -- <cmd>` | `--role <name>`, `--in-crew <crew>`, `--crew <nameOrId>`, `--environment <env>` (default `production`), `--env-file <path>` | Execute the server-stored skill on THIS machine via a transparent revision-checked cache — no pull step; crew vars fetched from the platform (default env production; secrets need `env:reveal`) |
+| `skill exec <name> --target sandbox -- <cmd>` (`--target` required) | `--role <name>`, `--in-crew <crew>`, `--environment <env>` (default `production`) | Execute the server-stored skill in its server sandbox (post-push smoke; default env production) |
+| `skill exec <name> --target host -- <cmd>` (`--target` required) | `--role <name>`, `--in-crew <crew>`, `--crew <nameOrId>`, `--environment <env>` (default `production`), `--env-file <path>` | Execute the server-stored skill on THIS machine via a transparent revision-checked cache — no pull step; crew vars fetched from the platform (default env production; secrets need `env:reveal`) |
 | `skill dev <dir> -- <cmd>` | `--crew <nameOrId>`, `--environment <env>` (default `dev`), `--env-file <path>` | Run your local working copy (the folder you're editing) with platform crew vars (default env dev). Replaces `skill run` (deprecated) |
 
 `skill exec` always executes the **server-stored** skill — `--target` only picks

--- a/README.md
+++ b/README.md
@@ -150,10 +150,19 @@ Manage agent skills on the crews SOP surface. `push` is an idempotent upsert (cr
 | `skill view <name>` | `--json` | Show one skill |
 | `skill pull <name> [dest]` | `--json` | Fetch a skill to a local folder for editing (inverse of push); writes a `.solidactions-skill.json` provenance sidecar used by `push`'s drift guard |
 | `skill delete <name>` | `--json` | Delete a skill (Admin only) |
-| `skill run <dir> -- <command...>` | `--crew <nameOrId>`, `--environment <env>` (default `dev`), `--env-file <path>` | Run a skill script LOCALLY with crew variables fetched from the platform (dev loop). Secret values need a token with `env:reveal`; see `skill exec` for the remote/deployed counterpart |
-| `skill exec <name> -- <command...>` | `--role <name>`, `--in-crew <crew>`, `--environment <env>` (default `production`) | Run a command against the DEPLOYED skill in its real sandbox runtime (post-push smoke); see `skill run` for the local dev-loop counterpart |
+| `skill exec <name> --target sandbox -- <cmd>` | `--role <name>`, `--in-crew <crew>`, `--environment <env>` (default `production`) | Execute the server-stored skill in its server sandbox (post-push smoke; default env production) |
+| `skill exec <name> --target host -- <cmd>` | `--role <name>`, `--in-crew <crew>`, `--crew <nameOrId>`, `--environment <env>` (default `production`), `--env-file <path>` | Execute the server-stored skill on THIS machine via a transparent revision-checked cache — no pull step; crew vars fetched from the platform (default env production; secrets need `env:reveal`) |
+| `skill dev <dir> -- <cmd>` | `--crew <nameOrId>`, `--environment <env>` (default `dev`), `--env-file <path>` | Run your local working copy (the folder you're editing) with platform crew vars (default env dev). Replaces `skill run` (deprecated) |
 
-For `skill run` / `skill exec`, pass the command as separate words after `--` (e.g. `-- python script.py --flag`); to run a single preformed shell string, wrap it explicitly with `sh -c '...'`.
+`skill exec` always executes the **server-stored** skill — `--target` only picks
+where it runs (`sandbox` = server, `host` = your machine, cached under
+`~/.solidactions/cache/skills/`, refreshed automatically when the skill's
+published revision changes). `skill dev` always runs the **folder you're
+editing**. Passing a directory to `exec` or a bare name to `dev` is an error
+that points at the right command. Both `exec` targets default to `production`
+variables; `dev` defaults to `dev`.
+
+For `skill dev` / `skill exec`, pass the command as separate words after `--` (e.g. `-- python script.py --flag`); to run a single preformed shell string, wrap it explicitly with `sh -c '...'`.
 
 ### role
 

--- a/src/commands/crew-env-list.ts
+++ b/src/commands/crew-env-list.ts
@@ -17,16 +17,17 @@ interface CrewVariable {
 }
 
 /**
- * Format a value for display. Secrets are ALWAYS masked with a fixed
- * placeholder — regardless of what the server sent — so a server-side
- * masking bug can never leak a raw secret into stdout.
+ * Format a value for display. A null/undefined value means the env is
+ * unset and always renders as '-'. Otherwise, a secret's value is ALWAYS
+ * masked with a fixed placeholder — regardless of what the server sent —
+ * so a server-side masking bug can never leak a raw secret into stdout.
  */
-function formatValue(value: string | null, isSecret: boolean): string {
-    if (isSecret) {
-        return chalk.yellow('••••••');
-    }
+export function formatValue(value: string | null, isSecret: boolean): string {
     if (value === null || value === undefined) {
         return chalk.gray('-');
+    }
+    if (isSecret) {
+        return chalk.yellow('••••••');
     }
     return value.substring(0, 18);
 }

--- a/src/commands/skill-dev.ts
+++ b/src/commands/skill-dev.ts
@@ -1,0 +1,11 @@
+/**
+ * solidactions skill dev <dir> -- <command...>
+ *
+ * Runs YOUR WORKING COPY (the folder you're editing) locally, with crew
+ * variables fetched at runtime. Counterpart of `skill exec`, which always
+ * executes the SERVER-STORED skill (--target sandbox|host). Renamed from
+ * `skill run` (deprecated alias kept until v2.0.0): "run" collides with the
+ * workflow-runs noun (`solidactions run …`), and run-vs-exec didn't encode
+ * the source-of-truth split agents need.
+ */
+export { skillRun as skillDev, SkillRunOptions as SkillDevOptions } from './skill-run';

--- a/src/commands/skill-exec.ts
+++ b/src/commands/skill-exec.ts
@@ -20,7 +20,7 @@ import { callCrewsTool } from '../utils/mcp';
 import { execLocally, shellQuoteArg } from './skill-run';
 import { resolveCrewId, resolveRoleCrewPath, crewIdForPath } from '../utils/crew';
 import {
-    artifactIdentity, cacheDirFor, cacheOrigin, planCacheRefresh,
+    cacheDirFor, cacheOrigin, planCacheRefresh,
     CacheManifest, CacheScope, DesiredFile,
 } from '../utils/skill-cache';
 import {

--- a/src/commands/skill-exec.ts
+++ b/src/commands/skill-exec.ts
@@ -207,10 +207,14 @@ async function execOnHost(
                     newFiles[p] = { sha256: spec.sha256 as string };
                 } else {
                     if (plan.writes.includes(p)) {
-                        const bytes = await fetchBinaryReference(config, tool as 'skills' | 'roles', locator, p);
+                        const ref = bundle.binaryFiles[p];
+                        const bytes = await fetchBinaryReference(config, tool as 'skills' | 'roles', locator, p, { size: ref.size, blobSha: ref.blobSha });
                         contents[p] = bytes;
                         newFiles[p] = { sha256: sha256Hex(bytes), blob_sha: spec.blobSha };
                     } else {
+                        // Invariant: the planner only omits a binary from writes when the
+                        // manifest entry exists and matches (upstreamSame && diskSame), so
+                        // this carry-over cannot be undefined.
                         newFiles[p] = manifest?.files[p] as CacheManifest['files'][string];
                     }
                 }

--- a/src/commands/skill-exec.ts
+++ b/src/commands/skill-exec.ts
@@ -1,22 +1,63 @@
 /**
- * solidactions skill exec <name> [--role <r>] [--environment <env>] -- <command...>
+ * solidactions skill exec <name> --target sandbox|host [...] -- <command...>
  *
- * Runs a command against the DEPLOYED skill in its real sandbox runtime via
- * the crews MCP exec_skill action — the post-push smoke step. Counterpart to
- * `skill run` (local). DELIBERATE DIVERGENCE from `skill run`: default
- * environment here is `production` (matches the server default — this is the
- * "verify deployed" step); `skill run` defaults to `dev` (a local dev loop).
+ * ALWAYS executes the server-stored skill (the artifact) — never local edits;
+ * that's `skill dev <dir>`. --target picks WHERE the stored skill executes:
+ *   sandbox — the server-managed sandbox via crews MCP exec_skill (v1.30 behavior)
+ *   host    — this machine, from a transparent revision-checked cache under
+ *             ~/.solidactions/cache/skills/ (no visible pull step)
+ * --target is REQUIRED (no default): a half-remembered command errors instead
+ * of guessing where to execute. Both targets default --environment production —
+ * moving execution between sandbox and host never silently changes the env.
  */
+import fs from 'fs';
+import axios from 'axios';
 import chalk from 'chalk';
+import path from 'path';
 import { Config } from '../utils/config';
-import { requireConfigWithWorkspace } from '../utils/api';
+import { getApiHeaders, requireConfigWithWorkspace } from '../utils/api';
 import { callCrewsTool } from '../utils/mcp';
-import { shellQuoteArg } from './skill-run';
+import { execLocally, shellQuoteArg } from './skill-run';
+import { resolveCrewId, resolveRoleCrewPath, crewIdForPath } from '../utils/crew';
+import {
+    artifactIdentity, cacheDirFor, cacheOrigin, planCacheRefresh,
+    CacheManifest, CacheScope, DesiredFile,
+} from '../utils/skill-cache';
+import {
+    applyCachePlan, onDiskHashes, readManifest, sha256Hex, withCacheLock,
+} from '../utils/skill-cache-fs';
+import { normalizeBundle, fetchBinaryReference, SkillBundle } from '../utils/skill-bundle';
 
 export interface SkillExecOptions {
+    target?: string;
     role?: string;
     inCrew?: string;
+    crew?: string;
     environment?: string;
+    envFile?: string;
+}
+
+/** Pure invocation checks (option matrix + name shape). Returns error text or null. */
+export function validateExecInvocation(name: string, options: SkillExecOptions): string | null {
+    if (options.target !== 'sandbox' && options.target !== 'host') {
+        return "--target is required: 'sandbox' (run in the server sandbox) or 'host' (run on this machine from the stored skill)";
+    }
+    if (name.startsWith('./') || name.startsWith('../') || path.isAbsolute(name)) {
+        return `'${name}' looks like a directory — skill exec executes the server-stored skill by name. To run a working copy: skill dev ${name}`;
+    }
+    if (options.target === 'sandbox' && options.crew) {
+        return '--crew only applies to --target host (sandbox variable composition is server-side)';
+    }
+    if (options.target === 'sandbox' && options.envFile) {
+        return '--env-file only applies to --target host (the sandbox env is composed server-side)';
+    }
+    if (options.role && options.crew) {
+        return '--crew conflicts with --role: a role-scoped skill takes its variables from the crew the role lives in';
+    }
+    if (options.inCrew && !options.role) {
+        return '--in-crew requires --role';
+    }
+    return null;
 }
 
 export async function skillExecWithConfig(
@@ -25,10 +66,36 @@ export async function skillExecWithConfig(
     options: SkillExecOptions,
     config: Config,
 ): Promise<void> {
-    if (commandParts.length === 0) {
-        process.stderr.write(chalk.red('error: no command given — usage: skill exec <name> -- <command...>\n'));
+    const invalid = validateExecInvocation(name, options);
+    if (invalid) {
+        process.stderr.write(chalk.red(`error: ${invalid}\n`));
         process.exit(1);
     }
+    if (fs.existsSync(name) && fs.statSync(name).isDirectory()) {
+        process.stderr.write(chalk.red(`error: '${name}' looks like a directory — skill exec executes the server-stored skill by name. To run a working copy: skill dev ${name}\n`));
+        process.exit(1);
+    }
+    if (commandParts.length === 0) {
+        process.stderr.write(chalk.red('error: no command given — usage: skill exec <name> --target sandbox|host -- <command...>\n'));
+        process.exit(1);
+    }
+
+    const environment = options.environment ?? 'production';
+
+    if (options.target === 'sandbox') {
+        await execInSandbox(name, commandParts, options, environment, config);
+    } else {
+        await execOnHost(name, commandParts, options, environment, config);
+    }
+}
+
+async function execInSandbox(
+    name: string,
+    commandParts: string[],
+    options: SkillExecOptions,
+    environment: string,
+    config: Config,
+): Promise<void> {
     const command = commandParts.map(shellQuoteArg).join(' ');
 
     const isRole = Boolean(options.role);
@@ -38,6 +105,8 @@ export async function skillExecWithConfig(
         : { action: 'exec_skill', identifier: name, command };
     if (options.environment) args.environment = options.environment;
     if (isRole && options.inCrew) args.in_crew = options.inCrew;
+
+    process.stderr.write(chalk.blue(`▶ stored skill ${name} → sandbox (${environment})\n`));
 
     let result: Awaited<ReturnType<typeof callCrewsTool>>;
     try {
@@ -59,6 +128,136 @@ export async function skillExecWithConfig(
     if (data.stderr) process.stderr.write(data.stderr.endsWith('\n') ? data.stderr : data.stderr + '\n');
     process.stderr.write(chalk.blue(`remote exec: status=${data.status ?? 'unknown'} exit_code=${data.exit_code ?? 'unknown'}\n`));
     process.exit(data.exit_code ?? 1);
+}
+
+async function execOnHost(
+    name: string,
+    commandParts: string[],
+    options: SkillExecOptions,
+    environment: string,
+    config: Config,
+): Promise<void> {
+    const isRole = Boolean(options.role);
+    const tool = isRole ? 'roles' : 'skills';
+    const locator: Record<string, unknown> = isRole
+        ? { role: options.role, name, ...(options.inCrew ? { in_crew: options.inCrew } : {}) }
+        : { identifier: name };
+
+    // 1. Fetch the bundle.
+    let result: Awaited<ReturnType<typeof callCrewsTool>>;
+    try {
+        result = await callCrewsTool(config, tool, isRole
+            ? { action: 'read_skill', ...locator }
+            : { action: 'read', ...locator });
+    } catch (e: any) {
+        process.stderr.write(chalk.red(`error: ${e.message}\n`));
+        process.exit(1);
+    }
+    if (!result.ok) {
+        const code = result.data?.code ?? 'unknown_error';
+        const message = result.data?.message ?? 'MCP returned an error with no message';
+        process.stderr.write(chalk.red(`error: ${code}: ${message}\n`));
+        process.exit(1);
+    }
+
+    const bundle: SkillBundle = normalizeBundle(result.data);
+    for (const unsafe of bundle.skippedUnsafe) {
+        process.stderr.write(chalk.yellow(`warn: skipping unsafe reference key: ${unsafe}\n`));
+    }
+
+    // 2. Resolve crew identity (vars + cache scope).
+    let crewId: string | number | null = null;
+    let scope: CacheScope = { kind: 'shared' };
+    if (isRole) {
+        const crewPath = await resolveRoleCrewPath(config, options.role as string, options.inCrew);
+        crewId = await crewIdForPath(config, crewPath);
+        scope = { kind: 'role', crewPath, role: options.role as string };
+    } else if (options.crew) {
+        crewId = (await resolveCrewId(config, options.crew)).id;
+    } else {
+        process.stderr.write(chalk.gray('no --crew given — running without crew variables (shared-skill parity)\n'));
+    }
+
+    // 3. Plan + refresh the cache under the lock.
+    const cacheDir = cacheDirFor(config, scope, name);
+    const origin = cacheOrigin(config);
+
+    const desired: Record<string, DesiredFile> = { 'SKILL.md': { kind: 'text', sha256: sha256Hex(bundle.skillMd) } };
+    for (const [p, content] of Object.entries(bundle.textFiles)) {
+        desired[p] = { kind: 'text', sha256: sha256Hex(content) };
+    }
+    for (const [p, ref] of Object.entries(bundle.binaryFiles)) {
+        desired[p] = { kind: 'binary', blobSha: ref.blobSha };
+    }
+
+    await withCacheLock(cacheDir, async () => {
+        const manifest = readManifest(cacheDir);
+        const onDisk = onDiskHashes(cacheDir, [...new Set([...Object.keys(desired), ...Object.keys(manifest?.files ?? {})])]);
+        const plan = planCacheRefresh({ manifest, origin, identity: bundle.identity, desired, onDisk });
+
+        if (plan.action === 'refresh') {
+            const contents: Record<string, Buffer | string> = {};
+            const newFiles: CacheManifest['files'] = {};
+
+            for (const p of Object.keys(desired)) {
+                const spec = desired[p];
+                if (spec.kind === 'text') {
+                    const content = p === 'SKILL.md' ? bundle.skillMd : bundle.textFiles[p];
+                    if (plan.writes.includes(p)) contents[p] = content;
+                    newFiles[p] = { sha256: spec.sha256 as string };
+                } else {
+                    if (plan.writes.includes(p)) {
+                        const bytes = await fetchBinaryReference(config, tool as 'skills' | 'roles', locator, p);
+                        contents[p] = bytes;
+                        newFiles[p] = { sha256: sha256Hex(bytes), blob_sha: spec.blobSha };
+                    } else {
+                        newFiles[p] = manifest?.files[p] as CacheManifest['files'][string];
+                    }
+                }
+            }
+
+            applyCachePlan(cacheDir, plan, contents, {
+                schema_version: 1,
+                origin,
+                doc_id: bundle.identity.docId,
+                published: bundle.identity.published,
+                execution_revision_id: bundle.identity.executionRevisionId,
+                files: newFiles,
+            });
+        }
+    });
+
+    // 4. Resolve crew variables.
+    let resolved: Record<string, string> = {};
+    let skippedSecrets: string[] = [];
+    if (crewId !== null) {
+        try {
+            const response = await axios.get(
+                `${config.host}/api/v1/crews/${crewId}/variables/resolve?environment=${encodeURIComponent(environment)}`,
+                { headers: getApiHeaders(config) },
+            );
+            resolved = response.data?.variables ?? {};
+            skippedSecrets = response.data?.skipped_secrets ?? [];
+        } catch (e: any) {
+            process.stderr.write(chalk.red(`error: failed to resolve crew variables: ${e?.response?.data?.message ?? e.message}\n`));
+            process.exit(1);
+        }
+    }
+
+    // 5. Run.
+    if (!bundle.identity.published) {
+        process.stderr.write(chalk.yellow('running unpublished draft revision\n'));
+    }
+    execLocally({
+        dir: cacheDir,
+        commandParts,
+        environment,
+        resolved,
+        skippedSecrets,
+        envFile: options.envFile,
+        config,
+        banner: `▶ stored skill ${name} @ rev ${bundle.identity.executionRevisionId ?? '?'} → local cache (${environment})`,
+    });
 }
 
 export async function skillExec(name: string, commandParts: string[], options: SkillExecOptions): Promise<void> {

--- a/src/commands/skill-pull.ts
+++ b/src/commands/skill-pull.ts
@@ -13,10 +13,10 @@
 import fs from 'fs';
 import path from 'path';
 import chalk from 'chalk';
-import yaml from 'js-yaml';
 import { Config } from '../utils/config';
 import { requireConfigWithWorkspace } from '../utils/api';
 import { callCrewsTool } from '../utils/mcp';
+import { reconstructSkillMd } from '../utils/skill-bundle';
 
 export interface SkillPullOptions {
     json?: boolean;
@@ -85,22 +85,7 @@ export async function skillPullWithConfig(
     // The server stores a `type` field but it is stripped on push (parseSkillFile
     // does `const { type: _type, ...properties } = rest`). We mirror that here
     // so that pull → push is idempotent.
-    const { type: _type, name: propName, description: propDescription, ...extraProps } = data.properties;
-
-    // Reconstruct the full frontmatter: name + description (from properties)
-    // followed by all remaining extra props (minus type).
-    const frontmatterObj: Record<string, unknown> = {
-        name: propName,
-        description: propDescription,
-        ...extraProps,
-    };
-
-    // yaml.dump produces "key: value\n" lines; we wrap in ---\n...\n---\n
-    const yamlBlock = yaml.dump(frontmatterObj, { lineWidth: -1 });
-    const body = data.body ?? '';
-
-    // Ensure the body starts on its own line after the closing ---
-    const skillMdContent = `---\n${yamlBlock}---\n${body.startsWith('\n') ? body : '\n' + body}`;
+    const skillMdContent = reconstructSkillMd(data.properties, data.body);
 
     // Create the output directory (and parents) if needed
     fs.mkdirSync(absOut, { recursive: true });

--- a/src/commands/skill-push.ts
+++ b/src/commands/skill-push.ts
@@ -114,7 +114,7 @@ export function parseSkillFile(content: string): {
  * SKILL.md cites them, so bundled reference docs land complete (#247).
  *
  * Also excludes `skill pull`'s provenance sidecar (SKILL_SIDECAR) and
- * `skill run`'s local runtime-state dir (.sa-state/) — neither is skill
+ * `skill dev`'s local runtime-state dir (.sa-state/) — neither is skill
  * content, and uploading them would leak local revision bookkeeping / state
  * into the remote library and agent sandboxes.
  */
@@ -125,7 +125,7 @@ export function readReferences(dir: string): Record<string, string> {
         for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
             const abs = path.join(current, entry.name);
             if (entry.isDirectory()) {
-                if (entry.name === '.sa-state') continue; // skill run's local runtime-state dir
+                if (entry.name === '.sa-state') continue; // skill dev's local runtime-state dir
                 walk(abs);
                 continue;
             }

--- a/src/commands/skill-run.ts
+++ b/src/commands/skill-run.ts
@@ -110,6 +110,49 @@ function readStorageScope(dir: string): string | null {
     return scope === 'crew' || scope === 'workspace' ? scope : null;
 }
 
+export interface ExecLocallyArgs {
+    dir: string;
+    commandParts: string[];
+    environment: string;
+    resolved: Record<string, string>;
+    skippedSecrets: string[];
+    envFile?: string;
+    config: Config;
+    banner: string;
+}
+
+/**
+ * Shared local runner: env assembly + provenance banner + spawn. Used by both
+ * `skill dev` (working copy) and `skill exec --target host` (cached artifact).
+ */
+export function execLocally(args: ExecLocallyArgs): never {
+    const fileVars = args.envFile ? parseEnvFile(fs.readFileSync(path.resolve(args.envFile), 'utf8')) : {};
+    const storageScope = readStorageScope(args.dir);
+    const { env, warnings } = assembleEnv({
+        resolved: args.resolved, fileVars, storageScope, dir: args.dir, config: args.config,
+    });
+
+    for (const w of warnings) process.stderr.write(chalk.yellow(`warn: ${w}\n`));
+    if (env.SOLIDACTIONS_STATE_DIR) fs.mkdirSync(env.SOLIDACTIONS_STATE_DIR, { recursive: true });
+    if (env.SOLIDACTIONS_SHARED_DIR) fs.mkdirSync(env.SOLIDACTIONS_SHARED_DIR, { recursive: true });
+
+    process.stderr.write(chalk.blue(`${args.banner}\n`));
+    if (args.skippedSecrets.length > 0) {
+        process.stderr.write(chalk.yellow(
+            `${args.skippedSecrets.length} secret ${args.skippedSecrets.length === 1 ? 'var' : 'vars'} unavailable (${args.skippedSecrets.join(', ')}): ` +
+            `your API key lacks the 'env:reveal' ability. Mint a key with env:reveal, set a dev value with \`solidactions crew env set\`, or use --env-file.\n`,
+        ));
+    }
+
+    const result = spawnSync(args.commandParts.map(shellQuoteArg).join(' '), {
+        shell: true,
+        cwd: args.dir,
+        stdio: 'inherit',
+        env: { ...process.env, ...env },
+    });
+    process.exit(result.status ?? 1);
+}
+
 export interface SkillRunOptions {
     crew?: string;
     environment?: string;
@@ -154,30 +197,17 @@ export async function skillRunWithConfig(
         process.stderr.write(chalk.gray('no --crew given — running without crew variables (shared-skill parity)\n'));
     }
 
-    const fileVars = options.envFile ? parseEnvFile(fs.readFileSync(path.resolve(options.envFile), 'utf8')) : {};
-    const storageScope = readStorageScope(absDir);
-    const { env, warnings } = assembleEnv({ resolved, fileVars, storageScope, dir: absDir, config });
-
-    for (const w of warnings) process.stderr.write(chalk.yellow(`warn: ${w}\n`));
-    if (env.SOLIDACTIONS_STATE_DIR) fs.mkdirSync(env.SOLIDACTIONS_STATE_DIR, { recursive: true });
-    if (env.SOLIDACTIONS_SHARED_DIR) fs.mkdirSync(env.SOLIDACTIONS_SHARED_DIR, { recursive: true });
-
     const plainCount = Object.keys(resolved).length;
-    process.stderr.write(chalk.blue(`running locally in ${dir} — env '${environment}', ${plainCount} crew vars loaded\n`));
-    if (skippedSecrets.length > 0) {
-        process.stderr.write(chalk.yellow(
-            `${skippedSecrets.length} secret ${skippedSecrets.length === 1 ? 'var' : 'vars'} unavailable (${skippedSecrets.join(', ')}): ` +
-            `your API key lacks the 'env:reveal' ability. Mint a key with env:reveal, set a dev value with \`solidactions crew env set\`, or use --env-file.\n`,
-        ));
-    }
-
-    const result = spawnSync(commandParts.map(shellQuoteArg).join(' '), {
-        shell: true,
-        cwd: absDir,
-        stdio: 'inherit',
-        env: { ...process.env, ...env },
+    execLocally({
+        dir: absDir,
+        commandParts,
+        environment,
+        resolved,
+        skippedSecrets,
+        envFile: options.envFile,
+        config,
+        banner: `▶ working copy ${dir} → local (${environment}) — ${plainCount} crew vars`,
     });
-    process.exit(result.status ?? 1);
 }
 
 export async function skillRun(dir: string, commandParts: string[], options: SkillRunOptions): Promise<void> {

--- a/src/commands/skill-run.ts
+++ b/src/commands/skill-run.ts
@@ -1,5 +1,5 @@
 /**
- * solidactions skill run <dir> [--crew <c>] [--environment <env>] [--env-file <f>] -- <command...>
+ * solidactions skill dev <dir> [--crew <c>] [--environment <env>] [--env-file <f>] -- <command...>
  *
  * Local analogue of the crews MCP exec_skill: runs <command> with cwd=<dir>
  * (matching the sandbox's cwd=/work/skills/<slug>), with crew variables
@@ -166,12 +166,16 @@ export async function skillRunWithConfig(
     config: Config,
 ): Promise<void> {
     const absDir = path.resolve(dir);
+    if (!fs.existsSync(absDir) || !fs.statSync(absDir).isDirectory()) {
+        process.stderr.write(chalk.red(`error: '${dir}' is not a directory — skill dev runs a local working folder. To execute the stored skill locally: skill exec ${dir} --target host\n`));
+        process.exit(1);
+    }
     if (!fs.existsSync(path.join(absDir, 'SKILL.md'))) {
         process.stderr.write(chalk.red(`error: ${dir} does not contain a SKILL.md\n`));
         process.exit(1);
     }
     if (commandParts.length === 0) {
-        process.stderr.write(chalk.red('error: no command given — usage: skill run <dir> -- <command...>\n'));
+        process.stderr.write(chalk.red('error: no command given — usage: skill dev <dir> -- <command...>\n'));
         process.exit(1);
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -634,12 +634,15 @@ skill
 
 skill
     .command('exec')
-    .description('Run a command against the DEPLOYED skill in its real sandbox runtime (post-push smoke; default env production; see `skill run` for the local dev-loop counterpart, default env dev)')
-    .argument('<name>', 'Skill name or identifier')
-    .argument('<command...>', 'Command to run remotely (after --), e.g. -- node scripts/q.js')
-    .option('--role <name>', 'Role-scoped skill (uses roles.exec_skill)')
+    .description('Execute the SERVER-STORED skill (never local edits — see `skill dev`). --target picks where: sandbox (server) or host (this machine, transparent cache). Default env production for both targets; secrets on host need env:reveal')
+    .argument('<name>', 'Skill name or identifier (names only — directories are rejected)')
+    .argument('<command...>', 'Command to run (after --), e.g. -- node scripts/q.js')
+    .requiredOption('--target <target>', "Where to execute: 'sandbox' or 'host'")
+    .option('--role <name>', 'Role-scoped skill (crew inferred from the role)')
     .option('--in-crew <crew>', 'Disambiguate when the role name exists in multiple crews')
-    .option('--environment <env>', 'Sandbox environment: production|staging|dev (default production)')
+    .option('--crew <nameOrId>', 'host+shared only: crew whose variables to fetch')
+    .option('--environment <env>', 'Variable environment: production|staging|dev (default production)')
+    .option('--env-file <path>', 'host only: local KEY=VALUE overrides (reserved names ignored)')
     .action(async (name, commandParts, options) => {
         await skillExec(name, commandParts, options);
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,7 @@ import { skillPull } from './commands/skill-pull';
 import { skillList } from './commands/skill-list';
 import { skillView } from './commands/skill-view';
 import { skillDelete } from './commands/skill-delete';
-import { skillRun } from './commands/skill-run';
+import { skillDev } from './commands/skill-dev';
 import { skillExec } from './commands/skill-exec';
 import { rolePush } from './commands/role-push';
 import { docsPush } from './commands/docs-push';
@@ -621,15 +621,28 @@ skill
     });
 
 skill
-    .command('run')
-    .description('Run a skill script LOCALLY with crew variables fetched from the platform (dev loop; default env dev; secrets need env:reveal; see `skill exec` for the remote/deployed counterpart, default env production)')
+    .command('dev')
+    .description('Run YOUR WORKING COPY of a skill locally with crew variables fetched from the platform (dev loop; default env dev; secrets need env:reveal). To execute the server-stored skill instead: skill exec <name> --target sandbox|host')
     .argument('<dir>', 'Local skill directory (must contain SKILL.md)')
     .argument('<command...>', 'Command to run (after --), e.g. -- node scripts/q.js')
     .option('--crew <nameOrId>', 'Crew whose variables to fetch (omit for shared skills)')
     .option('--environment <env>', 'Variable environment: production|staging|dev', 'dev')
     .option('--env-file <path>', 'Local KEY=VALUE overrides (reserved names ignored)')
     .action(async (dir, commandParts, options) => {
-        await skillRun(dir, commandParts, options);
+        await skillDev(dir, commandParts, options);
+    });
+
+skill
+    .command('run', { hidden: true })
+    .description('[deprecated] alias of `skill dev` — removed in v2.0.0')
+    .argument('<dir>', 'Local skill directory (must contain SKILL.md)')
+    .argument('<command...>', 'Command to run (after --)')
+    .option('--crew <nameOrId>', 'Crew whose variables to fetch (omit for shared skills)')
+    .option('--environment <env>', 'Variable environment: production|staging|dev', 'dev')
+    .option('--env-file <path>', 'Local KEY=VALUE overrides (reserved names ignored)')
+    .action(async (dir, commandParts, options) => {
+        process.stderr.write(chalk.yellow("warn: 'skill run' is deprecated — use 'skill dev' (alias removed in v2.0.0)\n"));
+        await skillDev(dir, commandParts, options);
     });
 
 skill

--- a/src/utils/crew.ts
+++ b/src/utils/crew.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import chalk from 'chalk';
 import { Config } from './config';
 import { getApiHeaders } from './api';
+import { callCrewsTool } from './mcp';
 
 export interface CrewRecord {
     id: string | number;
@@ -76,4 +77,51 @@ export async function resolveCrewId(config: Config, input: string): Promise<Crew
         process.exit(1);
     }
     return result.crew;
+}
+
+/**
+ * Resolve the containment crew path for a role-scoped skill. --in-crew names it
+ * directly; otherwise roles.list is consulted (each entry carries in_crew).
+ * roles.read_skill does NOT return the crew, so this lookup is load-bearing for
+ * both variable resolution and cache scoping.
+ */
+export async function resolveRoleCrewPath(config: Config, role: string, inCrew?: string): Promise<string> {
+    if (inCrew) return inCrew;
+
+    const result = await callCrewsTool(config, 'roles', { action: 'list' });
+    if (!result.ok) {
+        console.error(chalk.red(`Failed to list roles: ${result.data?.message ?? 'unknown error'}`));
+        process.exit(1);
+    }
+    const roles: Array<{ identifier: string; in_crew: string | null }> = result.data?.roles ?? [];
+    const matches = roles.filter((r) => r.identifier === role);
+
+    if (matches.length === 0) {
+        console.error(chalk.red(`Role "${role}" not found.`));
+        process.exit(1);
+    }
+    if (matches.length > 1) {
+        console.error(chalk.red(`Role "${role}" exists in multiple crews — pass --in-crew <crew>:`));
+        for (const m of matches) console.error(chalk.gray(`  --in-crew ${m.in_crew ?? '(legacy flat role)'}`));
+        process.exit(1);
+    }
+    if (!matches[0].in_crew) {
+        console.error(chalk.red(`Role "${role}" is a legacy flat role with no crew — crew variables cannot be resolved.`));
+        process.exit(1);
+    }
+    return matches[0].in_crew;
+}
+
+/** Map a containment crew path (e.g. "acme/marketing") to the crew doc id used by /variables/resolve. */
+export async function crewIdForPath(config: Config, crewPath: string): Promise<string | number> {
+    const crews = await fetchCrews(config);
+    const byPath = crews.filter((c) => c.path === crewPath);
+    if (byPath.length === 1) return byPath[0].id;
+
+    const lastSegment = crewPath.split('/').pop() ?? crewPath;
+    const byName = crews.filter((c) => c.name.toLowerCase() === lastSegment.toLowerCase());
+    if (byName.length === 1) return byName[0].id;
+
+    console.error(chalk.red(`Could not resolve crew "${crewPath}" to a crew id (matched ${byPath.length} by path, ${byName.length} by name).`));
+    process.exit(1);
 }

--- a/src/utils/mcp.ts
+++ b/src/utils/mcp.ts
@@ -21,14 +21,14 @@ export interface McpToolResult {
     data: any;
 }
 
-/**
- * Internal: call a single MCP tool on the given endpoint path.
- *
- * Returns { ok: true, data: <success shape> } or { ok: false, data: { code, message } }.
- */
-async function callMcpTool(config: Config, endpointPath: string, toolName: string, args: Record<string, unknown>): Promise<McpToolResult> {
+interface McpRawResult {
+    isError: boolean;
+    content: any[];
+}
+
+/** Internal: POST one tools/call and return the raw result envelope (isError + content blocks). */
+async function postMcpTool(config: Config, endpointPath: string, toolName: string, args: Record<string, unknown>): Promise<McpRawResult> {
     const baseHeaders = getApiHeaders(config, 'application/json');
-    // Override Accept to include text/event-stream for streamable-HTTP transport
     const headers: Record<string, string> = {
         ...baseHeaders,
         'Accept': 'application/json, text/event-stream',
@@ -38,10 +38,7 @@ async function callMcpTool(config: Config, endpointPath: string, toolName: strin
         jsonrpc: '2.0',
         id: 1,
         method: 'tools/call',
-        params: {
-            name: toolName,
-            arguments: args,
-        },
+        params: { name: toolName, arguments: args },
     });
 
     const parsed = new URL(`${config.host}${endpointPath}`);
@@ -54,10 +51,7 @@ async function callMcpTool(config: Config, endpointPath: string, toolName: strin
             port: parsed.port || (isHttps ? 443 : 80),
             path: parsed.pathname + (parsed.search || ''),
             method: 'POST',
-            headers: {
-                ...headers,
-                'Content-Length': Buffer.byteLength(body),
-            },
+            headers: { ...headers, 'Content-Length': Buffer.byteLength(body) },
         };
 
         const req = transport.request(options, (res) => {
@@ -87,8 +81,17 @@ async function callMcpTool(config: Config, endpointPath: string, toolName: strin
     }
 
     const result = parsed2?.result;
-    const isError: boolean = result?.isError === true;
-    const textContent: string = result?.content?.[0]?.text ?? '{}';
+    return { isError: result?.isError === true, content: result?.content ?? [] };
+}
+
+/**
+ * Internal: call a single MCP tool and JSON-parse its first text content block.
+ *
+ * Returns { ok: true, data: <success shape> } or { ok: false, data: { code, message } }.
+ */
+async function callMcpTool(config: Config, endpointPath: string, toolName: string, args: Record<string, unknown>): Promise<McpToolResult> {
+    const raw = await postMcpTool(config, endpointPath, toolName, args);
+    const textContent: string = raw.content?.[0]?.text ?? '{}';
 
     let toolData: any;
     try {
@@ -97,7 +100,7 @@ async function callMcpTool(config: Config, endpointPath: string, toolName: strin
         throw new Error(`MCP tool result content is not valid JSON: ${textContent}`);
     }
 
-    return { ok: !isError, data: toolData };
+    return { ok: !raw.isError, data: toolData };
 }
 
 const UNIFIED_MCP_PATH = '/mcp';
@@ -118,4 +121,20 @@ export async function callCrewsTool(config: Config, toolName: string, args: Reco
  */
 export async function callDocsTool(config: Config, toolName: string, args: Record<string, unknown>): Promise<McpToolResult> {
     return callMcpTool(config, UNIFIED_MCP_PATH, toolName, args);
+}
+
+export interface McpContentResult {
+    ok: boolean;
+    content: any[];
+}
+
+/**
+ * Call a crews MCP tool and return the RAW content blocks. Needed for
+ * read_reference_file, whose success responses can be an MCP image block
+ * (base64 bytes) rather than a JSON text block — JSON-parsing content[0].text
+ * (callCrewsTool) would throw on those.
+ */
+export async function callCrewsToolContent(config: Config, toolName: string, args: Record<string, unknown>): Promise<McpContentResult> {
+    const raw = await postMcpTool(config, UNIFIED_MCP_PATH, CREWS_TOOL_NAMES[toolName] ?? toolName, args);
+    return { ok: !raw.isError, content: raw.content };
 }

--- a/src/utils/skill-bundle.ts
+++ b/src/utils/skill-bundle.ts
@@ -13,6 +13,7 @@ import yaml from 'js-yaml';
 import { Config } from './config';
 import { callCrewsToolContent } from './mcp';
 import { ArtifactIdentity, artifactIdentity } from './skill-cache';
+import { sha256Hex } from './skill-cache-fs';
 
 export function reconstructSkillMd(properties: Record<string, unknown>, body: string | undefined): string {
     const { type: _type, name: propName, description: propDescription, ...extraProps } = properties;
@@ -95,6 +96,7 @@ export async function fetchBinaryReference(
     tool: 'skills' | 'roles',
     locator: Record<string, unknown>,
     refPath: string,
+    expected: { size: number; blobSha: string },
 ): Promise<Buffer> {
     const result = await callCrewsToolContent(config, tool, {
         action: 'read_reference_file',
@@ -107,9 +109,11 @@ export async function fetchBinaryReference(
         throw new Error(`failed to fetch binary reference '${refPath}': ${text}`);
     }
 
+    let bytes: Buffer | null = null;
     for (const block of result.content) {
         if (block?.type === 'image' && typeof block.data === 'string') {
-            return Buffer.from(block.data, 'base64');
+            bytes = Buffer.from(block.data, 'base64');
+            break;
         }
         if (block?.type === 'text' && typeof block.text === 'string') {
             let parsed: any;
@@ -120,10 +124,25 @@ export async function fetchBinaryReference(
             }
             if (parsed?.signed_url) {
                 const response = await axios.get(parsed.signed_url, { responseType: 'arraybuffer' });
-                return Buffer.from(response.data);
+                bytes = Buffer.from(response.data);
+                break;
             }
         }
     }
 
-    throw new Error(`failed to fetch binary reference '${refPath}': unrecognized response shape`);
+    if (bytes === null) {
+        throw new Error(`failed to fetch binary reference '${refPath}': unrecognized response shape`);
+    }
+
+    if (bytes.length !== expected.size) {
+        throw new Error(`binary reference '${refPath}' failed validation (got ${bytes.length} bytes, expected ${expected.size}) — refusing to cache a corrupt download`);
+    }
+    if (/^[0-9a-f]{64}$/.test(expected.blobSha)) {
+        const actualHash = sha256Hex(bytes);
+        if (actualHash !== expected.blobSha) {
+            throw new Error(`binary reference '${refPath}' failed validation (sha256 mismatch: got ${actualHash}, expected ${expected.blobSha}) — refusing to cache a corrupt download`);
+        }
+    }
+
+    return bytes;
 }

--- a/src/utils/skill-bundle.ts
+++ b/src/utils/skill-bundle.ts
@@ -1,0 +1,127 @@
+/**
+ * Normalization of a skills.read / roles.read_skill bundle into the pieces the
+ * host-cache needs, plus binary reference fetching.
+ *
+ * Binary reference values arrive as {binary, mime, size, blob_sha} metadata —
+ * bytes come from a separate read_reference_file call which returns EITHER a
+ * JSON text block {signed_url,...} (non-image or large) OR an MCP image block
+ * (base64) for small images. fetchBinaryReference handles both.
+ */
+import axios from 'axios';
+import path from 'path';
+import yaml from 'js-yaml';
+import { Config } from './config';
+import { callCrewsToolContent } from './mcp';
+import { ArtifactIdentity, artifactIdentity } from './skill-cache';
+
+export function reconstructSkillMd(properties: Record<string, unknown>, body: string | undefined): string {
+    const { type: _type, name: propName, description: propDescription, ...extraProps } = properties;
+    const frontmatterObj: Record<string, unknown> = {
+        name: propName,
+        description: propDescription,
+        ...extraProps,
+    };
+    const yamlBlock = yaml.dump(frontmatterObj, { lineWidth: -1 });
+    const bodyText = body ?? '';
+    return `---\n${yamlBlock}---\n${bodyText.startsWith('\n') ? bodyText : '\n' + bodyText}`;
+}
+
+export interface BinaryRef {
+    blobSha: string;
+    mime: string;
+    size: number;
+}
+
+export interface SkillBundle {
+    identifier: string;
+    properties: Record<string, unknown>;
+    skillMd: string;
+    textFiles: Record<string, string>;
+    binaryFiles: Record<string, BinaryRef>;
+    identity: ArtifactIdentity;
+    storageScope: 'crew' | 'workspace' | null;
+    skippedUnsafe: string[];
+}
+
+function readStorageScopeProp(properties: Record<string, unknown>): 'crew' | 'workspace' | null {
+    const nested = (properties.storage as Record<string, unknown> | undefined)?.scope;
+    const flat = properties['storage.scope'];
+    const scope = nested ?? flat ?? null;
+    return scope === 'crew' || scope === 'workspace' ? scope : null;
+}
+
+/** True when a reference key would escape the cache dir (same guards as skill pull). */
+function isUnsafeReferenceKey(key: string): boolean {
+    if (path.isAbsolute(key)) return true;
+    const root = path.resolve('/probe-root');
+    return !path.resolve(root, key).startsWith(root + path.sep);
+}
+
+export function normalizeBundle(data: any): SkillBundle {
+    const properties = (data.properties ?? {}) as Record<string, unknown>;
+    const textFiles: Record<string, string> = {};
+    const binaryFiles: Record<string, BinaryRef> = {};
+    const skippedUnsafe: string[] = [];
+
+    for (const [key, value] of Object.entries((data.reference ?? {}) as Record<string, unknown>)) {
+        if (isUnsafeReferenceKey(key)) {
+            skippedUnsafe.push(key);
+            continue;
+        }
+        if (typeof value === 'string') {
+            textFiles[key] = value;
+        } else if (value && typeof value === 'object' && (value as any).binary === true) {
+            const v = value as any;
+            binaryFiles[key] = { blobSha: v.blob_sha, mime: v.mime, size: v.size };
+        }
+    }
+
+    return {
+        identifier: data.identifier,
+        properties,
+        skillMd: reconstructSkillMd(properties, data.body),
+        textFiles,
+        binaryFiles,
+        identity: artifactIdentity(data),
+        storageScope: readStorageScopeProp(properties),
+        skippedUnsafe,
+    };
+}
+
+export async function fetchBinaryReference(
+    config: Config,
+    tool: 'skills' | 'roles',
+    locator: Record<string, unknown>,
+    refPath: string,
+): Promise<Buffer> {
+    const result = await callCrewsToolContent(config, tool, {
+        action: 'read_reference_file',
+        ...locator,
+        path: refPath,
+    });
+
+    if (!result.ok) {
+        const text = result.content?.[0]?.text ?? '';
+        throw new Error(`failed to fetch binary reference '${refPath}': ${text}`);
+    }
+
+    for (const block of result.content) {
+        if (block?.type === 'image' && typeof block.data === 'string') {
+            return Buffer.from(block.data, 'base64');
+        }
+        if (block?.type === 'text' && typeof block.text === 'string') {
+            let parsed: any;
+            try {
+                parsed = JSON.parse(block.text);
+            } catch {
+                continue;
+            }
+            if (parsed?.signed_url) {
+                const response = await axios.get(parsed.signed_url, { responseType: 'arraybuffer' });
+                return Buffer.from(response.data);
+            }
+        }
+    }
+
+    throw new Error(`failed to fetch binary reference '${refPath}': unrecognized response shape`);
+}

--- a/src/utils/skill-bundle.ts
+++ b/src/utils/skill-bundle.ts
@@ -74,6 +74,8 @@ export function normalizeBundle(data: any): SkillBundle {
             const v = value as any;
             binaryFiles[key] = { blobSha: v.blob_sha, mime: v.mime, size: v.size };
         }
+        // else: unreachable — the server wire contract has exactly two reference
+        // shapes, string | {binary:true,...} (see ResolvedReference::toWireValue).
     }
 
     return {

--- a/src/utils/skill-cache-fs.ts
+++ b/src/utils/skill-cache-fs.ts
@@ -14,7 +14,9 @@
  * (token included) before re-acquiring, and release only removes the lock
  * dir when its `owner` file still matches our token — so a holder that ran
  * past the staleness window and had its lock stolen can't rm the new
- * holder's lock out from under it.
+ * holder's lock out from under it. If a concurrent stale-takeover `rmSync`
+ * lands between our `mkdirSync` and the `owner` write, that write sees
+ * ENOENT — treated as having lost the race, so acquisition retries.
  */
 import crypto from 'crypto';
 import fs from 'fs';
@@ -96,7 +98,7 @@ export async function withCacheLock<T>(cacheDir: string, fn: () => Promise<T>): 
             fs.writeFileSync(path.join(lockDir, 'owner'), token);
             break;
         } catch (e: any) {
-            if (e?.code !== 'EEXIST') throw e;
+            if (e?.code !== 'EEXIST' && e?.code !== 'ENOENT') throw e;
             let stale = false;
             try {
                 stale = Date.now() - fs.statSync(lockDir).mtimeMs > LOCK_STALE_MS;

--- a/src/utils/skill-cache-fs.ts
+++ b/src/utils/skill-cache-fs.ts
@@ -1,0 +1,110 @@
+/**
+ * Filesystem side of the host skill cache: hashing, atomic writes, the
+ * per-cache-key lock, and plan application. Kept separate from the pure
+ * planner (skill-cache.ts) so planning stays unit-testable without fs.
+ *
+ * Write protocol: every managed file is written via temp-file + rename in the
+ * same directory (atomic on POSIX); the manifest is written LAST, so a crash
+ * mid-refresh leaves a manifest that simply mismatches on the next run and
+ * triggers a clean re-refresh. Per-file renames also mean a concurrently
+ * RUNNING exec keeps its already-open scripts.
+ */
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+import { CacheManifest, CachePlan, CACHE_MANIFEST } from './skill-cache';
+
+export function sha256Hex(data: Buffer | string): string {
+    return crypto.createHash('sha256').update(data).digest('hex');
+}
+
+export function hashFileOrNull(filePath: string): string | null {
+    try {
+        return sha256Hex(fs.readFileSync(filePath));
+    } catch {
+        return null;
+    }
+}
+
+export function readManifest(cacheDir: string): CacheManifest | null {
+    try {
+        const parsed = JSON.parse(fs.readFileSync(path.join(cacheDir, CACHE_MANIFEST), 'utf8'));
+        if (parsed?.schema_version !== 1 || typeof parsed?.files !== 'object') return null;
+        return parsed as CacheManifest;
+    } catch {
+        return null;
+    }
+}
+
+export function onDiskHashes(cacheDir: string, paths: string[]): Record<string, string | null> {
+    const out: Record<string, string | null> = {};
+    for (const p of paths) {
+        out[p] = hashFileOrNull(path.join(cacheDir, p));
+    }
+    return out;
+}
+
+export function writeFileAtomic(target: string, data: Buffer | string): void {
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    const tmp = path.join(path.dirname(target), `.tmp-${process.pid}-${crypto.randomBytes(4).toString('hex')}`);
+    fs.writeFileSync(tmp, data);
+    fs.renameSync(tmp, target);
+}
+
+export function applyCachePlan(
+    cacheDir: string,
+    plan: CachePlan,
+    contents: Record<string, Buffer | string>,
+    manifest: CacheManifest,
+): void {
+    fs.mkdirSync(cacheDir, { recursive: true });
+    for (const rel of plan.writes) {
+        if (!(rel in contents)) {
+            throw new Error(`applyCachePlan: no content provided for planned write '${rel}'`);
+        }
+        writeFileAtomic(path.join(cacheDir, rel), contents[rel]);
+    }
+    for (const rel of plan.deletes) {
+        fs.rmSync(path.join(cacheDir, rel), { force: true });
+    }
+    writeFileAtomic(path.join(cacheDir, CACHE_MANIFEST), JSON.stringify(manifest, null, 2) + '\n');
+}
+
+const LOCK_STALE_MS = 30_000;
+const LOCK_TIMEOUT_MS = 20_000;
+const LOCK_POLL_MS = 100;
+
+export async function withCacheLock<T>(cacheDir: string, fn: () => Promise<T>): Promise<T> {
+    const lockDir = cacheDir + '.lock';
+    fs.mkdirSync(path.dirname(lockDir), { recursive: true });
+    const deadline = Date.now() + LOCK_TIMEOUT_MS;
+
+    for (;;) {
+        try {
+            fs.mkdirSync(lockDir);
+            break;
+        } catch (e: any) {
+            if (e?.code !== 'EEXIST') throw e;
+            let stale = false;
+            try {
+                stale = Date.now() - fs.statSync(lockDir).mtimeMs > LOCK_STALE_MS;
+            } catch {
+                continue; // holder just released — retry immediately
+            }
+            if (stale) {
+                try { fs.rmdirSync(lockDir); } catch { /* raced another taker */ }
+                continue;
+            }
+            if (Date.now() > deadline) {
+                throw new Error(`timed out waiting for skill cache lock: ${lockDir} (another exec running? delete it if stale)`);
+            }
+            await new Promise((r) => setTimeout(r, LOCK_POLL_MS));
+        }
+    }
+
+    try {
+        return await fn();
+    } finally {
+        try { fs.rmdirSync(lockDir); } catch { /* best-effort */ }
+    }
+}

--- a/src/utils/skill-cache-fs.ts
+++ b/src/utils/skill-cache-fs.ts
@@ -8,6 +8,13 @@
  * mid-refresh leaves a manifest that simply mismatches on the next run and
  * triggers a clean re-refresh. Per-file renames also mean a concurrently
  * RUNNING exec keeps its already-open scripts.
+ *
+ * Lock ownership: the lock dir carries an `owner` token file written right
+ * after `mkdirSync` succeeds. A stale-lock takeover removes the whole dir
+ * (token included) before re-acquiring, and release only removes the lock
+ * dir when its `owner` file still matches our token — so a holder that ran
+ * past the staleness window and had its lock stolen can't rm the new
+ * holder's lock out from under it.
  */
 import crypto from 'crypto';
 import fs from 'fs';
@@ -29,7 +36,7 @@ export function hashFileOrNull(filePath: string): string | null {
 export function readManifest(cacheDir: string): CacheManifest | null {
     try {
         const parsed = JSON.parse(fs.readFileSync(path.join(cacheDir, CACHE_MANIFEST), 'utf8'));
-        if (parsed?.schema_version !== 1 || typeof parsed?.files !== 'object') return null;
+        if (parsed?.schema_version !== 1 || typeof parsed?.files !== 'object' || parsed.files === null || Array.isArray(parsed.files)) return null;
         return parsed as CacheManifest;
     } catch {
         return null;
@@ -70,7 +77,7 @@ export function applyCachePlan(
     writeFileAtomic(path.join(cacheDir, CACHE_MANIFEST), JSON.stringify(manifest, null, 2) + '\n');
 }
 
-const LOCK_STALE_MS = 30_000;
+const LOCK_STALE_MS = 120_000;
 const LOCK_TIMEOUT_MS = 20_000;
 const LOCK_POLL_MS = 100;
 
@@ -78,10 +85,15 @@ export async function withCacheLock<T>(cacheDir: string, fn: () => Promise<T>): 
     const lockDir = cacheDir + '.lock';
     fs.mkdirSync(path.dirname(lockDir), { recursive: true });
     const deadline = Date.now() + LOCK_TIMEOUT_MS;
+    const token = `${process.pid}-${crypto.randomBytes(8).toString('hex')}`;
 
     for (;;) {
+        if (Date.now() > deadline) {
+            throw new Error(`timed out waiting for skill cache lock: ${lockDir} (another exec running? delete it if stale)`);
+        }
         try {
             fs.mkdirSync(lockDir);
+            fs.writeFileSync(path.join(lockDir, 'owner'), token);
             break;
         } catch (e: any) {
             if (e?.code !== 'EEXIST') throw e;
@@ -92,11 +104,8 @@ export async function withCacheLock<T>(cacheDir: string, fn: () => Promise<T>): 
                 continue; // holder just released — retry immediately
             }
             if (stale) {
-                try { fs.rmdirSync(lockDir); } catch { /* raced another taker */ }
+                try { fs.rmSync(lockDir, { recursive: true, force: true }); } catch { /* raced another taker */ }
                 continue;
-            }
-            if (Date.now() > deadline) {
-                throw new Error(`timed out waiting for skill cache lock: ${lockDir} (another exec running? delete it if stale)`);
             }
             await new Promise((r) => setTimeout(r, LOCK_POLL_MS));
         }
@@ -105,6 +114,10 @@ export async function withCacheLock<T>(cacheDir: string, fn: () => Promise<T>): 
     try {
         return await fn();
     } finally {
-        try { fs.rmdirSync(lockDir); } catch { /* best-effort */ }
+        try {
+            if (fs.readFileSync(path.join(lockDir, 'owner'), 'utf8') === token) {
+                fs.rmSync(lockDir, { recursive: true, force: true });
+            }
+        } catch { /* lock missing or owned by someone else — best-effort, do nothing */ }
     }
 }

--- a/src/utils/skill-cache-fs.ts
+++ b/src/utils/skill-cache-fs.ts
@@ -66,7 +66,7 @@ export function applyCachePlan(
     contents: Record<string, Buffer | string>,
     manifest: CacheManifest,
 ): void {
-    fs.mkdirSync(cacheDir, { recursive: true });
+    fs.mkdirSync(cacheDir, { recursive: true, mode: 0o700 });
     for (const rel of plan.writes) {
         if (!(rel in contents)) {
             throw new Error(`applyCachePlan: no content provided for planned write '${rel}'`);

--- a/src/utils/skill-cache.ts
+++ b/src/utils/skill-cache.ts
@@ -1,0 +1,127 @@
+/**
+ * Pure cache-planning core for `skill exec --target host`.
+ *
+ * The executed artifact is identified by {doc_id, published, execution_revision_id}:
+ * reads serve ACTIVE-SNAPSHOT content when published (head may be newer), so the
+ * execution revision is active_snapshot_revision_id when published and
+ * head_revision_id only for unpublished drafts. Comparing head alone would run
+ * stale cached content after a publish that promotes without moving head.
+ *
+ * planCacheRefresh() is deliberately pure (no fs, no network) so cache
+ * correctness — noop detection, per-file skip, upstream deletions, local
+ * drift — is unit-testable. The fs side lives in skill-cache-fs.ts.
+ */
+import os from 'os';
+import path from 'path';
+import { URL } from 'url';
+import { Config } from './config';
+
+export interface BundleMeta {
+    doc_id: number | string;
+    published?: boolean;
+    head_revision_id?: number | string | null;
+    active_snapshot_revision_id?: number | string | null;
+}
+
+export interface ArtifactIdentity {
+    docId: number;
+    published: boolean;
+    executionRevisionId: number | null;
+}
+
+export interface ManifestFileEntry {
+    sha256: string;
+    blob_sha?: string;
+}
+
+export interface CacheManifest {
+    schema_version: 1;
+    origin: string;
+    doc_id: number;
+    published: boolean;
+    execution_revision_id: number | null;
+    files: Record<string, ManifestFileEntry>;
+}
+
+export const CACHE_MANIFEST = '.sa-cache-manifest.json';
+
+function toNum(v: number | string | null | undefined): number | null {
+    if (v === null || v === undefined) return null;
+    return typeof v === 'string' ? parseInt(v, 10) : v;
+}
+
+export function artifactIdentity(bundle: BundleMeta): ArtifactIdentity {
+    const published = bundle.published !== false;
+    const executionRevisionId = published
+        ? (toNum(bundle.active_snapshot_revision_id) ?? toNum(bundle.head_revision_id))
+        : toNum(bundle.head_revision_id);
+    return { docId: toNum(bundle.doc_id) as number, published, executionRevisionId };
+}
+
+export function sanitizeSegment(s: string): string {
+    return s.replace(/[^a-zA-Z0-9._-]/g, '_');
+}
+
+/**
+ * Cache identity for "which server + which workspace": host authority (host:port)
+ * plus the canonical workspace id. NOT the workspace slug — Config distinguishes
+ * cosmetic `workspace` from canonical `workspaceId`, and custom hosts may collide
+ * on ids alone.
+ */
+export function cacheOrigin(config: Config): string {
+    const authority = new URL(config.host).host; // host[:port]
+    return `${sanitizeSegment(authority)}__${sanitizeSegment(config.workspaceId ?? 'default')}`;
+}
+
+export type CacheScope = { kind: 'shared' } | { kind: 'role'; crewPath: string; role: string };
+
+export function cacheDirFor(config: Config, scope: CacheScope, skillName: string): string {
+    const base = path.join(os.homedir(), '.solidactions', 'cache', 'skills', cacheOrigin(config));
+    const scopeSegs = scope.kind === 'shared'
+        ? ['shared']
+        : [sanitizeSegment(scope.crewPath), sanitizeSegment(scope.role)];
+    return path.join(base, ...scopeSegs, sanitizeSegment(skillName));
+}
+
+export interface DesiredFile {
+    kind: 'text' | 'binary';
+    sha256?: string;  // text: sha256 of the new content
+    blobSha?: string; // binary: server-side blob identity
+}
+
+export interface CachePlan {
+    action: 'noop' | 'refresh';
+    writes: string[];
+    deletes: string[];
+}
+
+export function planCacheRefresh(args: {
+    manifest: CacheManifest | null;
+    origin: string;
+    identity: ArtifactIdentity;
+    desired: Record<string, DesiredFile>;
+    onDisk: Record<string, string | null>;
+}): CachePlan {
+    const { manifest, origin, identity, desired, onDisk } = args;
+    const mfiles = manifest?.files ?? {};
+
+    const identityOk = !!manifest
+        && manifest.schema_version === 1
+        && manifest.origin === origin
+        && manifest.doc_id === identity.docId
+        && manifest.published === identity.published
+        && manifest.execution_revision_id === identity.executionRevisionId;
+
+    const writes: string[] = [];
+    for (const [p, spec] of Object.entries(desired)) {
+        const m = mfiles[p];
+        const upstreamSame = !!m && (spec.kind === 'text' ? m.sha256 === spec.sha256 : m.blob_sha === spec.blobSha);
+        const diskSame = !!m && onDisk[p] !== null && onDisk[p] !== undefined && onDisk[p] === m.sha256;
+        if (!upstreamSame || !diskSame) writes.push(p);
+    }
+
+    const deletes = Object.keys(mfiles).filter((p) => !(p in desired));
+
+    const action = !identityOk || writes.length > 0 || deletes.length > 0 ? 'refresh' : 'noop';
+    return { action, writes: action === 'noop' ? [] : writes, deletes: action === 'noop' ? [] : deletes };
+}

--- a/src/utils/skill-cache.ts
+++ b/src/utils/skill-cache.ts
@@ -47,7 +47,8 @@ export const CACHE_MANIFEST = '.sa-cache-manifest.json';
 
 function toNum(v: number | string | null | undefined): number | null {
     if (v === null || v === undefined) return null;
-    return typeof v === 'string' ? parseInt(v, 10) : v;
+    const n = typeof v === 'string' ? parseInt(v, 10) : v;
+    return Number.isNaN(n) ? null : n;
 }
 
 export function artifactIdentity(bundle: BundleMeta): ArtifactIdentity {

--- a/src/utils/skill-cache.ts
+++ b/src/utils/skill-cache.ts
@@ -53,6 +53,8 @@ function toNum(v: number | string | null | undefined): number | null {
 export function artifactIdentity(bundle: BundleMeta): ArtifactIdentity {
     const published = bundle.published !== false;
     const executionRevisionId = published
+        // The `?? toNum(bundle.head_revision_id)` fallback guards a domain-unreachable
+        // state: a published doc without an active snapshot revision.
         ? (toNum(bundle.active_snapshot_revision_id) ?? toNum(bundle.head_revision_id))
         : toNum(bundle.head_revision_id);
     return { docId: toNum(bundle.doc_id) as number, published, executionRevisionId };

--- a/src/utils/skills.ts
+++ b/src/utils/skills.ts
@@ -8,6 +8,7 @@ const SKILL_NAMES = [
     'solidactions-workflow-coding',
     'solidactions-deploy-and-config',
     'solidactions-oauth-actions',
+    'solidactions-crew-skills',
 ] as const;
 
 const EXAMPLES_OWNER = 'SolidActions';

--- a/tests/crew-env.test.ts
+++ b/tests/crew-env.test.ts
@@ -17,7 +17,7 @@ import * as path from 'path';
 import prompts from 'prompts';
 import { describe, expect, it, beforeAll, afterAll, beforeEach } from 'vitest';
 import { crewEnvSet, buildVariableBody } from '../src/commands/crew-env-set';
-import { crewEnvList } from '../src/commands/crew-env-list';
+import { crewEnvList, formatValue } from '../src/commands/crew-env-list';
 import { crewEnvDelete } from '../src/commands/crew-env-delete';
 import { crewEnvPush, diffPushEntry } from '../src/commands/crew-env-push';
 import { matchCrewByName } from '../src/utils/crew';
@@ -271,6 +271,34 @@ describe('diffPushEntry', () => {
         };
         const entry = diffPushEntry('KEY', 'v', 'all', false, existing);
         expect(entry.action).toBe('update');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Pure unit tests: formatValue (unset-vs-masked column rendering)
+// ---------------------------------------------------------------------------
+
+describe('formatValue', () => {
+    it('null (unset env) renders "-" for a secret column, not the mask', () => {
+        const result = formatValue(null, true);
+        expect(result).toContain('-');
+        expect(result).not.toContain('•');
+    });
+
+    it('null (unset env) renders "-" for a plain column', () => {
+        const result = formatValue(null, false);
+        expect(result).toContain('-');
+        expect(result).not.toContain('•');
+    });
+
+    it('a set secret value is always masked, never printed raw', () => {
+        const result = formatValue('dev-secret-value', true);
+        expect(result).toContain('••••••');
+        expect(result).not.toContain('dev-secret-value');
+    });
+
+    it('a set plain value is printed as-is', () => {
+        expect(formatValue('us-east-1', false)).toContain('us-east-1');
     });
 });
 

--- a/tests/skill-bundle.test.ts
+++ b/tests/skill-bundle.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { reconstructSkillMd, normalizeBundle } from '../src/utils/skill-bundle';
+
+describe('reconstructSkillMd', () => {
+    it('drops type, leads with name/description, appends body after frontmatter', () => {
+        const md = reconstructSkillMd(
+            { type: 'skill', name: 'q-tool', description: 'queries things', 'storage.scope': 'crew' },
+            'Body text\n',
+        );
+        expect(md.startsWith('---\n')).toBe(true);
+        expect(md).toContain('name: q-tool\n');
+        expect(md).toContain('description: queries things\n');
+        expect(md).toContain('storage.scope: crew\n');
+        expect(md).not.toContain('type:');
+        expect(md).toMatch(/---\n\nBody text\n$/);
+    });
+});
+
+describe('normalizeBundle', () => {
+    const data = {
+        identifier: 'q-tool',
+        doc_id: 42,
+        published: true,
+        head_revision_id: 9,
+        active_snapshot_revision_id: 7,
+        properties: { name: 'q-tool', description: 'd', storage: { scope: 'crew' } },
+        body: 'B',
+        reference: {
+            'scripts/q.js': 'console.log(1)',
+            'assets/logo.png': { binary: true, mime: 'image/png', size: 3, blob_sha: 'blob1' },
+            '/etc/passwd': 'evil',
+            '../escape.js': 'evil',
+        },
+    };
+
+    it('separates text and binary references, computes identity and storage scope, flags unsafe keys', () => {
+        const b = normalizeBundle(data);
+        expect(b.identifier).toBe('q-tool');
+        expect(b.identity).toEqual({ docId: 42, published: true, executionRevisionId: 7 });
+        expect(b.textFiles).toEqual({ 'scripts/q.js': 'console.log(1)' });
+        expect(b.binaryFiles).toEqual({ 'assets/logo.png': { blobSha: 'blob1', mime: 'image/png', size: 3 } });
+        expect(b.skillMd).toContain('name: q-tool');
+        expect(b.storageScope).toBe('crew');
+        expect(b.skippedUnsafe.sort()).toEqual(['../escape.js', '/etc/passwd']);
+    });
+
+    it('reads flat storage.scope property form too, and null when absent/invalid', () => {
+        expect(normalizeBundle({ ...data, properties: { name: 'x', 'storage.scope': 'workspace' } }).storageScope).toBe('workspace');
+        expect(normalizeBundle({ ...data, properties: { name: 'x' } }).storageScope).toBeNull();
+        expect(normalizeBundle({ ...data, properties: { name: 'x', storage: { scope: 'bogus' } } }).storageScope).toBeNull();
+    });
+});

--- a/tests/skill-cache-fs.test.ts
+++ b/tests/skill-cache-fs.test.ts
@@ -98,6 +98,7 @@ describe('withCacheLock', () => {
         const dir = tmpdir();
         const lockDir = dir + '.lock';
         fs.mkdirSync(lockDir, { recursive: true });
+        fs.writeFileSync(path.join(lockDir, 'owner'), 'some-stale-token');
         const past = Date.now() / 1000 - 3600;
         fs.utimesSync(lockDir, past, past);
         let ran = false;
@@ -109,5 +110,25 @@ describe('withCacheLock', () => {
         const dir = tmpdir();
         await expect(withCacheLock(dir, async () => { throw new Error('boom'); })).rejects.toThrow('boom');
         expect(fs.existsSync(dir + '.lock')).toBe(false);
+    });
+
+    it('does not release a lock it no longer owns', async () => {
+        const dir = tmpdir();
+        const lockDir = dir + '.lock';
+        await withCacheLock(dir, async () => {
+            fs.rmSync(lockDir, { recursive: true, force: true });
+            fs.mkdirSync(lockDir);
+            fs.writeFileSync(path.join(lockDir, 'owner'), 'someone-else');
+        });
+        expect(fs.existsSync(lockDir)).toBe(true);
+        fs.rmSync(lockDir, { recursive: true, force: true });
+    });
+});
+
+describe('readManifest', () => {
+    it('returns null when files is an array', () => {
+        const dir = tmpdir();
+        fs.writeFileSync(path.join(dir, CACHE_MANIFEST), JSON.stringify({ schema_version: 1, files: [] }));
+        expect(readManifest(dir)).toBeNull();
     });
 });

--- a/tests/skill-cache-fs.test.ts
+++ b/tests/skill-cache-fs.test.ts
@@ -1,0 +1,113 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { describe, it, expect } from 'vitest';
+import { CacheManifest, CACHE_MANIFEST } from '../src/utils/skill-cache';
+import {
+    sha256Hex, hashFileOrNull, readManifest, onDiskHashes,
+    writeFileAtomic, applyCachePlan, withCacheLock,
+} from '../src/utils/skill-cache-fs';
+
+function tmpdir(): string {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'sa-cache-fs-'));
+}
+
+const baseManifest: CacheManifest = {
+    schema_version: 1, origin: 'o', doc_id: 1, published: true, execution_revision_id: 2,
+    files: { 'SKILL.md': { sha256: sha256Hex('hello') } },
+};
+
+describe('hashing + manifest io', () => {
+    it('sha256Hex matches for string and buffer, hashFileOrNull null on missing', () => {
+        expect(sha256Hex('abc')).toBe(sha256Hex(Buffer.from('abc')));
+        expect(hashFileOrNull(path.join(tmpdir(), 'nope'))).toBeNull();
+    });
+
+    it('readManifest returns null for missing or corrupt manifests', () => {
+        const dir = tmpdir();
+        expect(readManifest(dir)).toBeNull();
+        fs.writeFileSync(path.join(dir, CACHE_MANIFEST), 'not json');
+        expect(readManifest(dir)).toBeNull();
+        fs.writeFileSync(path.join(dir, CACHE_MANIFEST), JSON.stringify({ schema_version: 99 }));
+        expect(readManifest(dir)).toBeNull();
+    });
+
+    it('onDiskHashes hashes present files and nulls missing ones', () => {
+        const dir = tmpdir();
+        fs.writeFileSync(path.join(dir, 'a.txt'), 'hello');
+        const hashes = onDiskHashes(dir, ['a.txt', 'missing/b.txt']);
+        expect(hashes['a.txt']).toBe(sha256Hex('hello'));
+        expect(hashes['missing/b.txt']).toBeNull();
+    });
+});
+
+describe('applyCachePlan', () => {
+    it('writes files atomically (nested dirs), deletes removed files, writes manifest last', () => {
+        const dir = tmpdir();
+        fs.mkdirSync(path.join(dir, 'old'), { recursive: true });
+        fs.writeFileSync(path.join(dir, 'old/gone.js'), 'x');
+
+        applyCachePlan(
+            dir,
+            { action: 'refresh', writes: ['SKILL.md', 'scripts/q.js'], deletes: ['old/gone.js'] },
+            { 'SKILL.md': 'hello', 'scripts/q.js': Buffer.from('console.log(1)') },
+            baseManifest,
+        );
+
+        expect(fs.readFileSync(path.join(dir, 'SKILL.md'), 'utf8')).toBe('hello');
+        expect(fs.readFileSync(path.join(dir, 'scripts/q.js'), 'utf8')).toBe('console.log(1)');
+        expect(fs.existsSync(path.join(dir, 'old/gone.js'))).toBe(false);
+        expect(readManifest(dir)).toEqual(baseManifest);
+        // no temp litter
+        expect(fs.readdirSync(dir).filter((f) => f.includes('.tmp-'))).toEqual([]);
+    });
+
+    it('leaves unmanaged files (node_modules, .sa-state) untouched', () => {
+        const dir = tmpdir();
+        fs.mkdirSync(path.join(dir, 'node_modules/pkg'), { recursive: true });
+        fs.writeFileSync(path.join(dir, 'node_modules/pkg/index.js'), 'kept');
+        fs.mkdirSync(path.join(dir, '.sa-state'), { recursive: true });
+        fs.writeFileSync(path.join(dir, '.sa-state/state.json'), '{}');
+
+        applyCachePlan(dir, { action: 'refresh', writes: ['SKILL.md'], deletes: [] }, { 'SKILL.md': 'hello' }, baseManifest);
+
+        expect(fs.readFileSync(path.join(dir, 'node_modules/pkg/index.js'), 'utf8')).toBe('kept');
+        expect(fs.readFileSync(path.join(dir, '.sa-state/state.json'), 'utf8')).toBe('{}');
+    });
+});
+
+describe('withCacheLock', () => {
+    it('serializes two concurrent critical sections', async () => {
+        const dir = tmpdir();
+        const order: string[] = [];
+        await Promise.all([
+            withCacheLock(dir, async () => {
+                order.push('a-in');
+                await new Promise((r) => setTimeout(r, 300));
+                order.push('a-out');
+            }),
+            (async () => {
+                await new Promise((r) => setTimeout(r, 50)); // let A win the lock
+                await withCacheLock(dir, async () => { order.push('b-in'); });
+            })(),
+        ]);
+        expect(order).toEqual(['a-in', 'a-out', 'b-in']);
+    });
+
+    it('takes over a stale lock', async () => {
+        const dir = tmpdir();
+        const lockDir = dir + '.lock';
+        fs.mkdirSync(lockDir, { recursive: true });
+        const past = Date.now() / 1000 - 3600;
+        fs.utimesSync(lockDir, past, past);
+        let ran = false;
+        await withCacheLock(dir, async () => { ran = true; });
+        expect(ran).toBe(true);
+    });
+
+    it('releases the lock on callback throw', async () => {
+        const dir = tmpdir();
+        await expect(withCacheLock(dir, async () => { throw new Error('boom'); })).rejects.toThrow('boom');
+        expect(fs.existsSync(dir + '.lock')).toBe(false);
+    });
+});

--- a/tests/skill-cache.test.ts
+++ b/tests/skill-cache.test.ts
@@ -1,0 +1,114 @@
+import * as path from 'path';
+import { describe, it, expect } from 'vitest';
+import {
+    artifactIdentity, sanitizeSegment, cacheOrigin, cacheDirFor,
+    planCacheRefresh, CacheManifest,
+} from '../src/utils/skill-cache';
+import { Config } from '../src/utils/config';
+
+const config = { host: 'https://sa.test:8443', apiKey: 'k', workspaceId: 'ws-123' } as Config;
+
+describe('artifactIdentity', () => {
+    it('uses active_snapshot_revision_id when published (read serves snapshot content, head may be newer)', () => {
+        const id = artifactIdentity({ doc_id: '42', published: true, head_revision_id: 9, active_snapshot_revision_id: 7 });
+        expect(id).toEqual({ docId: 42, published: true, executionRevisionId: 7 });
+    });
+
+    it('uses head_revision_id for an unpublished draft', () => {
+        const id = artifactIdentity({ doc_id: 42, published: false, head_revision_id: 9, active_snapshot_revision_id: null });
+        expect(id).toEqual({ docId: 42, published: false, executionRevisionId: 9 });
+    });
+
+    it('treats missing published as published (skills.read only flags false explicitly)', () => {
+        const id = artifactIdentity({ doc_id: 1, head_revision_id: 3, active_snapshot_revision_id: 3 });
+        expect(id.published).toBe(true);
+        expect(id.executionRevisionId).toBe(3);
+    });
+});
+
+describe('cache paths', () => {
+    it('sanitizes path segments', () => {
+        expect(sanitizeSegment('acme/marketing')).toBe('acme_marketing');
+        expect(sanitizeSegment('a b:c')).toBe('a_b_c');
+        expect(sanitizeSegment('ok-name_1.2')).toBe('ok-name_1.2');
+    });
+
+    it('origin combines host authority and canonical workspace id, never the slug', () => {
+        expect(cacheOrigin(config)).toBe('sa.test_8443__ws-123');
+    });
+
+    it('builds shared and role scope dirs under ~/.solidactions/cache/skills', () => {
+        const shared = cacheDirFor(config, { kind: 'shared' }, 'q-tool');
+        expect(shared).toContain(path.join('.solidactions', 'cache', 'skills', 'sa.test_8443__ws-123', 'shared', 'q-tool'));
+
+        const role = cacheDirFor(config, { kind: 'role', crewPath: 'acme/marketing', role: 'writer' }, 'q-tool');
+        expect(role).toContain(path.join('sa.test_8443__ws-123', 'acme_marketing', 'writer', 'q-tool'));
+    });
+});
+
+describe('planCacheRefresh', () => {
+    const identity = { docId: 42, published: true, executionRevisionId: 7 };
+    const origin = 'sa.test_8443__ws-123';
+    const manifest: CacheManifest = {
+        schema_version: 1, origin, doc_id: 42, published: true, execution_revision_id: 7,
+        files: {
+            'SKILL.md': { sha256: 'aaa' },
+            'scripts/q.js': { sha256: 'bbb' },
+            'assets/logo.png': { sha256: 'ccc', blob_sha: 'blob1' },
+        },
+    };
+    const desired = {
+        'SKILL.md': { kind: 'text' as const, sha256: 'aaa' },
+        'scripts/q.js': { kind: 'text' as const, sha256: 'bbb' },
+        'assets/logo.png': { kind: 'binary' as const, blobSha: 'blob1' },
+    };
+    const onDiskClean = { 'SKILL.md': 'aaa', 'scripts/q.js': 'bbb', 'assets/logo.png': 'ccc' };
+
+    it('noop when identity, upstream hashes, and disk hashes all match', () => {
+        expect(planCacheRefresh({ manifest, origin, identity, desired, onDisk: onDiskClean }))
+            .toEqual({ action: 'noop', writes: [], deletes: [] });
+    });
+
+    it('cold cache (no manifest): writes everything, deletes nothing', () => {
+        const plan = planCacheRefresh({ manifest: null, origin, identity, desired, onDisk: {} });
+        expect(plan.action).toBe('refresh');
+        expect(plan.writes.sort()).toEqual(['SKILL.md', 'assets/logo.png', 'scripts/q.js']);
+        expect(plan.deletes).toEqual([]);
+    });
+
+    it('revision bump: refresh, but unchanged files (incl. binaries by blob_sha) are not rewritten', () => {
+        const plan = planCacheRefresh({
+            manifest, origin, identity: { ...identity, executionRevisionId: 8 },
+            desired: { ...desired, 'scripts/q.js': { kind: 'text', sha256: 'NEW' } },
+            onDisk: onDiskClean,
+        });
+        expect(plan.action).toBe('refresh');
+        expect(plan.writes).toEqual(['scripts/q.js']);
+        expect(plan.deletes).toEqual([]);
+    });
+
+    it('upstream deletion: file in manifest but not in bundle is deleted', () => {
+        const { 'assets/logo.png': _gone, ...remaining } = desired;
+        const plan = planCacheRefresh({ manifest, origin, identity, desired: remaining, onDisk: onDiskClean });
+        expect(plan.action).toBe('refresh');
+        expect(plan.writes).toEqual([]);
+        expect(plan.deletes).toEqual(['assets/logo.png']);
+    });
+
+    it('local drift: tampered managed file is rewritten even at same revision', () => {
+        const plan = planCacheRefresh({ manifest, origin, identity, desired, onDisk: { ...onDiskClean, 'scripts/q.js': 'TAMPERED' } });
+        expect(plan.action).toBe('refresh');
+        expect(plan.writes).toEqual(['scripts/q.js']);
+    });
+
+    it('missing file on disk is rewritten', () => {
+        const plan = planCacheRefresh({ manifest, origin, identity, desired, onDisk: { ...onDiskClean, 'SKILL.md': null } });
+        expect(plan.writes).toEqual(['SKILL.md']);
+    });
+
+    it('origin mismatch invalidates identity (workspace switch) but still skips byte-identical files', () => {
+        const plan = planCacheRefresh({ manifest: { ...manifest, origin: 'other__ws-999' }, origin, identity, desired, onDisk: onDiskClean });
+        expect(plan.action).toBe('refresh'); // manifest must be rewritten with the new origin
+        expect(plan.writes).toEqual([]);     // bytes match — no file writes
+    });
+});

--- a/tests/skill-dev.test.ts
+++ b/tests/skill-dev.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Tests for `solidactions skill dev <dir> -- <command...>` (Task 5: rename of
+ * `skill run` to `skill dev`, with `skill run` kept as a hidden deprecated
+ * alias until v2.0.0).
+ *
+ * Test-double policy: no mock/spy/stub libraries. Follows the exact pattern
+ * of tests/skill-run.test.ts / tests/skill-exec-target.test.ts: spawn the
+ * BUILT CLI (dist/index.js) as a real subprocess against a real in-process
+ * http.createServer stub (crews list + variables/resolve only).
+ */
+import * as fs from 'fs';
+import * as http from 'http';
+import * as os from 'os';
+import * as path from 'path';
+import * as childProcess from 'child_process';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+
+const CLI_BINARY = path.resolve(__dirname, '../dist/index.js');
+
+interface CliResult {
+    stdout: string;
+    stderr: string;
+    status: number | null;
+}
+
+function runCli(args: string[], env: Record<string, string>): Promise<CliResult> {
+    return new Promise((resolve, reject) => {
+        const child = childProcess.spawn(process.execPath, [CLI_BINARY, ...args], {
+            env: { ...process.env, ...env },
+        });
+        let stdout = '';
+        let stderr = '';
+        child.stdout.on('data', (chunk) => { stdout += chunk; });
+        child.stderr.on('data', (chunk) => { stderr += chunk; });
+        const timer = setTimeout(() => {
+            child.kill();
+            reject(new Error(`CLI timed out. stdout so far: ${stdout} stderr so far: ${stderr}`));
+        }, 15_000);
+        child.on('close', (status) => {
+            clearTimeout(timer);
+            resolve({ stdout, stderr, status });
+        });
+        child.on('error', (err) => {
+            clearTimeout(timer);
+            reject(err);
+        });
+    });
+}
+
+describe('solidactions skill dev — integration (rename from skill run)', () => {
+    let stubServer: http.Server;
+    let stubPort: number;
+    let homeRoot: string;
+    let home: string;
+    let dir: string;
+
+    beforeAll(async () => {
+        if (!fs.existsSync(CLI_BINARY)) {
+            throw new Error(`CLI not built — run \`npm run build\` first (expected: ${CLI_BINARY})`);
+        }
+
+        stubServer = http.createServer((req, res) => {
+            if (req.url === '/api/v1/crews') {
+                res.writeHead(200, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ data: [{ id: 7, name: 'my-crew' }] }));
+                return;
+            }
+            if (req.url?.startsWith('/api/v1/crews/7/variables/resolve')) {
+                res.writeHead(200, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ variables: { PROBE: 'resolved' }, skipped_secrets: [] }));
+                return;
+            }
+            res.writeHead(404, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ message: 'not found' }));
+        });
+
+        await new Promise<void>((resolve) => {
+            stubServer.listen(0, '127.0.0.1', () => {
+                stubPort = (stubServer.address() as { port: number }).port;
+                resolve();
+            });
+        });
+    });
+
+    afterAll(() => {
+        return new Promise<void>((resolve, reject) => {
+            stubServer.close((err) => (err ? reject(err) : resolve()));
+        });
+    });
+
+    beforeAll(() => {
+        homeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sa-skill-dev-test-'));
+        home = path.join(homeRoot, 'home');
+        fs.mkdirSync(home, { recursive: true });
+
+        dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sa-skill-dev-workdir-'));
+        fs.writeFileSync(path.join(dir, 'SKILL.md'), '---\nname: probe\ndescription: test skill\n---\n\nbody\n');
+    });
+
+    afterAll(() => {
+        fs.rmSync(homeRoot, { recursive: true, force: true });
+        fs.rmSync(dir, { recursive: true, force: true });
+    });
+
+    function baseEnv(): Record<string, string> {
+        return {
+            HOME: home,
+            SOLIDACTIONS_HOST: `http://127.0.0.1:${stubPort}`,
+            SOLIDACTIONS_API_KEY: 'test-api-key',
+            SOLIDACTIONS_WORKSPACE_ID: 'ws-123',
+        };
+    }
+
+    it('1. skill dev <dir with SKILL.md> --crew --environment runs locally with resolved crew vars', async () => {
+        const result = await runCli(
+            [
+                'skill', 'dev', dir,
+                '--crew', 'my-crew',
+                '--environment', 'dev',
+                '--',
+                'node', '-e', 'console.log("PROBE="+process.env.PROBE)',
+            ],
+            baseEnv(),
+        );
+        expect(result.status).toBe(0);
+        expect(result.stdout).toContain('PROBE=resolved');
+        expect(result.stderr).toContain('▶ working copy');
+        expect(result.stderr).toContain('(dev)');
+    });
+
+    it('2. skill dev q-tool (name, not a directory) is rejected pointing at `skill exec ... --target host`', async () => {
+        const result = await runCli(['skill', 'dev', 'q-tool', '--', 'node', '-e', '1'], baseEnv());
+        expect(result.status).toBe(1);
+        expect(result.stderr).toContain('skill exec q-tool --target host');
+    });
+
+    it('3. skill run <same dir> is a deprecated alias — identical stdout to skill dev, plus a deprecation warning on stderr', async () => {
+        const devResult = await runCli(
+            [
+                'skill', 'dev', dir,
+                '--crew', 'my-crew',
+                '--',
+                'node', '-e', 'console.log("PROBE="+process.env.PROBE)',
+            ],
+            baseEnv(),
+        );
+        const runResult = await runCli(
+            [
+                'skill', 'run', dir,
+                '--crew', 'my-crew',
+                '--',
+                'node', '-e', 'console.log("PROBE="+process.env.PROBE)',
+            ],
+            baseEnv(),
+        );
+        expect(runResult.status).toBe(0);
+        expect(runResult.stdout).toBe(devResult.stdout);
+        expect(runResult.stderr).toContain('deprecated');
+        expect(runResult.stderr).toContain('skill dev');
+    });
+
+    it("4. skill --help hides `run` but lists `dev` and `exec`", async () => {
+        const result = await runCli(['skill', '--help'], baseEnv());
+        expect(result.status).toBe(0);
+        expect(result.stdout).toContain('dev');
+        expect(result.stdout).toContain('exec');
+        expect(result.stdout).not.toMatch(/^\s*run\s/m);
+    });
+});

--- a/tests/skill-dev.test.ts
+++ b/tests/skill-dev.test.ts
@@ -153,6 +153,7 @@ describe('solidactions skill dev — integration (rename from skill run)', () =>
             ],
             baseEnv(),
         );
+        expect(devResult.status).toBe(0);
         expect(runResult.status).toBe(0);
         expect(runResult.stdout).toBe(devResult.stdout);
         expect(runResult.stderr).toContain('deprecated');
@@ -162,8 +163,8 @@ describe('solidactions skill dev — integration (rename from skill run)', () =>
     it("4. skill --help hides `run` but lists `dev` and `exec`", async () => {
         const result = await runCli(['skill', '--help'], baseEnv());
         expect(result.status).toBe(0);
-        expect(result.stdout).toContain('dev');
-        expect(result.stdout).toContain('exec');
+        expect(result.stdout).toMatch(/^\s*dev\s/m);
+        expect(result.stdout).toMatch(/^\s*exec\s/m);
         expect(result.stdout).not.toMatch(/^\s*run\s/m);
     });
 });

--- a/tests/skill-exec-target.test.ts
+++ b/tests/skill-exec-target.test.ts
@@ -115,6 +115,9 @@ describe('solidactions skill exec — integration (--target sandbox|host)', () =
 
     // Mutable bundle served by crews_skills/read and crews_roles/read_skill.
     let BUNDLE: any;
+    // Separate skill served only to the corrupt-binary negative-case test, so it
+    // never shares cache state with the BUNDLE-driven tests above.
+    let BAD_BUNDLE: any;
     let execSkillCalls: Array<Record<string, unknown>> = [];
 
     beforeAll(async () => {
@@ -136,10 +139,34 @@ describe('solidactions skill exec — integration (--target sandbox|host)', () =
             },
         };
 
+        BAD_BUNDLE = {
+            identifier: 'bad-tool',
+            doc_id: 99,
+            published: true,
+            head_revision_id: 1,
+            active_snapshot_revision_id: 1,
+            properties: { name: 'bad-tool', description: 'd' },
+            body: 'B',
+            reference: {
+                'assets/bad-blob.bin': { binary: true, mime: 'application/octet-stream', size: 5, blob_sha: 'badblob1' },
+            },
+        };
+
         stubServer = http.createServer((req, res) => {
             if (req.method === 'GET' && req.url === '/signed/blob.bin') {
                 res.writeHead(200, { 'Content-Type': 'application/octet-stream' });
                 res.end(Buffer.from('BIN!'));
+                return;
+            }
+            if (req.method === 'GET' && req.url === '/signed/role-blob.bin') {
+                res.writeHead(200, { 'Content-Type': 'application/octet-stream' });
+                res.end(Buffer.from('RBIN!'));
+                return;
+            }
+            if (req.method === 'GET' && req.url === '/signed/bad-blob.bin') {
+                // Wrong length on purpose: bundle declares size 5, this serves 3.
+                res.writeHead(200, { 'Content-Type': 'application/octet-stream' });
+                res.end(Buffer.from('BAD'));
                 return;
             }
             if (req.method === 'GET' && req.url === '/api/v1/crews') {
@@ -170,10 +197,29 @@ describe('solidactions skill exec — integration (--target sandbox|host)', () =
                     };
 
                     if (toolName === 'crews_skills' && action === 'read') {
-                        respondText(BUNDLE);
+                        respondText(args.identifier === 'bad-tool' ? BAD_BUNDLE : BUNDLE);
                         return;
                     }
-                    if (toolName === 'crews_skills' && action === 'read_reference_file') {
+                    if ((toolName === 'crews_skills' || toolName === 'crews_roles') && action === 'read_reference_file') {
+                        const refPath = args.path as string;
+                        if (refPath === 'assets/role-blob.bin') {
+                            respondText({
+                                path: refPath,
+                                mime: 'application/octet-stream',
+                                size: 5,
+                                signed_url: `http://127.0.0.1:${stubPort}/signed/role-blob.bin`,
+                            });
+                            return;
+                        }
+                        if (refPath === 'assets/bad-blob.bin') {
+                            respondText({
+                                path: refPath,
+                                mime: 'application/octet-stream',
+                                size: 5,
+                                signed_url: `http://127.0.0.1:${stubPort}/signed/bad-blob.bin`,
+                            });
+                            return;
+                        }
                         respondText({
                             path: 'assets/blob.bin',
                             mime: 'application/octet-stream',
@@ -200,6 +246,7 @@ describe('solidactions skill exec — integration (--target sandbox|host)', () =
                     if (toolName === 'crews_roles' && action === 'read_skill') {
                         const roleReference = { ...BUNDLE.reference };
                         delete roleReference['assets/blob.bin'];
+                        roleReference['assets/role-blob.bin'] = { binary: true, mime: 'application/octet-stream', size: 5, blob_sha: 'roleblob1' };
                         respondText({ ...BUNDLE, identifier: 'q-tool', reference: roleReference });
                         return;
                     }
@@ -397,6 +444,10 @@ describe('solidactions skill exec — integration (--target sandbox|host)', () =
         expect(writerResult.status).toBe(0);
         expect(writerResult.stdout).toContain('VAR=resolved');
 
+        const roleCacheDir = findCacheDir(home, 'acme', 'writer');
+        expect(fs.existsSync(path.join(roleCacheDir, 'assets/role-blob.bin'))).toBe(true);
+        expect(fs.readFileSync(path.join(roleCacheDir, 'assets/role-blob.bin'), 'utf8')).toBe('RBIN!');
+
         const dupeResult = await runCli(
             ['skill', 'exec', 'q-tool', '--target', 'host', '--role', 'dupe', '--', 'node', 'scripts/q.js'],
             baseEnv(home),
@@ -405,7 +456,34 @@ describe('solidactions skill exec — integration (--target sandbox|host)', () =
         expect(dupeResult.stderr).toContain('--in-crew');
     });
 
-    it('11. two simultaneous cold-cache runs both succeed (lock serializes materialization)', async () => {
+    it('11. --target host refuses to cache a corrupt/truncated binary download (size mismatch)', async () => {
+        // Fresh HOME + a dedicated skill name so this never contaminates the
+        // q-tool cache state exercised by the other tests.
+        const badRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sa-skill-exec-target-badbin-'));
+        const badHome = path.join(badRoot, 'home');
+        fs.mkdirSync(badHome, { recursive: true });
+
+        try {
+            const result = await runCli(
+                ['skill', 'exec', 'bad-tool', '--target', 'host', '--', 'node', '-e', 'x'],
+                baseEnv(badHome),
+            );
+            expect(result.status).not.toBe(0);
+            expect(result.stderr).toContain('failed validation');
+
+            const base = path.join(badHome, '.solidactions', 'cache', 'skills');
+            if (fs.existsSync(base)) {
+                for (const origin of fs.readdirSync(base)) {
+                    const manifestPath = path.join(base, origin, 'shared', 'bad-tool', '.sa-cache-manifest.json');
+                    expect(fs.existsSync(manifestPath)).toBe(false);
+                }
+            }
+        } finally {
+            fs.rmSync(badRoot, { recursive: true, force: true });
+        }
+    }, 20_000);
+
+    it('12. two simultaneous cold-cache runs both succeed (lock serializes materialization)', async () => {
         const coldRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sa-skill-exec-target-cold-'));
         const coldHome = path.join(coldRoot, 'home');
         fs.mkdirSync(coldHome, { recursive: true });

--- a/tests/skill-exec-target.test.ts
+++ b/tests/skill-exec-target.test.ts
@@ -1,0 +1,427 @@
+/**
+ * Tests for `solidactions skill exec <name> --target sandbox|host [...] -- <command...>`
+ * (Task 4: required --target, option matrix, host orchestration).
+ *
+ * Test-double policy: no mock/spy/stub libraries. Follows the exact pattern of
+ * tests/skill-run.test.ts: async `spawn` of the BUILT CLI (dist/index.js)
+ * against a real in-process http.createServer stub. `--target host` writes
+ * real cache files to disk and shells out via `stdio: 'inherit'`, both of
+ * which are unobservable/unexercisable via an in-process function call — see
+ * tests/skill-run.test.ts's header comment for the full rationale (stdio
+ * inherit + spawnSync deadlock).
+ *
+ * HOME is redirected per test (group) to a temp dir so `~/.solidactions/cache`
+ * lands in a sandboxed location. Config comes entirely from SOLIDACTIONS_*
+ * env vars, so redirecting HOME does not affect CLI auth/config resolution —
+ * only where the host cache is materialized.
+ */
+import * as fs from 'fs';
+import * as http from 'http';
+import * as os from 'os';
+import * as path from 'path';
+import * as childProcess from 'child_process';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { validateExecInvocation } from '../src/commands/skill-exec';
+
+const CLI_BINARY = path.resolve(__dirname, '../dist/index.js');
+
+// ---------------------------------------------------------------------------
+// Pure unit tests: validateExecInvocation covers the option matrix directly
+// (fast, no server/process needed) — including branches the integration
+// suite below doesn't happen to exercise.
+// ---------------------------------------------------------------------------
+
+describe('validateExecInvocation', () => {
+    it('requires --target sandbox|host', () => {
+        expect(validateExecInvocation('q-tool', {})).toMatch(/--target is required/);
+        expect(validateExecInvocation('q-tool', { target: 'bogus' })).toMatch(/'sandbox'.*'host'|sandbox.*host/s);
+    });
+
+    it('rejects directory-looking names regardless of target', () => {
+        expect(validateExecInvocation('./local', { target: 'host' })).toMatch(/skill dev \.\/local/);
+        expect(validateExecInvocation('../local', { target: 'host' })).toMatch(/skill dev/);
+        expect(validateExecInvocation('/abs/local', { target: 'host' })).toMatch(/skill dev/);
+    });
+
+    it('rejects --crew with --target sandbox', () => {
+        expect(validateExecInvocation('q-tool', { target: 'sandbox', crew: 'acme' })).toMatch(/--crew/);
+    });
+
+    it('rejects --env-file with --target sandbox', () => {
+        expect(validateExecInvocation('q-tool', { target: 'sandbox', envFile: '.env' })).toMatch(/--env-file/);
+    });
+
+    it('rejects --crew combined with --role', () => {
+        expect(validateExecInvocation('q-tool', { target: 'host', role: 'writer', crew: 'acme' })).toMatch(/--crew/);
+    });
+
+    it('rejects --in-crew without --role', () => {
+        expect(validateExecInvocation('q-tool', { target: 'host', inCrew: 'acme' })).toMatch(/--in-crew/);
+    });
+
+    it('allows valid host and sandbox invocations', () => {
+        expect(validateExecInvocation('q-tool', { target: 'sandbox' })).toBeNull();
+        expect(validateExecInvocation('q-tool', { target: 'host' })).toBeNull();
+        expect(validateExecInvocation('q-tool', { target: 'host', crew: 'acme' })).toBeNull();
+        expect(validateExecInvocation('q-tool', { target: 'host', role: 'writer', inCrew: 'acme' })).toBeNull();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: real HTTP server + real built CLI subprocess
+// ---------------------------------------------------------------------------
+
+interface CliResult {
+    stdout: string;
+    stderr: string;
+    status: number | null;
+}
+
+/**
+ * Spawn the built CLI as a real subprocess. Uses async `spawn` (not
+ * `spawnSync`) — spawnSync blocks this process's event loop until the child
+ * exits, which would prevent the in-process stub HTTP server (running on
+ * this same event loop) from ever accepting the child's connection.
+ */
+function runCli(args: string[], env: Record<string, string>): Promise<CliResult> {
+    return new Promise((resolve, reject) => {
+        const child = childProcess.spawn(process.execPath, [CLI_BINARY, ...args], {
+            env: { ...process.env, ...env },
+        });
+        let stdout = '';
+        let stderr = '';
+        child.stdout.on('data', (chunk) => { stdout += chunk; });
+        child.stderr.on('data', (chunk) => { stderr += chunk; });
+        const timer = setTimeout(() => {
+            child.kill();
+            reject(new Error(`CLI timed out. stdout so far: ${stdout} stderr so far: ${stderr}`));
+        }, 15_000);
+        child.on('close', (status) => {
+            clearTimeout(timer);
+            resolve({ stdout, stderr, status });
+        });
+        child.on('error', (err) => {
+            clearTimeout(timer);
+            reject(err);
+        });
+    });
+}
+
+describe('solidactions skill exec — integration (--target sandbox|host)', () => {
+    let stubServer: http.Server;
+    let stubPort: number;
+    let homeRoot: string;
+    let home: string;
+
+    // Mutable bundle served by crews_skills/read and crews_roles/read_skill.
+    let BUNDLE: any;
+    let execSkillCalls: Array<Record<string, unknown>> = [];
+
+    beforeAll(async () => {
+        if (!fs.existsSync(CLI_BINARY)) {
+            throw new Error(`CLI not built — run \`npm run build\` first (expected: ${CLI_BINARY})`);
+        }
+
+        BUNDLE = {
+            identifier: 'q-tool',
+            doc_id: 42,
+            published: true,
+            head_revision_id: 7,
+            active_snapshot_revision_id: 7,
+            properties: { name: 'q-tool', description: 'd' },
+            body: 'B',
+            reference: {
+                'scripts/q.js': 'console.log("VAR="+(process.env.PROBE||"none"))',
+                'assets/blob.bin': { binary: true, mime: 'application/octet-stream', size: 4, blob_sha: 'blob1' },
+            },
+        };
+
+        stubServer = http.createServer((req, res) => {
+            if (req.method === 'GET' && req.url === '/signed/blob.bin') {
+                res.writeHead(200, { 'Content-Type': 'application/octet-stream' });
+                res.end(Buffer.from('BIN!'));
+                return;
+            }
+            if (req.method === 'GET' && req.url === '/api/v1/crews') {
+                res.writeHead(200, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ data: [{ id: 7, name: 'acme', path: 'acme' }] }));
+                return;
+            }
+            if (req.method === 'GET' && req.url?.startsWith('/api/v1/crews/7/variables/resolve')) {
+                res.writeHead(200, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ variables: { PROBE: 'resolved' }, skipped_secrets: [] }));
+                return;
+            }
+            if (req.method === 'POST' && req.url === '/mcp') {
+                let raw = '';
+                req.on('data', (chunk) => { raw += chunk; });
+                req.on('end', () => {
+                    const parsed = JSON.parse(raw);
+                    const toolName: string = parsed.params.name;
+                    const args: Record<string, unknown> = parsed.params.arguments;
+                    const action = args.action;
+
+                    const respondText = (toolData: object) => {
+                        res.writeHead(200, { 'Content-Type': 'application/json' });
+                        res.end(JSON.stringify({
+                            jsonrpc: '2.0', id: 1,
+                            result: { isError: false, content: [{ type: 'text', text: JSON.stringify(toolData) }] },
+                        }));
+                    };
+
+                    if (toolName === 'crews_skills' && action === 'read') {
+                        respondText(BUNDLE);
+                        return;
+                    }
+                    if (toolName === 'crews_skills' && action === 'read_reference_file') {
+                        respondText({
+                            path: 'assets/blob.bin',
+                            mime: 'application/octet-stream',
+                            size: 4,
+                            signed_url: `http://127.0.0.1:${stubPort}/signed/blob.bin`,
+                        });
+                        return;
+                    }
+                    if (toolName === 'crews_skills' && action === 'exec_skill') {
+                        execSkillCalls.push(args);
+                        respondText({ stdout: 'sandbox ran', exit_code: 0, status: 'ok' });
+                        return;
+                    }
+                    if (toolName === 'crews_roles' && action === 'list') {
+                        respondText({
+                            roles: [
+                                { identifier: 'writer', in_crew: 'acme' },
+                                { identifier: 'dupe', in_crew: 'acme' },
+                                { identifier: 'dupe', in_crew: 'beta' },
+                            ],
+                        });
+                        return;
+                    }
+                    if (toolName === 'crews_roles' && action === 'read_skill') {
+                        const roleReference = { ...BUNDLE.reference };
+                        delete roleReference['assets/blob.bin'];
+                        respondText({ ...BUNDLE, identifier: 'q-tool', reference: roleReference });
+                        return;
+                    }
+
+                    res.writeHead(200, { 'Content-Type': 'application/json' });
+                    res.end(JSON.stringify({
+                        jsonrpc: '2.0', id: 1,
+                        result: { isError: true, content: [{ type: 'text', text: JSON.stringify({ code: 'unhandled', message: `no stub for ${toolName}/${action}` }) }] },
+                    }));
+                });
+                return;
+            }
+
+            res.writeHead(404, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ message: 'not found' }));
+        });
+
+        await new Promise<void>((resolve) => {
+            stubServer.listen(0, '127.0.0.1', () => {
+                stubPort = (stubServer.address() as { port: number }).port;
+                resolve();
+            });
+        });
+    });
+
+    afterAll(() => {
+        return new Promise<void>((resolve, reject) => {
+            stubServer.close((err) => (err ? reject(err) : resolve()));
+        });
+    });
+
+    beforeAll(() => {
+        homeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sa-skill-exec-target-test-'));
+        home = path.join(homeRoot, 'home');
+        fs.mkdirSync(home, { recursive: true });
+    });
+
+    afterAll(() => {
+        fs.rmSync(homeRoot, { recursive: true, force: true });
+    });
+
+    function baseEnv(homeDir: string): Record<string, string> {
+        return {
+            HOME: homeDir,
+            SOLIDACTIONS_HOST: `http://127.0.0.1:${stubPort}`,
+            SOLIDACTIONS_API_KEY: 'test-api-key',
+            SOLIDACTIONS_WORKSPACE_ID: 'ws-123',
+        };
+    }
+
+    /** Locate the single cache dir for q-tool under a shared or role scope. */
+    function findCacheDir(homeDir: string, ...scopeSegs: string[]): string {
+        const base = path.join(homeDir, '.solidactions', 'cache', 'skills');
+        const origins = fs.readdirSync(base);
+        expect(origins.length).toBe(1);
+        return path.join(base, origins[0], ...scopeSegs, 'q-tool');
+    }
+
+    it('1. exec without --target exits 1 (commander requiredOption error)', async () => {
+        const result = await runCli(['skill', 'exec', 'q-tool', '--', 'node', '-e', 'x'], baseEnv(home));
+        expect(result.status).toBe(1);
+        expect(result.stderr).toContain('--target');
+    });
+
+    it('2. exec with --target bogus exits 1 mentioning both valid targets', async () => {
+        const result = await runCli(['skill', 'exec', 'q-tool', '--target', 'bogus', '--', 'node', '-e', 'x'], baseEnv(home));
+        expect(result.status).toBe(1);
+        expect(result.stderr).toContain('sandbox');
+        expect(result.stderr).toContain('host');
+    });
+
+    it('3. exec ./somedir --target host exits 1 pointing at `skill dev`', async () => {
+        const result = await runCli(['skill', 'exec', './somedir', '--target', 'host', '--', 'node', '-e', 'x'], baseEnv(home));
+        expect(result.status).toBe(1);
+        expect(result.stderr).toContain('skill dev');
+    });
+
+    it('4. exec q-tool --target sandbox runs remotely (v1.30 behavior + banner)', async () => {
+        execSkillCalls = [];
+        const result = await runCli(
+            ['skill', 'exec', 'q-tool', '--target', 'sandbox', '--', 'node', '-e', 'x'],
+            baseEnv(home),
+        );
+        expect(result.status).toBe(0);
+        expect(result.stdout).toContain('sandbox ran');
+        expect(result.stderr).toContain('▶ stored skill q-tool → sandbox (production)');
+        expect(execSkillCalls[0].environment).toBeUndefined();
+    });
+
+    it('5. exec q-tool --target sandbox --crew acme is rejected', async () => {
+        const result = await runCli(
+            ['skill', 'exec', 'q-tool', '--target', 'sandbox', '--crew', 'acme', '--', 'node', '-e', 'x'],
+            baseEnv(home),
+        );
+        expect(result.status).toBe(1);
+        expect(result.stderr).toContain('--crew');
+    });
+
+    it('6. exec q-tool --target host --crew acme materializes the cache and runs locally', async () => {
+        const result = await runCli(
+            ['skill', 'exec', 'q-tool', '--target', 'host', '--crew', 'acme', '--', 'node', 'scripts/q.js'],
+            baseEnv(home),
+        );
+        expect(result.status).toBe(0);
+        expect(result.stdout).toContain('VAR=resolved');
+        expect(result.stderr).toContain('@ rev 7');
+        expect(result.stderr).toContain('local cache (production)');
+
+        const cacheDir = findCacheDir(home, 'shared');
+        expect(fs.readFileSync(path.join(cacheDir, 'SKILL.md'), 'utf8')).toContain('name: q-tool');
+        expect(fs.existsSync(path.join(cacheDir, 'scripts/q.js'))).toBe(true);
+        expect(fs.readFileSync(path.join(cacheDir, 'assets/blob.bin'), 'utf8')).toBe('BIN!');
+        expect(fs.existsSync(path.join(cacheDir, '.sa-cache-manifest.json'))).toBe(true);
+    });
+
+    it('7. second identical run against a read-only cache dir is a no-op (proves no writes)', async () => {
+        const cacheDir = findCacheDir(home, 'shared');
+
+        function chmodTree(dir: string, fileMode: number, dirMode: number) {
+            for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+                const full = path.join(dir, entry.name);
+                if (entry.isDirectory()) {
+                    chmodTree(full, fileMode, dirMode);
+                    fs.chmodSync(full, dirMode);
+                } else {
+                    fs.chmodSync(full, fileMode);
+                }
+            }
+        }
+
+        chmodTree(cacheDir, 0o444, 0o555);
+        fs.chmodSync(cacheDir, 0o555);
+
+        try {
+            const result = await runCli(
+                ['skill', 'exec', 'q-tool', '--target', 'host', '--crew', 'acme', '--', 'node', 'scripts/q.js'],
+                baseEnv(home),
+            );
+            expect(result.status).toBe(0);
+            expect(result.stdout).toContain('VAR=resolved');
+        } finally {
+            fs.chmodSync(cacheDir, 0o755);
+            chmodTree(cacheDir, 0o644, 0o755);
+        }
+    });
+
+    it('8. upstream change refreshes tracked files, deletes dropped ones, and preserves untracked scratch files', async () => {
+        const cacheDir = findCacheDir(home, 'shared');
+        fs.mkdirSync(path.join(cacheDir, 'node_modules'), { recursive: true });
+        fs.writeFileSync(path.join(cacheDir, 'node_modules', 'keep.txt'), 'keep');
+        fs.mkdirSync(path.join(cacheDir, '.sa-state'), { recursive: true });
+        fs.writeFileSync(path.join(cacheDir, '.sa-state', 'state.json'), '{}');
+
+        BUNDLE = {
+            ...BUNDLE,
+            body: 'B2',
+            active_snapshot_revision_id: 8,
+            reference: {
+                'scripts/q.js': 'console.log("VAR="+(process.env.PROBE||"none"));\n// v2',
+            },
+        };
+
+        const result = await runCli(
+            ['skill', 'exec', 'q-tool', '--target', 'host', '--crew', 'acme', '--', 'node', 'scripts/q.js'],
+            baseEnv(home),
+        );
+        expect(result.status).toBe(0);
+        expect(result.stdout).toContain('VAR=resolved');
+
+        expect(fs.existsSync(path.join(cacheDir, 'assets/blob.bin'))).toBe(false);
+        expect(fs.readFileSync(path.join(cacheDir, 'node_modules', 'keep.txt'), 'utf8')).toBe('keep');
+        expect(fs.readFileSync(path.join(cacheDir, '.sa-state', 'state.json'), 'utf8')).toBe('{}');
+
+        const manifest = JSON.parse(fs.readFileSync(path.join(cacheDir, '.sa-cache-manifest.json'), 'utf8'));
+        expect(manifest.execution_revision_id).toBe(8);
+    });
+
+    it('9. local tampering (drift) is self-healed on the next run', async () => {
+        const cacheDir = findCacheDir(home, 'shared');
+        fs.writeFileSync(path.join(cacheDir, 'scripts/q.js'), 'GARBAGE, not valid js');
+
+        const result = await runCli(
+            ['skill', 'exec', 'q-tool', '--target', 'host', '--crew', 'acme', '--', 'node', 'scripts/q.js'],
+            baseEnv(home),
+        );
+        expect(result.status).toBe(0);
+        expect(result.stdout).toContain('VAR=resolved');
+    });
+
+    it('10. role path: crew resolved via roles.list; ambiguous role rejected asking for --in-crew', async () => {
+        const writerResult = await runCli(
+            ['skill', 'exec', 'q-tool', '--target', 'host', '--role', 'writer', '--', 'node', 'scripts/q.js'],
+            baseEnv(home),
+        );
+        expect(writerResult.status).toBe(0);
+        expect(writerResult.stdout).toContain('VAR=resolved');
+
+        const dupeResult = await runCli(
+            ['skill', 'exec', 'q-tool', '--target', 'host', '--role', 'dupe', '--', 'node', 'scripts/q.js'],
+            baseEnv(home),
+        );
+        expect(dupeResult.status).toBe(1);
+        expect(dupeResult.stderr).toContain('--in-crew');
+    });
+
+    it('11. two simultaneous cold-cache runs both succeed (lock serializes materialization)', async () => {
+        const coldRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sa-skill-exec-target-cold-'));
+        const coldHome = path.join(coldRoot, 'home');
+        fs.mkdirSync(coldHome, { recursive: true });
+
+        try {
+            const args = ['skill', 'exec', 'q-tool', '--target', 'host', '--crew', 'acme', '--', 'node', 'scripts/q.js'];
+            const [a, b] = await Promise.all([
+                runCli(args, baseEnv(coldHome)),
+                runCli(args, baseEnv(coldHome)),
+            ]);
+            expect(a.status).toBe(0);
+            expect(b.status).toBe(0);
+            expect(a.stdout).toContain('VAR=resolved');
+            expect(b.stdout).toContain('VAR=resolved');
+        } finally {
+            fs.rmSync(coldRoot, { recursive: true, force: true });
+        }
+    }, 20_000);
+});

--- a/tests/skill-exec.test.ts
+++ b/tests/skill-exec.test.ts
@@ -1,5 +1,10 @@
 /**
- * Tests for `solidactions skill exec <name> -- <command...>`.
+ * Tests for `solidactions skill exec <name> --target sandbox -- <command...>`
+ * (the `--target sandbox` path — v1.30 behavior unchanged by Task 4). The
+ * `--target host` path and the option-matrix/validation rules added in
+ * Task 4 are covered by the built-CLI integration suite in
+ * tests/skill-exec-target.test.ts (host execution needs a real fs cache and
+ * `stdio: 'inherit'`, which this in-process harness can't observe).
  *
  * Test-double policy: no mock/spy/stub libraries. Uses a real in-process HTTP
  * server (Node's http.createServer) to stub the unified /mcp endpoint —
@@ -7,10 +12,10 @@
  *
  * Unlike `skill run` (tests/skill-run.test.ts), which spawns the built CLI
  * binary because production code uses `stdio: 'inherit'` (unobservable via a
- * JS-level monkeypatch), `skill exec` writes remote stdout/stderr via
- * `process.stdout.write` / `process.stderr.write` directly. That makes the
- * in-process pattern (patchProcessExit + captured writes) sufficient here —
- * no subprocess needed.
+ * JS-level monkeypatch), `skill exec --target sandbox` writes remote
+ * stdout/stderr via `process.stdout.write` / `process.stderr.write` directly.
+ * That makes the in-process pattern (patchProcessExit + captured writes)
+ * sufficient here — no subprocess needed.
  */
 import * as http from 'http';
 import { describe, expect, it, beforeAll, afterAll, beforeEach } from 'vitest';
@@ -147,7 +152,7 @@ describe('skillExecWithConfig — shared skill (no --role)', () => {
     it('posts tools/call with name:crews_skills and action:exec_skill, exits 0, prints remote stdout', async () => {
         responseQueue = [makeMcpSuccess({ stdout: 'hi', stderr: '', exit_code: 0, status: 'ok' })];
 
-        const { code, stdout } = await run('my-skill', ['node', 'scripts/q.js'], {});
+        const { code, stdout } = await run('my-skill', ['node', 'scripts/q.js'], { target: 'sandbox' });
 
         expect(code).toBe(0);
         expect(stdout).toContain('hi');
@@ -171,7 +176,7 @@ describe('skillExecWithConfig — role-scoped skill (--role)', () => {
     it('posts tools/call with name:crews_roles and action:exec_skill, sends role and name arguments', async () => {
         responseQueue = [makeMcpSuccess({ stdout: 'hi', stderr: '', exit_code: 0, status: 'ok', available_variables: [] })];
 
-        const { code } = await run('my-skill', ['node', 'scripts/q.js'], { role: 'writer' });
+        const { code } = await run('my-skill', ['node', 'scripts/q.js'], { target: 'sandbox', role: 'writer' });
 
         expect(code).toBe(0);
         expect(lastCapture).not.toBeNull();
@@ -188,7 +193,7 @@ describe('skillExecWithConfig — remote exit_code propagation', () => {
     it('exits with the remote exit_code (non-zero)', async () => {
         responseQueue = [makeMcpSuccess({ stdout: '', stderr: 'boom', exit_code: 3, status: 'failed' })];
 
-        const { code, stderr } = await run('my-skill', ['node', 'scripts/q.js'], {});
+        const { code, stderr } = await run('my-skill', ['node', 'scripts/q.js'], { target: 'sandbox' });
 
         expect(code).toBe(3);
         expect(stderr).toContain('boom');
@@ -197,24 +202,26 @@ describe('skillExecWithConfig — remote exit_code propagation', () => {
 
 describe('skillExecWithConfig — options passthrough', () => {
     it('sends --environment as top-level environment argument', async () => {
-        await run('my-skill', ['echo', 'hi'], { environment: 'staging' });
+        await run('my-skill', ['echo', 'hi'], { target: 'sandbox', environment: 'staging' });
         expect(lastCapture!.body.params.arguments.environment).toBe('staging');
     });
 
     it('sends --in-crew as in_crew only when --role is also given', async () => {
-        await run('my-skill', ['echo', 'hi'], { role: 'writer', inCrew: 'crew-a' });
+        await run('my-skill', ['echo', 'hi'], { target: 'sandbox', role: 'writer', inCrew: 'crew-a' });
         expect(lastCapture!.body.params.arguments.in_crew).toBe('crew-a');
     });
 
-    it('does not send in_crew when --role is absent, even if inCrew is set', async () => {
-        await run('my-skill', ['echo', 'hi'], { inCrew: 'crew-a' });
-        expect(lastCapture!.body.params.arguments).not.toHaveProperty('in_crew');
+    it('rejects --in-crew when --role is absent (option matrix: Task 4)', async () => {
+        const { code, stderr } = await run('my-skill', ['echo', 'hi'], { target: 'sandbox', inCrew: 'crew-a' });
+        expect(code).toBe(1);
+        expect(stderr).toContain('--in-crew');
+        expect(lastCapture).toBeNull();
     });
 });
 
 describe('skillExecWithConfig — command quoting', () => {
     it('shell-quotes each command word before joining into params.arguments.command, so shell metacharacters in an argv word (e.g. parens in a `node -e` script) survive the remote shell unmangled', async () => {
-        const { code } = await run('my-skill', ['node', '-e', 'console.log(42)'], {});
+        const { code } = await run('my-skill', ['node', '-e', 'console.log(42)'], { target: 'sandbox' });
 
         expect(code).toBe(0);
         // Matches shellQuoteArg's single-quote-every-word behavior in skill-run.ts:
@@ -225,7 +232,7 @@ describe('skillExecWithConfig — command quoting', () => {
 
 describe('skillExecWithConfig — error cases', () => {
     it('exits 1 with no command given, without making any HTTP request', async () => {
-        const { code, stderr } = await run('my-skill', [], {});
+        const { code, stderr } = await run('my-skill', [], { target: 'sandbox' });
         expect(code).toBe(1);
         expect(stderr).toContain('no command given');
         expect(lastCapture).toBeNull();
@@ -234,7 +241,7 @@ describe('skillExecWithConfig — error cases', () => {
     it('surfaces an MCP error code and message and exits 1', async () => {
         responseQueue = [makeMcpError('skill_not_found', 'No skill with that identifier exists.')];
 
-        const { code, stderr } = await run('missing-skill', ['echo', 'hi'], {});
+        const { code, stderr } = await run('missing-skill', ['echo', 'hi'], { target: 'sandbox' });
 
         expect(code).toBe(1);
         expect(stderr).toContain('skill_not_found');


### PR DESCRIPTION
## What

Re-keys the skill execution verbs on **source of truth** and adds one-step local execution of server-stored skills:

- `skill exec <name> --target sandbox|host` — always the SERVER-STORED skill. `--target` is **required** (breaking: was implicit sandbox). `host` is new: executes locally via a transparent revision-checked cache (`~/.solidactions/cache/skills/`, identity = doc/published/active-snapshot revision, sha256 manifest, ownership-token lock, binaries validated against size/sha before caching, 0700 dirs). Crew vars fetched from `/variables/resolve` at runtime; secrets need `env:reveal`. Both targets default to production vars.
- `skill dev <dir>` — rename of `skill run` (working copy, dev vars). `skill run` = hidden deprecated alias until v2.0.0. Wrong-shape args error with cross-references both directions.
- Fixes riding along: `crew env list` now renders unset envs as `-` instead of masking all three columns for secrets; `ai init` installs the new `solidactions-crew-skills` skill (**merge SolidActions/solidactions-examples#22 first** — skills fetch from that repo's main).

Spec: solidactions-app `docs/superpowers/specs/2026-07-12-skill-exec-local-design.md` (codex-reviewed). Server side (`variables/resolve`) already live — no app changes needed.

## Verification

- 632 tests passing (4 pre-existing `@solidactions/sdk/testing` env failures exist on main too)
- Per-task + final whole-branch reviews; live smoke 7/7 against the dev stack (cache materialization, noop re-run, revision bump, guards, alias, secret masking both ways)
- Cleanroom: context-free Sonnet TUI agent discovered `exec --target host` and the pull→edit→`skill dev` loop cold from `--help`, zero wrong-source mistakes

## Release notes

Breaking: `skill exec` without `--target` errors (add `--target sandbox`); `skill run` → `skill dev`. Ships as v1.31.0 (version bump not in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YNAuCMvbcdsbmaAqnoT1os