### PR TITLE
feat: solidactions login --device (OAuth device authorization) + workspace-scoped session enforcement

### DIFF
--- a/scripts/smoke-init.mjs
+++ b/scripts/smoke-init.mjs
@@ -94,8 +94,12 @@ async function startSourceServer() {
 
 async function expectHelp(binary, args, expected, env, cwd) {
   const output = await run(binary, [...args, '--help'], { capture: true, env, cwd });
+  // commander wraps help text to the terminal width, which can be narrower in CI
+  // (no TTY / piped output) than locally, splitting a phrase across a line break.
+  // Collapse all whitespace before matching so wrapping doesn't affect the check.
+  const normalized = output.replace(/\s+/g, ' ');
   for (const fragment of expected) {
-    assert(output.includes(fragment), `${args.join(' ')} --help is missing ${fragment}`);
+    assert(normalized.includes(fragment), `${args.join(' ')} --help is missing ${fragment}`);
   }
 }
 

--- a/src/commands/device-login.ts
+++ b/src/commands/device-login.ts
@@ -42,20 +42,31 @@ function sleep(ms: number): Promise<void> {
  * Poll POST /oauth/token per RFC 8628 §3.5: repeat at `intervalSeconds`,
  * honoring `authorization_pending` (keep polling) and `slow_down` (add
  * `slowDownIncrementSeconds` to the interval and keep polling). Rejects on
- * any other OAuth error. `slowDownIncrementSeconds` defaults to the
- * RFC-recommended 5s and is only overridden by tests, to keep them fast.
+ * any other OAuth error, including a server-sent `expired_token`.
+ * `slowDownIncrementSeconds` defaults to the RFC-recommended 5s and is only
+ * overridden by tests, to keep them fast.
+ *
+ * `expiresInSeconds` bounds the loop client-side to the device code's own
+ * lifetime, so a server that never emits `expired_token` (and just keeps
+ * returning `authorization_pending`) can't cause an infinite poll.
  */
 export async function pollForToken(
     host: string,
     clientId: string,
     deviceCode: string,
     intervalSeconds: number,
+    expiresInSeconds: number,
     slowDownIncrementSeconds = 5,
 ): Promise<TokenResponse> {
     let interval = intervalSeconds;
+    let elapsed = 0;
 
     while (true) {
+        if (elapsed + interval > expiresInSeconds) {
+            throw new Error('device code expired — run `solidactions login --device` again');
+        }
         await sleep(interval * 1000);
+        elapsed += interval;
 
         try {
             const response = await axios.post(`${host}/oauth/token`, {
@@ -72,6 +83,9 @@ export async function pollForToken(
             if (oauthError === 'slow_down') {
                 interval += slowDownIncrementSeconds;
                 continue;
+            }
+            if (oauthError === 'expired_token') {
+                throw new Error('device code expired — run `solidactions login --device` again');
             }
             throw new Error(oauthError || error.message);
         }
@@ -97,7 +111,7 @@ export async function deviceLogin(
 
     let token: TokenResponse;
     try {
-        token = await pollForToken(host, CLI_OAUTH_CLIENT_ID, code.device_code, code.interval || 5);
+        token = await pollForToken(host, CLI_OAUTH_CLIENT_ID, code.device_code, code.interval || 5, code.expires_in);
     } catch (error: any) {
         console.error(chalk.red('Device login failed:'), error.message);
         process.exit(1);

--- a/src/commands/device-login.ts
+++ b/src/commands/device-login.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import chalk from 'chalk';
 import { Config } from '../utils/config';
-import { fetchWorkspaces, WorkspaceLookupRecord } from '../utils/workspace-lookup';
+import { fetchWorkspaces, WorkspaceLookupRecord, WorkspaceScope } from '../utils/workspace-lookup';
 import { completeLogin, resolveLoginHost } from './login';
 
 // Public device-flow client id — not a secret; matches the server-seeded
@@ -123,8 +123,9 @@ export async function deviceLogin(
     // Same tail as login(): fetch workspaces, then resolve + write + report
     // exactly as login() does via the shared completeLogin() helper.
     let workspaces: WorkspaceLookupRecord[];
+    let scope: WorkspaceScope | null;
     try {
-        workspaces = await fetchWorkspaces(config);
+        ({ workspaces, scope } = await fetchWorkspaces(config));
     } catch (e: any) {
         if (e.response?.status === 401) {
             console.error(chalk.red(`Invalid API key for ${host}.`));
@@ -135,5 +136,5 @@ export async function deviceLogin(
         return;
     }
 
-    await completeLogin(config, workspaces, options);
+    await completeLogin(config, workspaces, options, scope);
 }

--- a/src/commands/device-login.ts
+++ b/src/commands/device-login.ts
@@ -1,0 +1,125 @@
+import axios from 'axios';
+import chalk from 'chalk';
+import { Config } from '../utils/config';
+import { fetchWorkspaces, WorkspaceLookupRecord } from '../utils/workspace-lookup';
+import { completeLogin, resolveLoginHost } from './login';
+
+// Public device-flow client id — not a secret; matches the server-seeded
+// oauth_clients row (config('services.cli.oauth_client_id') on the app side).
+const CLI_OAUTH_CLIENT_ID = '9f1b6e2a-9c1e-4b6e-8f0a-6c9f2b1e7d4c';
+
+// CLI capability scopes requested at device-code issuance — the server
+// rejects any scope not pre-registered via Passport::tokensCan().
+const CLI_SCOPES = 'env deploy runs docs';
+
+interface DeviceCodeResponse {
+    device_code: string;
+    user_code: string;
+    verification_uri: string;
+    verification_uri_complete?: string;
+    expires_in: number;
+    interval: number;
+}
+
+export interface TokenResponse {
+    access_token: string;
+    expires_in: number;
+}
+
+export async function requestDeviceCode(host: string): Promise<DeviceCodeResponse> {
+    const response = await axios.post(`${host}/oauth/device/code`, {
+        client_id: CLI_OAUTH_CLIENT_ID,
+        scope: CLI_SCOPES,
+    });
+    return response.data;
+}
+
+function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Poll POST /oauth/token per RFC 8628 §3.5: repeat at `intervalSeconds`,
+ * honoring `authorization_pending` (keep polling) and `slow_down` (add
+ * `slowDownIncrementSeconds` to the interval and keep polling). Rejects on
+ * any other OAuth error. `slowDownIncrementSeconds` defaults to the
+ * RFC-recommended 5s and is only overridden by tests, to keep them fast.
+ */
+export async function pollForToken(
+    host: string,
+    clientId: string,
+    deviceCode: string,
+    intervalSeconds: number,
+    slowDownIncrementSeconds = 5,
+): Promise<TokenResponse> {
+    let interval = intervalSeconds;
+
+    while (true) {
+        await sleep(interval * 1000);
+
+        try {
+            const response = await axios.post(`${host}/oauth/token`, {
+                grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+                device_code: deviceCode,
+                client_id: clientId,
+            });
+            return response.data;
+        } catch (error: any) {
+            const oauthError = error?.response?.data?.error;
+            if (oauthError === 'authorization_pending') {
+                continue;
+            }
+            if (oauthError === 'slow_down') {
+                interval += slowDownIncrementSeconds;
+                continue;
+            }
+            throw new Error(oauthError || error.message);
+        }
+    }
+}
+
+export async function deviceLogin(
+    options: { dev?: boolean; host?: string; workspace?: string; local?: boolean; global?: boolean; gitignore?: boolean },
+): Promise<void> {
+    const resolved = resolveLoginHost(options);
+    const host = resolved.host;
+
+    console.log(chalk.blue('Requesting device authorization...'));
+    const code = await requestDeviceCode(host);
+
+    const verifyUrl = code.verification_uri_complete || code.verification_uri;
+    console.log('');
+    console.log(chalk.green('To finish signing in, visit:'));
+    console.log('  ' + chalk.blue.underline(verifyUrl));
+    console.log(chalk.gray('  Enter code: ') + chalk.bold(code.user_code));
+    console.log('');
+    console.log(chalk.gray('Waiting for approval in your browser...'));
+
+    let token: TokenResponse;
+    try {
+        token = await pollForToken(host, CLI_OAUTH_CLIENT_ID, code.device_code, code.interval || 5);
+    } catch (error: any) {
+        console.error(chalk.red('Device login failed:'), error.message);
+        process.exit(1);
+        return;
+    }
+
+    const config: Config = { host, apiKey: token.access_token };
+
+    // Same tail as login(): fetch workspaces, then resolve + write + report
+    // exactly as login() does via the shared completeLogin() helper.
+    let workspaces: WorkspaceLookupRecord[];
+    try {
+        workspaces = await fetchWorkspaces(config);
+    } catch (e: any) {
+        if (e.response?.status === 401) {
+            console.error(chalk.red(`Invalid API key for ${host}.`));
+        } else {
+            console.error(chalk.red(`Could not reach ${host}: ${e.message}`));
+        }
+        process.exit(1);
+        return;
+    }
+
+    await completeLogin(config, workspaces, options);
+}

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -12,7 +12,7 @@ import {
     getGlobalConfigPath,
 } from '../utils/config';
 import { decideWriteTarget, pathForTarget, ensureGitignoreCovers, confirmOverwrite } from '../utils/config-write-target';
-import { fetchWorkspaces, matchWorkspace, WorkspaceLookupRecord } from '../utils/workspace-lookup';
+import { fetchWorkspaces, matchWorkspace, WorkspaceLookupRecord, WorkspaceScope } from '../utils/workspace-lookup';
 
 export type { Config };
 
@@ -182,7 +182,15 @@ export async function completeLogin(
     config: Config,
     workspaces: WorkspaceLookupRecord[],
     options: { workspace?: string; local?: boolean; global?: boolean; gitignore?: boolean },
+    scope: WorkspaceScope | null = null,
 ): Promise<void> {
+    // Device-flow tokens carry a scope (mode + workspace_ids) that later
+    // gates `workspace set`; absent for user-scoped Sanctum PATs.
+    if (scope) {
+        config.scopeMode = scope.mode;
+        config.scopedWorkspaceIds = scope.workspace_ids;
+    }
+
     // 2. Resolve the workspace (still before writing).
     if (options.workspace) {
         const match = matchWorkspace(options.workspace, workspaces);
@@ -265,8 +273,9 @@ export async function login(
 
     // 1. Validate the key BEFORE any disk write.
     let workspaces: WorkspaceLookupRecord[];
+    let scope: WorkspaceScope | null;
     try {
-        workspaces = await fetchWorkspaces(config);
+        ({ workspaces, scope } = await fetchWorkspaces(config));
     } catch (e: any) {
         if (e.response?.status === 401) {
             console.error(chalk.red(`Invalid API key for ${host}.`));
@@ -277,7 +286,7 @@ export async function login(
         return;
     }
 
-    await completeLogin(config, workspaces, options);
+    await completeLogin(config, workspaces, options, scope);
 }
 
 export function logout(options: { local?: boolean; global?: boolean } = {}) {

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -173,43 +173,16 @@ async function selectWorkspaceInteractively(
     return workspaces[index];
 }
 
-export async function login(
-    apiKey: string,
-    options: { dev?: boolean; host?: string; workspace?: string; local?: boolean; global?: boolean; gitignore?: boolean },
-) {
-    const resolved = resolveLoginHost(options);
-    const host = resolved.host;
-
-    if (!apiKey || apiKey.trim().length === 0) {
-        console.error(chalk.red('Error: API key is required.'));
-        console.log(chalk.gray('Generate an API key at: ') + chalk.blue(`${host}/settings/api-keys`));
-        process.exit(1);
-    }
-
-    console.log(chalk.blue(`Initializing SolidActions CLI...`));
-    for (const line of loginHostLines(resolved)) {
-        console.log(resolved.isDefault ? chalk.yellow(line) : chalk.gray(line));
-    }
-
-    const config: Config = {
-        host,
-        apiKey: apiKey.trim(),
-    };
-
-    // 1. Validate the key BEFORE any disk write.
-    let workspaces: WorkspaceLookupRecord[];
-    try {
-        workspaces = await fetchWorkspaces(config);
-    } catch (e: any) {
-        if (e.response?.status === 401) {
-            console.error(chalk.red(`Invalid API key for ${host}.`));
-        } else {
-            console.error(chalk.red(`Could not reach ${host}: ${e.message}`));
-        }
-        process.exit(1);
-        return;
-    }
-
+/**
+ * Shared tail of `login`, reused verbatim by `deviceLogin`: resolve the
+ * workspace against an already-fetched list, determine the write target,
+ * back up + write the config file once, and print the success output.
+ */
+export async function completeLogin(
+    config: Config,
+    workspaces: WorkspaceLookupRecord[],
+    options: { workspace?: string; local?: boolean; global?: boolean; gitignore?: boolean },
+): Promise<void> {
     // 2. Resolve the workspace (still before writing).
     if (options.workspace) {
         const match = matchWorkspace(options.workspace, workspaces);
@@ -265,6 +238,46 @@ export async function login(
     console.log(chalk.gray('  solidactions project deploy <name>    Deploy current directory'));
     console.log(chalk.gray('  solidactions run start <proj> <wf>    Run a workflow'));
     console.log(chalk.gray('  solidactions run list                 List recent runs'));
+}
+
+export async function login(
+    apiKey: string,
+    options: { dev?: boolean; host?: string; workspace?: string; local?: boolean; global?: boolean; gitignore?: boolean },
+) {
+    const resolved = resolveLoginHost(options);
+    const host = resolved.host;
+
+    if (!apiKey || apiKey.trim().length === 0) {
+        console.error(chalk.red('Error: API key is required.'));
+        console.log(chalk.gray('Generate an API key at: ') + chalk.blue(`${host}/settings/api-keys`));
+        process.exit(1);
+    }
+
+    console.log(chalk.blue(`Initializing SolidActions CLI...`));
+    for (const line of loginHostLines(resolved)) {
+        console.log(resolved.isDefault ? chalk.yellow(line) : chalk.gray(line));
+    }
+
+    const config: Config = {
+        host,
+        apiKey: apiKey.trim(),
+    };
+
+    // 1. Validate the key BEFORE any disk write.
+    let workspaces: WorkspaceLookupRecord[];
+    try {
+        workspaces = await fetchWorkspaces(config);
+    } catch (e: any) {
+        if (e.response?.status === 401) {
+            console.error(chalk.red(`Invalid API key for ${host}.`));
+        } else {
+            console.error(chalk.red(`Could not reach ${host}: ${e.message}`));
+        }
+        process.exit(1);
+        return;
+    }
+
+    await completeLogin(config, workspaces, options);
 }
 
 export function logout(options: { local?: boolean; global?: boolean } = {}) {

--- a/src/commands/workspaces.ts
+++ b/src/commands/workspaces.ts
@@ -58,6 +58,12 @@ interface WorkspaceSetOptions {
     gitignore?: boolean;
 }
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function looksLikeUuid(input: string): boolean {
+    return UUID_RE.test(input);
+}
+
 export async function workspaceSet(input: string, options: WorkspaceSetOptions = {}) {
     if (process.env.SOLIDACTIONS_WORKSPACE_ID) {
         console.error(chalk.red(
@@ -68,6 +74,21 @@ export async function workspaceSet(input: string, options: WorkspaceSetOptions =
     }
 
     const config = requireResolvedConfig().config;
+
+    if ((config.scopeMode === 'single' || config.scopeMode === 'subset') && config.scopedWorkspaceIds) {
+        // Best-effort pre-check: the scope list holds raw ids, so only an id
+        // input can be checked locally; slug/name inputs fall through to the
+        // server's authoritative 403 workspace_forbidden (surfaced cleanly).
+        const isKnownOutOfScope = config.scopedWorkspaceIds.length > 0
+            && !config.scopedWorkspaceIds.includes(input);
+        if (isKnownOutOfScope && looksLikeUuid(input)) {
+            console.error(chalk.red(
+                `This session is scoped to workspace(s) ${config.scopedWorkspaceIds.join(', ')}. `
+                + 'Re-run `solidactions login --device` to change scope.',
+            ));
+            process.exit(1);
+        }
+    }
 
     const workspace = await resolveWorkspaceInput(config, input);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,9 +110,10 @@ program.hook('preAction', (thisCommand, actionCommand) => {
 
 program
     .command('login')
-    .description('Authenticate the CLI (prompts securely for your API key)')
-    .argument('[api-key]', 'Legacy positional API key (prefer the masked prompt or --stdin)')
+    .description('Authenticate the CLI (prompts securely for your API key, or via --device for browser-based login)')
+    .argument('[api-key]', 'Legacy positional API key (prefer the masked prompt, --stdin, or --device)')
     .option('--stdin', 'Read the API key from stdin (for non-interactive automation)')
+    .option('--device', 'Authenticate via browser using OAuth device authorization')
     .option('--dev', 'Use local development server (http://localhost:8000)')
     .option('--host <url>', 'Custom API host URL')
     .option('--workspace <name-or-id>', 'Set workspace by name, slug, or ID (skips interactive prompt). Non-interactive logins without this flag leave the workspace unset.')
@@ -120,6 +121,11 @@ program
     .option('--global', 'Save config to ~/.solidactions/config.json (default if prompted)')
     .option('--gitignore', 'With --local, add .solidactions/ to .gitignore without prompting')
     .action(async (apiKey, options) => {
+        if (options.device) {
+            const { deviceLogin } = await import('./commands/device-login');
+            await deviceLogin(options);
+            return;
+        }
         const resolvedApiKey = await resolveLoginApiKey(apiKey, { stdin: options.stdin });
         await login(resolvedApiKey, options);
     });

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -31,10 +31,10 @@ export function augmentNotFoundMessage(error: any): any {
 /**
  * Inspect an axios error and, if it's a 403 with the app's `workspace_forbidden`
  * error code (device-flow-scoped token targeting a workspace outside its
- * scope), replace the raw server message with the same actionable guidance
- * `workspaceSet`'s local pre-check gives — so slug/name inputs (which can't
- * be pre-checked locally) still surface a clear message instead of a raw
- * axios/HTTP error.
+ * scope), replace the raw server message with actionable guidance similar in
+ * spirit to `workspaceSet`'s local pre-check (wording isn't kept in sync
+ * verbatim) — so slug/name inputs (which can't be pre-checked locally) still
+ * surface a clear message instead of a raw axios/HTTP error.
  */
 export function augmentWorkspaceForbiddenMessage(error: any): any {
     if (error?.response?.status === 403 && error.response.data?.code === 'workspace_forbidden') {

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -28,9 +28,26 @@ export function augmentNotFoundMessage(error: any): any {
     return error;
 }
 
+/**
+ * Inspect an axios error and, if it's a 403 with the app's `workspace_forbidden`
+ * error code (device-flow-scoped token targeting a workspace outside its
+ * scope), replace the raw server message with the same actionable guidance
+ * `workspaceSet`'s local pre-check gives — so slug/name inputs (which can't
+ * be pre-checked locally) still surface a clear message instead of a raw
+ * axios/HTTP error.
+ */
+export function augmentWorkspaceForbiddenMessage(error: any): any {
+    if (error?.response?.status === 403 && error.response.data?.code === 'workspace_forbidden') {
+        error.response.data.message =
+            'This session is scoped to a limited set of workspaces. '
+            + 'Re-run `solidactions login --device` to change scope.';
+    }
+    return error;
+}
+
 axios.interceptors.response.use(
     (response) => response,
-    (error) => Promise.reject(augmentNotFoundMessage(error)),
+    (error) => Promise.reject(augmentWorkspaceForbiddenMessage(augmentNotFoundMessage(error))),
 );
 
 export function getApiHeaders(config: Config, contentType?: string): Record<string, string> {
@@ -158,6 +175,12 @@ export async function ensureWorkspaceSelected(config: Config): Promise<Config> {
             }
         } else {
             workspaces = Array.isArray(grouped) ? grouped : [];
+        }
+
+        const scope = response.data.scope as { mode: 'all' | 'subset' | 'single'; workspace_ids: string[] } | null;
+        if (scope) {
+            config.scopeMode = scope.mode;
+            config.scopedWorkspaceIds = scope.workspace_ids;
         }
     } catch (error: any) {
         if (error.response?.status === 401) {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -8,6 +8,8 @@ export interface Config {
     apiKey: string;
     workspace?: string;     // human-readable slug; cosmetic
     workspaceId?: string;   // canonical UUID used in API calls
+    scopeMode?: 'all' | 'subset' | 'single'; // set for device-flow tokens; absent for user-scoped Sanctum PATs
+    scopedWorkspaceIds?: string[];           // present when scopeMode is 'subset' or 'single'
 }
 
 export type ConfigSource = 'env' | string | null;
@@ -188,6 +190,10 @@ export function mergeConfigs(
     const workspace = pickWorkspaceField('workspace');
     const workspaceId = pickWorkspaceField('workspaceId');
 
+    // Never env-settable — config-file layers only (local > global).
+    const scopeMode = pick('scopeMode');
+    const scopedWorkspaceIds = pick('scopedWorkspaceIds');
+
     if (!host.value && !apiKey.value) {
         return null;
     }
@@ -198,6 +204,8 @@ export function mergeConfigs(
             apiKey: (apiKey.value ?? '') as string,
             workspace: workspace.value as string | undefined,
             workspaceId: workspaceId.value as string | undefined,
+            scopeMode: scopeMode.value as Config['scopeMode'],
+            scopedWorkspaceIds: scopedWorkspaceIds.value as string[] | undefined,
         },
         sources: {
             host: host.source,

--- a/src/utils/workspace-lookup.ts
+++ b/src/utils/workspace-lookup.ts
@@ -8,6 +8,17 @@ export interface WorkspaceLookupRecord {
     name: string;
 }
 
+/** Device-flow token scope, as returned by GET /api/v1/workspaces. Null for user-scoped Sanctum PATs. */
+export interface WorkspaceScope {
+    mode: 'all' | 'subset' | 'single';
+    workspace_ids: string[];
+}
+
+export interface FetchWorkspacesResult {
+    workspaces: WorkspaceLookupRecord[];
+    scope: WorkspaceScope | null;
+}
+
 /**
  * Pure: given a list of workspaces and an input string, return the matching
  * workspace. Match order: id, slug, name (first match wins). Cross-tenant
@@ -25,7 +36,7 @@ export function matchWorkspace(
  * Network: fetch the full list of workspaces the current API key can see.
  * Normalizes the API's grouped/array response shapes.
  */
-export async function fetchWorkspaces(config: Config): Promise<WorkspaceLookupRecord[]> {
+export async function fetchWorkspaces(config: Config): Promise<FetchWorkspacesResult> {
     const response = await axios.get(`${config.host}/api/v1/workspaces`, {
         headers: {
             'Authorization': `Bearer ${config.apiKey}`,
@@ -41,7 +52,8 @@ export async function fetchWorkspaces(config: Config): Promise<WorkspaceLookupRe
     } else if (Array.isArray(grouped)) {
         out.push(...(grouped as WorkspaceLookupRecord[]));
     }
-    return out;
+    const scope = (response.data.scope as WorkspaceScope | null) ?? null;
+    return { workspaces: out, scope };
 }
 
 /**
@@ -54,7 +66,7 @@ export async function resolveWorkspaceInput(
 ): Promise<WorkspaceLookupRecord> {
     let workspaces: WorkspaceLookupRecord[];
     try {
-        workspaces = await fetchWorkspaces(config);
+        ({ workspaces } = await fetchWorkspaces(config));
     } catch (error: any) {
         console.error(chalk.red('Failed to list workspaces:'), error.response?.data?.message || error.message);
         process.exit(1);

--- a/tests/device-login.test.ts
+++ b/tests/device-login.test.ts
@@ -1,0 +1,79 @@
+/**
+ * pollForToken drives the RFC 8628 §3.5 device-flow polling loop. Test-double
+ * policy (matching tests/login-validation.test.ts): a real in-process HTTP
+ * server stubs POST /oauth/token, no mock/spy/stub libraries. Interval
+ * arguments are kept sub-second (fractional seconds) so the suite stays fast
+ * without needing fake timers.
+ */
+import http from 'http';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { pollForToken } from '../src/commands/device-login';
+
+describe('pollForToken', () => {
+    let server: http.Server;
+    let port: number;
+    let responses: Array<{ status: number; body: unknown }>;
+    let requestCount: number;
+
+    const HOST = () => `http://127.0.0.1:${port}`;
+
+    beforeAll(async () => {
+        server = http.createServer((_req, res) => {
+            requestCount++;
+            const next = responses.shift() ?? { status: 500, body: {} };
+            res.writeHead(next.status, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify(next.body));
+        });
+        await new Promise<void>((resolve) => {
+            server.listen(0, '127.0.0.1', () => {
+                port = (server.address() as { port: number }).port;
+                resolve();
+            });
+        });
+    });
+
+    afterAll(() => {
+        return new Promise<void>((resolve, reject) => {
+            server.close((err) => (err ? reject(err) : resolve()));
+        });
+    });
+
+    beforeEach(() => {
+        requestCount = 0;
+    });
+
+    it('honors authorization_pending and returns the token once approved', async () => {
+        responses = [
+            { status: 400, body: { error: 'authorization_pending' } },
+            { status: 200, body: { access_token: 'tok-123', expires_in: 3600 } },
+        ];
+
+        const result = await pollForToken(HOST(), 'client-id', 'devcode', 0.02, 0.02);
+
+        expect(result.access_token).toBe('tok-123');
+        expect(requestCount).toBe(2);
+    });
+
+    it('backs off on slow_down by increasing the interval before the next poll', async () => {
+        responses = [
+            { status: 400, body: { error: 'slow_down' } },
+            { status: 200, body: { access_token: 'tok-456', expires_in: 3600 } },
+        ];
+
+        const start = Date.now();
+        const result = await pollForToken(HOST(), 'client-id', 'devcode', 0.02, 0.1);
+        const elapsed = Date.now() - start;
+
+        expect(result.access_token).toBe('tok-456');
+        expect(requestCount).toBe(2);
+        // First poll after ~0.02s, second only after the bumped ~0.12s interval.
+        expect(elapsed).toBeGreaterThanOrEqual(110);
+    });
+
+    it('throws on access_denied', async () => {
+        responses = [{ status: 400, body: { error: 'access_denied' } }];
+
+        await expect(pollForToken(HOST(), 'client-id', 'devcode', 0.02, 0.02)).rejects.toThrow('access_denied');
+        expect(requestCount).toBe(1);
+    });
+});

--- a/tests/device-login.test.ts
+++ b/tests/device-login.test.ts
@@ -48,7 +48,7 @@ describe('pollForToken', () => {
             { status: 200, body: { access_token: 'tok-123', expires_in: 3600 } },
         ];
 
-        const result = await pollForToken(HOST(), 'client-id', 'devcode', 0.02, 0.02);
+        const result = await pollForToken(HOST(), 'client-id', 'devcode', 0.02, 10, 0.02);
 
         expect(result.access_token).toBe('tok-123');
         expect(requestCount).toBe(2);
@@ -61,7 +61,7 @@ describe('pollForToken', () => {
         ];
 
         const start = Date.now();
-        const result = await pollForToken(HOST(), 'client-id', 'devcode', 0.02, 0.1);
+        const result = await pollForToken(HOST(), 'client-id', 'devcode', 0.02, 10, 0.1);
         const elapsed = Date.now() - start;
 
         expect(result.access_token).toBe('tok-456');
@@ -73,7 +73,27 @@ describe('pollForToken', () => {
     it('throws on access_denied', async () => {
         responses = [{ status: 400, body: { error: 'access_denied' } }];
 
-        await expect(pollForToken(HOST(), 'client-id', 'devcode', 0.02, 0.02)).rejects.toThrow('access_denied');
+        await expect(pollForToken(HOST(), 'client-id', 'devcode', 0.02, 10, 0.02)).rejects.toThrow('access_denied');
         expect(requestCount).toBe(1);
+    });
+
+    it('throws on expired_token from the server', async () => {
+        responses = [{ status: 400, body: { error: 'expired_token' } }];
+
+        await expect(pollForToken(HOST(), 'client-id', 'devcode', 0.02, 10, 0.02)).rejects.toThrow(
+            'device code expired',
+        );
+        expect(requestCount).toBe(1);
+    });
+
+    it('aborts with a clear error once elapsed polling exceeds expires_in, without a server-sent expired_token', async () => {
+        // Server always returns authorization_pending (never expired_token); a
+        // short expires_in with a small interval means the client-side deadline
+        // check fires before it would run out of canned responses.
+        responses = Array.from({ length: 20 }, () => ({ status: 400, body: { error: 'authorization_pending' } }));
+
+        await expect(pollForToken(HOST(), 'client-id', 'devcode', 0.05, 0.15, 0.02)).rejects.toThrow(
+            'device code expired — run `solidactions login --device` again',
+        );
     });
 });

--- a/tests/login-validation.test.ts
+++ b/tests/login-validation.test.ts
@@ -196,4 +196,34 @@ describe('login — validates before writing (F-C2)', () => {
         expect(out).toContain('No workspace set');
         expect(out).toContain('Logged in successfully!');
     });
+
+    it('a scoped /v1/workspaces response (device-flow token) persists scopeMode + scopedWorkspaceIds through completeLogin', async () => {
+        nextStatus = 200;
+        nextBody = {
+            data: [{ id: 'ws-1', name: 'Some Workspace', slug: 'some-workspace' }],
+            scope: { mode: 'subset', workspace_ids: ['ws-1', 'ws-2'] },
+        };
+
+        await login('good-key', { global: true, host: HOST(), workspace: 'Some Workspace' });
+
+        const globalPath = path.join(env.home, '.solidactions', 'config.json');
+        const config = JSON.parse(fs.readFileSync(globalPath, 'utf-8'));
+        expect(config.scopeMode).toBe('subset');
+        expect(config.scopedWorkspaceIds).toEqual(['ws-1', 'ws-2']);
+    });
+
+    it('a null scope (Sanctum PAT) leaves scopeMode/scopedWorkspaceIds absent through completeLogin', async () => {
+        nextStatus = 200;
+        nextBody = {
+            data: [{ id: 'ws-1', name: 'Some Workspace', slug: 'some-workspace' }],
+            scope: null,
+        };
+
+        await login('good-key', { global: true, host: HOST(), workspace: 'Some Workspace' });
+
+        const globalPath = path.join(env.home, '.solidactions', 'config.json');
+        const config = JSON.parse(fs.readFileSync(globalPath, 'utf-8'));
+        expect(config.scopeMode).toBeUndefined();
+        expect(config.scopedWorkspaceIds).toBeUndefined();
+    });
 });

--- a/tests/workspace-set-scope-refusal.test.ts
+++ b/tests/workspace-set-scope-refusal.test.ts
@@ -1,0 +1,119 @@
+import http from 'http';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { workspaceSet } from '../src/commands/workspaces';
+import { ensureWorkspaceSelected } from '../src/utils/api';
+import { readConfigFile } from '../src/utils/config';
+import { makeTmpEnv, writeGlobal } from './helpers';
+
+describe('workspace set — scoped token refusal', () => {
+    let env: ReturnType<typeof makeTmpEnv>;
+    let exitSpy: any;
+    let errorSpy: any;
+    let logSpy: any;
+
+    beforeEach(() => {
+        env = makeTmpEnv();
+        exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => { throw new Error('exit'); }) as never);
+        errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        env?.cleanup();
+    });
+
+    const WS_A = '11111111-1111-1111-1111-111111111111';
+    const WS_B = '22222222-2222-2222-2222-222222222222';
+
+    it('refuses to switch to a workspace outside a subset-scoped token without a network call', async () => {
+        writeGlobal(env.home, {
+            host: 'http://127.0.0.1:1', // unroutable; a network call here would hang/fail the test
+            apiKey: 'sk_test',
+            workspaceId: WS_A,
+            scopeMode: 'subset',
+            scopedWorkspaceIds: [WS_A],
+        });
+
+        await expect(workspaceSet(WS_B, { global: true })).rejects.toThrow('exit');
+
+        expect(errorSpy.mock.calls.join(' ')).toContain('scoped to workspace');
+        expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it('allows switching to a workspace within scope (falls through to network resolution)', async () => {
+        const server = http.createServer((_req, res) => {
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ workspaces: { Org: [{ id: WS_A, slug: 'ws-a', name: 'Workspace A' }] } }));
+        });
+        await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+        const port = (server.address() as { port: number }).port;
+
+        try {
+            writeGlobal(env.home, {
+                host: `http://127.0.0.1:${port}`,
+                apiKey: 'sk_test',
+                workspaceId: WS_A,
+                scopeMode: 'subset',
+                scopedWorkspaceIds: [WS_A],
+            });
+
+            await workspaceSet(WS_A, { global: true });
+
+            expect(exitSpy).not.toHaveBeenCalled();
+            expect(logSpy.mock.calls.join(' ')).toContain('Workspace set to');
+        } finally {
+            await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+        }
+    });
+
+    it('persists scope from a scoped /v1/workspaces response inside ensureWorkspaceSelected', async () => {
+        const server = http.createServer((_req, res) => {
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({
+                workspaces: { Org: [{ id: 'ws-a', name: 'Workspace A', role: 'member' }] },
+                scope: { mode: 'single', workspace_ids: ['ws-a'] },
+            }));
+        });
+        await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+        const port = (server.address() as { port: number }).port;
+
+        try {
+            const globalPath = writeGlobal(env.home, { host: `http://127.0.0.1:${port}`, apiKey: 'sk_test' });
+
+            const config = { host: `http://127.0.0.1:${port}`, apiKey: 'sk_test' };
+            await ensureWorkspaceSelected(config);
+
+            const written = readConfigFile(globalPath);
+            expect(written?.scopeMode).toBe('single');
+            expect(written?.scopedWorkspaceIds).toEqual(['ws-a']);
+        } finally {
+            await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+        }
+    });
+
+    it('leaves scope fields absent for a sanctum (scope: null) response', async () => {
+        const server = http.createServer((_req, res) => {
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({
+                workspaces: { Org: [{ id: 'ws-a', name: 'Workspace A', role: 'member' }] },
+                scope: null,
+            }));
+        });
+        await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+        const port = (server.address() as { port: number }).port;
+
+        try {
+            const globalPath = writeGlobal(env.home, { host: `http://127.0.0.1:${port}`, apiKey: 'sk_test' });
+
+            const config = { host: `http://127.0.0.1:${port}`, apiKey: 'sk_test' };
+            await ensureWorkspaceSelected(config);
+
+            const written = readConfigFile(globalPath);
+            expect(written?.scopeMode).toBeUndefined();
+            expect(written?.scopedWorkspaceIds).toBeUndefined();
+        } finally {
+            await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- `solidactions login --device`: RFC 8628 device-authorization login — prints verification URL + user code, polls honoring `authorization_pending`/`slow_down`, bounded by the device code's `expires_in`; token lands in the same config.json as normal login (shared `completeLogin()` tail)
- Persists the server's token scope (`scopeMode` / `scopedWorkspaceIds`) from `/v1/workspaces` in the real login flow
- `workspace set`: local refusal for out-of-scope workspace ids on scoped sessions ("re-run `solidactions login --device` to change scope"); server `workspace_forbidden` 403s surface as actionable messages

Companion app PR: solidactions-app#795 (server side of the device flow).

## Test plan
- 8 new vitest cases using the repo's real-local-HTTP-server convention (no mocks): polling semantics, expiry bound (would hang pre-fix), scope persistence end-to-end through `completeLogin`, scoped `workspace set` refusal
- Full suite 661/661 + `npm run build` green
- Live smoke against the dev stack (real device login, subset grant, member-not-granted refusal) and a context-free cleanroom TUI agent completing the flow cold

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFu6yyJuWQJq6oRxu8w6so