### PR TITLE
publish tag-derived version + docs-push excludes + env delete --env (#77 #69 #31)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,16 @@ jobs:
       - run: npm ci
       - run: npm run build
 
+      # `npm version` resolves increment KEYWORDS (patch/minor/major/…), so a
+      # release tagged e.g. `patch` would silently publish a bumped version
+      # instead of failing. Assert the tag is a literal semver before we hand it
+      # to `npm version`, so only an explicit version ever reaches the registry.
+      - name: Assert release tag is a literal semver version
+        run: |
+          [[ "${GITHUB_REF_NAME}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+([-+].*)?$ ]] || {
+            echo "release tag '${GITHUB_REF_NAME}' is not a semver version"; exit 1;
+          }
+
       # The release tag is the single source of truth for the published version.
       # Deriving it here (rather than relying on a package.json bump commit) means
       # a release whose package.json wasn't bumped can no longer collide with the

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,4 +19,12 @@ jobs:
 
       - run: npm ci
       - run: npm run build
+
+      # The release tag is the single source of truth for the published version.
+      # Deriving it here (rather than relying on a package.json bump commit) means
+      # a release whose package.json wasn't bumped can no longer collide with the
+      # registry's existing version and fail `npm publish` silently (#77). No git
+      # tag is created — this only rewrites the in-workspace package.json version.
+      - run: npm version --no-git-tag-version --allow-same-version "${GITHUB_REF_NAME#v}"
+
       - run: npm publish --provenance --access public

--- a/src/commands/docs-push.ts
+++ b/src/commands/docs-push.ts
@@ -109,6 +109,18 @@ interface TrackedMissing {
     id: number;
 }
 
+const SKIP_DIRS = new Set(['node_modules']);
+
+/**
+ * Directory/dot entries neither walker descends into or picks up: dotfiles and
+ * dot-directories (also covers the `.solidactions-docs.json` sidecar itself) and
+ * `node_modules/`. Shared so the markdown and binary walkers stay in lockstep —
+ * an untracked `.md` under `node_modules/` or a dot-directory must not be pushed.
+ */
+function isSkippedEntry(name: string): boolean {
+    return name.startsWith('.') || SKIP_DIRS.has(name);
+}
+
 /**
  * Recursively walk `dir` and collect all *.md files.
  * Returns a list of absolute paths.
@@ -118,6 +130,7 @@ function walkMarkdownFiles(dir: string): string[] {
 
     const walk = (current: string): void => {
         for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+            if (isSkippedEntry(entry.name)) continue;
             const abs = path.join(current, entry.name);
             if (entry.isDirectory()) {
                 walk(abs);
@@ -131,8 +144,6 @@ function walkMarkdownFiles(dir: string): string[] {
     return results;
 }
 
-const SKIP_DIRS = new Set(['node_modules']);
-
 /**
  * Recursively walk `dir` and collect relative paths of non-.md files that
  * are not present in the manifest — never uploaded by `docs push`; `docs
@@ -145,7 +156,7 @@ function walkUntrackedBinaries(dir: string, manifest: DocsManifest | null): stri
 
     const walk = (current: string): void => {
         for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
-            if (entry.name.startsWith('.') || SKIP_DIRS.has(entry.name)) continue;
+            if (isSkippedEntry(entry.name)) continue;
             const abs = path.join(current, entry.name);
             if (entry.isDirectory()) {
                 walk(abs);

--- a/tests/docs-push.test.ts
+++ b/tests/docs-push.test.ts
@@ -2375,6 +2375,44 @@ describe('docsPushWithConfig — untracked binaries', () => {
         }
     });
 
+    it('never pushes untracked .md files under node_modules or dot-directories', async () => {
+        const { dir, cleanup } = makeTmpDocsDir({
+            'real.md': '# Real',
+            'node_modules/some-pkg/readme.md': '# Should be ignored',
+            '.cache/notes.md': '# Also ignored',
+        });
+
+        const restoreExit = patchProcessExit();
+        const { restore: restoreStdout } = captureStdout();
+        const { lines: stderrLines, restore: restoreStderr } = captureStderr();
+
+        try {
+            let caughtExit: ProcessExitError | null = null;
+            try {
+                await docsPushWithConfig(dir, { onConflict: 'skip' }, stubConfig());
+            } catch (e) {
+                if (e instanceof ProcessExitError) caughtExit = e;
+                else throw e;
+            }
+
+            expect(caughtExit?.code).toBe(0);
+
+            // Only `real.md` reaches bulk_create; the excluded trees are never sent.
+            const bulkItems = allCaptures
+                .flatMap((c) => c.body?.params?.arguments?.items ?? []);
+            const titles = bulkItems.map((i: any) => i.title);
+            expect(titles).toEqual(['real']);
+
+            // And they must not be warned about as untracked binaries either.
+            expect(stderrLines.join('')).not.toMatch(/not pushed/);
+        } finally {
+            restoreExit();
+            restoreStdout();
+            restoreStderr();
+            cleanup();
+        }
+    });
+
     it('exposes untracked_media in the --json payload, excluding tracked files and the manifest sidecar', async () => {
         const trackedContent = '# Doc';
         const { dir, cleanup } = makeTmpDocsDir({

--- a/tests/env-delete-env.test.ts
+++ b/tests/env-delete-env.test.ts
@@ -1,0 +1,107 @@
+/**
+ * #31: `env delete` gained a `--env` flag for symmetry with `env set`, so a
+ * dev/staging environment-scoped project variable can be deleted from the CLI
+ * (previously you had to hit the API directly). These tests lock in that the
+ * flag selects the same `<project>-<env>` slug `env set` uses, and that
+ * `--env production` targets the bare project name.
+ *
+ * Test-double policy: real in-process HTTP server (Node's http.createServer) —
+ * no mock/spy/stub libraries. Matches env-set-global-guard.test.ts.
+ */
+import * as http from 'http';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { envDelete } from '../src/commands/env-delete';
+import { makeTmpEnv, writeGlobal } from './helpers';
+
+class ProcessExitError extends Error {
+    constructor(public readonly code: number | undefined) {
+        super(`process.exit(${code})`);
+    }
+}
+
+function patchProcessExit(): () => void {
+    const orig = process.exit.bind(process);
+    (process as any).exit = (code?: number) => { throw new ProcessExitError(code); };
+    return () => { (process as any).exit = orig; };
+}
+
+let server: http.Server;
+let port: number;
+let requests: Array<{ method: string; path: string }> = [];
+
+beforeAll(async () => {
+    server = http.createServer((req, res) => {
+        req.on('data', () => { /* drain */ });
+        req.on('end', () => {
+            requests.push({ method: req.method || '', path: req.url || '' });
+
+            // GET variable-mappings → one mapping so delete has an id to target.
+            if (req.method === 'GET' && req.url?.match(/\/variable-mappings$/)) {
+                res.writeHead(200, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify([{ id: 42, env_name: 'API_KEY', is_yaml_declared: false }]));
+                return;
+            }
+            if (req.method === 'DELETE' && req.url?.match(/\/variable-mappings\/42$/)) {
+                res.writeHead(200, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({}));
+                return;
+            }
+            res.writeHead(404, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ message: `unhandled ${req.method} ${req.url}` }));
+        });
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => {
+        port = (server.address() as any).port;
+        resolve();
+    }));
+});
+
+afterAll(() => new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve()))));
+
+beforeEach(() => { requests = []; });
+
+describe('envDelete — --env flag (#31)', () => {
+    it('--env staging targets the <project>-staging slug (symmetric with env set)', async () => {
+        const env = makeTmpEnv();
+        writeGlobal(env.home, { host: `http://127.0.0.1:${port}`, apiKey: 'sk_test', workspaceId: 'ws-1' });
+        const restoreExit = patchProcessExit();
+        try {
+            let caught: ProcessExitError | null = null;
+            try { await envDelete('myproject', 'API_KEY', { yes: true, env: 'staging' }); }
+            catch (e) { if (e instanceof ProcessExitError) caught = e; else throw e; }
+
+            expect(caught).toBeNull();
+            expect(requests.some((r) => r.method === 'GET' && r.path.includes('/projects/myproject-staging/variable-mappings'))).toBe(true);
+            expect(requests.some((r) => r.method === 'DELETE' && r.path.includes('/projects/myproject-staging/variable-mappings/42'))).toBe(true);
+        } finally { restoreExit(); env.cleanup(); }
+    });
+
+    it('defaults to the -dev slug when --env is omitted', async () => {
+        const env = makeTmpEnv();
+        writeGlobal(env.home, { host: `http://127.0.0.1:${port}`, apiKey: 'sk_test', workspaceId: 'ws-1' });
+        const restoreExit = patchProcessExit();
+        try {
+            let caught: ProcessExitError | null = null;
+            try { await envDelete('myproject', 'API_KEY', { yes: true }); }
+            catch (e) { if (e instanceof ProcessExitError) caught = e; else throw e; }
+
+            expect(caught).toBeNull();
+            expect(requests.some((r) => r.path.includes('/projects/myproject-dev/variable-mappings'))).toBe(true);
+        } finally { restoreExit(); env.cleanup(); }
+    });
+
+    it('--env production targets the bare project name (no env suffix)', async () => {
+        const env = makeTmpEnv();
+        writeGlobal(env.home, { host: `http://127.0.0.1:${port}`, apiKey: 'sk_test', workspaceId: 'ws-1' });
+        const restoreExit = patchProcessExit();
+        try {
+            let caught: ProcessExitError | null = null;
+            try { await envDelete('myproject', 'API_KEY', { yes: true, env: 'production' }); }
+            catch (e) { if (e instanceof ProcessExitError) caught = e; else throw e; }
+
+            expect(caught).toBeNull();
+            expect(requests.some((r) => r.path.includes('/projects/myproject/variable-mappings'))).toBe(true);
+            expect(requests.some((r) => r.path.includes('/projects/myproject-production/'))).toBe(false);
+        } finally { restoreExit(); env.cleanup(); }
+    });
+});

--- a/tests/env-delete-help.test.ts
+++ b/tests/env-delete-help.test.ts
@@ -1,0 +1,33 @@
+/**
+ * #31: pins the Commander registration of `env delete --env` at the CLI level.
+ *
+ * The behavioral tests in env-delete-env.test.ts call envDelete() with a
+ * pre-built options object, so removing the `-e, --env` option registration in
+ * src/index.ts would NOT fail them. This spawns the real built CLI binary and
+ * asserts the flag appears in `env delete --help`, so the flag's existence is
+ * pinned to the actual command wiring.
+ *
+ * Test-double policy: spawns the real built CLI binary (dist/index.js) —
+ * matches the pattern in tests/dev-help-env-example.test.ts.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import * as childProcess from 'child_process';
+import { describe, expect, it } from 'vitest';
+
+const CLI_BINARY = path.resolve(__dirname, '../dist/index.js');
+
+describe('env delete --help — --env flag registration (#31)', () => {
+    it('CLI is built', () => {
+        expect(fs.existsSync(CLI_BINARY)).toBe(true);
+    });
+
+    it('registers the -e, --env flag on env delete', () => {
+        const result = childProcess.spawnSync(process.execPath, [CLI_BINARY, 'env', 'delete', '--help'], {
+            encoding: 'utf8',
+            timeout: 15_000,
+        });
+
+        expect(result.stdout).toMatch(/-e,\s+--env/);
+    });
+});


### PR DESCRIPTION
Three small maintenance fixes batched into one PR.

## #77 — publish.yml: tag-derived version (Closes #77)
A GitHub release whose `package.json` wasn't bumped fails `npm publish` silently against a duplicate version (v1.32.0 never reached npm). Now, before publishing:

```yaml
- name: Assert release tag is a literal semver version
  run: |
    [[ "${GITHUB_REF_NAME}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+([-+].*)?$ ]] || {
      echo "release tag '${GITHUB_REF_NAME}' is not a semver version"; exit 1;
    }
- run: npm version --no-git-tag-version --allow-same-version "${GITHUB_REF_NAME#v}"
```

The release tag becomes the single source of truth: the workspace `package.json` is rewritten to match the tag (no git tag created), so a missing bump commit can no longer collide with the registry. `--allow-same-version` keeps the normal already-bumped case a no-op. `npm publish --provenance --access public` is unchanged.

The semver **guard** matters because `npm version` resolves increment *keywords* (`patch`/`minor`/`major`/`premajor`/…): a release tagged e.g. `patch` would otherwise silently publish a bumped version instead of the intended literal. The guard fails the run loudly unless the tag is a literal semver (with optional `v` prefix and `-`/`+` suffix), so only an explicit version ever reaches the registry.

**Verification:** this workflow change is not exercised by the test suite — it's verified by reasoning + YAML lint (`yaml.safe_load` passes) + a local check of the guard regex against `v1.33.0`, `1.33.0`, `v1.33.0-rc.1` (pass) and `patch`, `minor`, `v1.2`, `1.2.3.4` (reject). `GITHUB_REF_NAME` for a release is `v1.33.0`; `${GITHUB_REF_NAME#v}` → `1.33.0`.

## #69 — docs push: exclude node_modules/ and dot-directories (Closes #69)
`walkMarkdownFiles` recursed into `node_modules/` and dot-directories while the newer `walkUntrackedBinaries` did not — so an untracked `.md` under either was `bulk_create`d as a real doc. Hoisted the skip predicate into a shared `isSkippedEntry(name)` used by both walkers.

**Behavior note (deliberate):** `isSkippedEntry` is `name.startsWith('.') || SKIP_DIRS.has(name)`, so aligning the two walkers means `walkMarkdownFiles` now also skips dot-prefixed **files** (e.g. a stray `.draft.md`), not just dot-directories — this matches `walkUntrackedBinaries`' established semantics (which already excluded dotfiles, including the `.solidactions-docs.json` sidecar). This is intentional consistency, not an accidental side effect.

**Verification:** new vitest test asserts an untracked `.md` under `node_modules/` and under a dot-directory is neither pushed (only `real.md` reaches `bulk_create`) nor warned about.

## #31 — env delete --env (Closes #31)
The `--env` flag was already added to `env delete` in commit `2b9c886` (after the issue was filed) and matches `env set`'s slug semantics (`<project>-<env>`, bare name for `production`). This PR adds the previously-missing **regression tests** locking in that behavior; no source change was needed.

Two layers of test:
- **Behavioral** (`env-delete-env.test.ts`): `envDelete()` against a stub server asserts `--env staging` → `-staging` slug, default → `-dev`, `--env production` → bare name.
- **Registration** (`env-delete-help.test.ts`): spawns the real built CLI and asserts `-e, --env` appears in `env delete --help`, so removing the Commander option registration in `src/index.ts` fails a test (the behavioral tests, which pass pre-built options, would not catch that on their own).

## Local verification
- `npm run build` — green (`ignore` dep required a fresh `npm install`)
- `npx vitest run` — **71 files / 667 tests passing** (includes the docs-push exclusion test, the `env delete --env` behavioral tests, and the new registration-level `--help` test)

This repo has no CI PR workflow, so the above is local verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
