### PR TITLE
Rename crews MCP action exec_skill to sandbox_exec

### DIFF
--- a/src/commands/skill-exec.ts
+++ b/src/commands/skill-exec.ts
@@ -3,7 +3,7 @@
  *
  * ALWAYS executes the server-stored skill (the artifact) — never local edits;
  * that's `skill dev <dir>`. --target picks WHERE the stored skill executes:
- *   sandbox — the server-managed sandbox via crews MCP exec_skill (v1.30 behavior)
+ *   sandbox — the server-managed sandbox via crews MCP sandbox_exec (v1.30 behavior)
  *   host    — this machine, from a transparent revision-checked cache under
  *             ~/.solidactions/cache/skills/ (no visible pull step)
  * --target is REQUIRED (no default): a half-remembered command errors instead
@@ -101,8 +101,8 @@ async function execInSandbox(
     const isRole = Boolean(options.role);
     const tool = isRole ? 'roles' : 'skills';
     const args: Record<string, unknown> = isRole
-        ? { action: 'exec_skill', role: options.role, name, command }
-        : { action: 'exec_skill', identifier: name, command };
+        ? { action: 'sandbox_exec', role: options.role, name, command }
+        : { action: 'sandbox_exec', identifier: name, command };
     if (options.environment) args.environment = options.environment;
     if (isRole && options.inCrew) args.in_crew = options.inCrew;
 

--- a/src/commands/skill-run.ts
+++ b/src/commands/skill-run.ts
@@ -1,11 +1,11 @@
 /**
  * solidactions skill dev <dir> [--crew <c>] [--environment <env>] [--env-file <f>] -- <command...>
  *
- * Local analogue of the crews MCP exec_skill: runs <command> with cwd=<dir>
+ * Local analogue of the crews MCP sandbox_exec: runs <command> with cwd=<dir>
  * (matching the sandbox's cwd=/work/skills/<slug>), with crew variables
  * fetched at runtime from /api/v1/crews/{id}/variables/resolve. Secrets are
  * included only when the API key holds env:reveal; skipped names are printed.
- * DELIBERATE DIVERGENCE from remote exec_skill: default environment is `dev`
+ * DELIBERATE DIVERGENCE from remote sandbox_exec: default environment is `dev`
  * (this is a dev tool); remote defaults to production. Always prints the env.
  */
 import fs from 'fs';

--- a/tests/skill-exec-target.test.ts
+++ b/tests/skill-exec-target.test.ts
@@ -228,7 +228,7 @@ describe('solidactions skill exec — integration (--target sandbox|host)', () =
                         });
                         return;
                     }
-                    if (toolName === 'crews_skills' && action === 'exec_skill') {
+                    if (toolName === 'crews_skills' && action === 'sandbox_exec') {
                         execSkillCalls.push(args);
                         respondText({ stdout: 'sandbox ran', exit_code: 0, status: 'ok' });
                         return;

--- a/tests/skill-exec.test.ts
+++ b/tests/skill-exec.test.ts
@@ -149,7 +149,7 @@ async function run(name: string, commandParts: string[], options: Record<string,
 }
 
 describe('skillExecWithConfig — shared skill (no --role)', () => {
-    it('posts tools/call with name:crews_skills and action:exec_skill, exits 0, prints remote stdout', async () => {
+    it('posts tools/call with name:crews_skills and action:sandbox_exec, exits 0, prints remote stdout', async () => {
         responseQueue = [makeMcpSuccess({ stdout: 'hi', stderr: '', exit_code: 0, status: 'ok' })];
 
         const { code, stdout } = await run('my-skill', ['node', 'scripts/q.js'], { target: 'sandbox' });
@@ -166,14 +166,14 @@ describe('skillExecWithConfig — shared skill (no --role)', () => {
         const body = lastCapture!.body;
         expect(body.method).toBe('tools/call');
         expect(body.params.name).toBe('crews_skills');
-        expect(body.params.arguments.action).toBe('exec_skill');
+        expect(body.params.arguments.action).toBe('sandbox_exec');
         expect(body.params.arguments.identifier).toBe('my-skill');
         expect(body.params.arguments.command).toBe("'node' 'scripts/q.js'");
     });
 });
 
 describe('skillExecWithConfig — role-scoped skill (--role)', () => {
-    it('posts tools/call with name:crews_roles and action:exec_skill, sends role and name arguments', async () => {
+    it('posts tools/call with name:crews_roles and action:sandbox_exec, sends role and name arguments', async () => {
         responseQueue = [makeMcpSuccess({ stdout: 'hi', stderr: '', exit_code: 0, status: 'ok', available_variables: [] })];
 
         const { code } = await run('my-skill', ['node', 'scripts/q.js'], { target: 'sandbox', role: 'writer' });
@@ -183,7 +183,7 @@ describe('skillExecWithConfig — role-scoped skill (--role)', () => {
 
         const body = lastCapture!.body;
         expect(body.params.name).toBe('crews_roles');
-        expect(body.params.arguments.action).toBe('exec_skill');
+        expect(body.params.arguments.action).toBe('sandbox_exec');
         expect(body.params.arguments.role).toBe('writer');
         expect(body.params.arguments.name).toBe('my-skill');
     });

--- a/tests/skill-run.test.ts
+++ b/tests/skill-run.test.ts
@@ -11,7 +11,7 @@
  *
  * 1. Spawn the built binary, don't call the function in-process. Production
  *    code runs the user's command with `stdio: 'inherit'` (real-time
- *    streaming + interactive stdin, matching the MCP exec_skill UX).
+ *    streaming + interactive stdin, matching the MCP sandbox_exec UX).
  *    `inherit` hands the grandchild the parent's raw file descriptor,
  *    bypassing `process.stdout.write` entirely — an in-process call can't
  *    capture it via a JS-level monkeypatch. Spawning the CLI as a subprocess


### PR DESCRIPTION
Server-side rename landed in solidactions-app v0.157.0 (SolidActions/solidactions-app#814): the crews MCP action is now `sandbox_exec` (skills are Agent Skills the agent runs with its own tools; the hosted sandbox is fallback compute). Without this, `skill exec --target sandbox` gets `unknown_action` from the server.

Mechanical rename in `skill-exec.ts` (wire payloads + comments), `skill-run.ts` (comments), and the three affected test files. Full suite: 666 passed locally (repo has no PR-triggered CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)