### PR TITLE
fix(dev): refuse --env runs that would silently fall back to the global (production) config

### DIFF
--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -142,6 +142,41 @@ export interface RunDevOptions {
 }
 
 /**
+ * Canonicalize a config path for identity comparison, so a project reached
+ * through a symlinked alias is not mistaken for a different project. Falls back
+ * to the given path when the file cannot be resolved (e.g. a broken symlink) —
+ * the caller is only comparing two paths, not dereferencing them.
+ */
+function realPath(p: string): string {
+    try {
+        return fs.realpathSync(p);
+    } catch {
+        return p;
+    }
+}
+
+/**
+ * Throw when a local config file exists but cannot be parsed as JSON.
+ *
+ * `readConfigFile()` swallows parse errors and returns null, which makes a
+ * corrupt local config indistinguishable from an absent one — resolution then
+ * falls through to the global config. Re-reading here lets us surface the
+ * actual parse error instead.
+ */
+function assertLocalConfigParses(configPath: string): void {
+    try {
+        JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    } catch (e: any) {
+        throw new Error(
+            `local config at ${configPath} is malformed: ${e?.message ?? e}\n`
+            + 'It exists but cannot be parsed, so config resolution would fall through to the global '
+            + `config ${getGlobalConfigPath()}, which usually points at production.\n`
+            + 'Fix: repair the file, or re-run `solidactions login --local` to rewrite it.',
+        );
+    }
+}
+
+/**
  * Refuse to run `dev --env` against a config the user did not choose.
  *
  * `dev --env` builds its API client from `resolveConfig(process.cwd())`, which
@@ -151,10 +186,14 @@ export interface RunDevOptions {
  * tree used to silently fetch vars from — and target — the wrong tenant, with
  * no diagnostic beyond a bare 404 (issue #30).
  *
- * Two situations are refused:
+ * Three situations are refused:
  *   1. No project-local config above the cwd — the run WOULD fall back to the
  *      global config.
- *   2. The entry file's project-local config is NOT the one the cwd resolves to
+ *   2. A local config that EXISTS but does not parse — `readConfigFile()`
+ *      swallows the parse error and returns null, so a corrupt file resolves
+ *      exactly like an absent one and falls through to global. Same leak, but
+ *      it slips past a path-existence check.
+ *   3. The entry file's project-local config is NOT the one the cwd resolves to
  *      — the run would target a different project's account. NOTE: this branch
  *      only engages for entries run IN-PROCESS (`.js`/`.mjs`). A `.ts` entry is
  *      re-exec'd by {@link reexecUnderTsx} with the child's cwd already set to
@@ -202,11 +241,14 @@ export function assertProjectLocalConfig(entryPath: string, env: string): void {
             + partial
             + found
             + 'Fix: cd into the project directory before running `solidactions dev`, '
-            + 'or run `solidactions init` there to create a project-local config.',
+            + 'or run `solidactions login --local` there to create a project-local config.',
         );
     }
 
-    if (entryLocal && entryLocal !== cwdLocal) {
+    // Exists — but a file that doesn't parse resolves like an absent one.
+    assertLocalConfigParses(cwdLocal);
+
+    if (entryLocal && realPath(entryLocal) !== realPath(cwdLocal)) {
         throw new Error(
             `config mismatch: the workflow's project config is ${entryLocal}, `
             + `but this directory resolves to ${cwdLocal}.\n`
@@ -789,7 +831,7 @@ export async function dev(file: string, options: DevOptions): Promise<void> {
 
     // .ts entry under plain node has no loader — re-exec under tsx, then return.
     if (!hasTsLoader() && /\.(ts|tsx|mts|cts)$/.test(filePath)) {
-        const projectDir = findProjectRoot(filePath) ?? process.cwd();
+        const projectDir = resolveDevProjectDir(filePath);
         // Surface a clear slug-resolution error here (before forking) rather
         // than letting the child fail with an opaque exit code. Only relevant
         // when an env was requested (bare runs do no platform fetch).
@@ -839,6 +881,31 @@ export async function dev(file: string, options: DevOptions): Promise<void> {
     // failed
     console.error(chalk.red(`✗ failed (${r.phase ?? 'run'}):`), r.error?.message ?? String(r.error));
     process.exit(1);
+}
+
+/**
+ * Choose the cwd for the tsx re-exec child.
+ *
+ * The child's cwd decides which config `resolveConfig(process.cwd())` picks, so
+ * it must be anchored to the workflow's OWN `.solidactions/config.json` when one
+ * exists. Using the nearest `package.json` parent (the previous behaviour) is
+ * wrong in a monorepo: for `/repo/package.json` + `/repo/apps/a/.solidactions/`,
+ * an entry under `apps/a` would re-exec with cwd `/repo`, where no local config
+ * is reachable — so resolution fell back to the global (production) config and
+ * the #30 guard then refused a perfectly legitimate run.
+ *
+ * Preference order: the directory owning the entry's nearest local config, then
+ * the nearest `package.json` parent, then the current cwd. `npx` still resolves
+ * `tsx` by walking node_modules upward, so a package-less project directory is
+ * fine.
+ */
+export function resolveDevProjectDir(entryPath: string): string {
+    const localConfig = findLocalConfigPath(path.dirname(path.resolve(entryPath)));
+    if (localConfig) {
+        // <dir>/.solidactions/config.json → <dir>
+        return path.dirname(path.dirname(localConfig));
+    }
+    return findProjectRoot(entryPath) ?? process.cwd();
 }
 
 function findProjectRoot(startPath: string): string | null {

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -155,13 +155,26 @@ export interface RunDevOptions {
  *   1. No project-local config above the cwd — the run WOULD fall back to the
  *      global config.
  *   2. The entry file's project-local config is NOT the one the cwd resolves to
- *      — the run would target a different project's account.
+ *      — the run would target a different project's account. NOTE: this branch
+ *      only engages for entries run IN-PROCESS (`.js`/`.mjs`). A `.ts` entry is
+ *      re-exec'd by {@link reexecUnderTsx} with the child's cwd already set to
+ *      the entry's own project root, so by the time the guard runs in the child
+ *      the two paths are equal by construction — the child is correctly
+ *      anchored to the entry's project and there is nothing to mismatch.
  *
- * Explicit `SOLIDACTIONS_HOST` / `SOLIDACTIONS_API_KEY` env overrides are a
- * deliberate choice of target and are always allowed through.
+ * `SOLIDACTIONS_HOST` / `SOLIDACTIONS_API_KEY` env overrides bypass the guard
+ * ONLY when BOTH are set. `resolveConfig()` picks host and apiKey INDEPENDENTLY
+ * (env > local > global), so with just one var set the OTHER field still falls
+ * through to the global config — i.e. a partial override would send a run to
+ * the production host, or to production credentials, exactly the way #30
+ * describes. A partial override therefore refuses like any other unanchored
+ * run, naming the field that would fall through.
  */
 export function assertProjectLocalConfig(entryPath: string, env: string): void {
-    if (process.env.SOLIDACTIONS_HOST || process.env.SOLIDACTIONS_API_KEY) {
+    const envHost = !!process.env.SOLIDACTIONS_HOST;
+    const envApiKey = !!process.env.SOLIDACTIONS_API_KEY;
+    if (envHost && envApiKey) {
+        // Both credential fields come from env — nothing can fall to global.
         return;
     }
 
@@ -169,6 +182,16 @@ export function assertProjectLocalConfig(entryPath: string, env: string): void {
     const cwdLocal = findLocalConfigPath(process.cwd());
 
     if (!cwdLocal) {
+        // Exactly one env override set: name the field that would fall through.
+        let partial = '';
+        if (envHost !== envApiKey) {
+            const supplied = envHost ? 'SOLIDACTIONS_HOST' : 'SOLIDACTIONS_API_KEY';
+            const missing = envHost ? 'apiKey' : 'host';
+            const missingVar = envHost ? 'SOLIDACTIONS_API_KEY' : 'SOLIDACTIONS_HOST';
+            partial = `${supplied} is set, but host and apiKey resolve independently — `
+                + `\`${missing}\` would still come from the global config. `
+                + `Set ${missingVar} too to target a host explicitly.\n`;
+        }
         const found = entryLocal
             ? `The workflow's own project config is ${entryLocal}.\n`
             : '';
@@ -176,6 +199,7 @@ export function assertProjectLocalConfig(entryPath: string, env: string): void {
             `no project-local .solidactions/config.json found from ${process.cwd()}.\n`
             + `Refusing to run --env ${env} against the global config ${getGlobalConfigPath()}, `
             + 'which usually points at production.\n'
+            + partial
             + found
             + 'Fix: cd into the project directory before running `solidactions dev`, '
             + 'or run `solidactions init` there to create a project-local config.',

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -7,7 +7,7 @@ import yaml from 'js-yaml';
 import { randomUUID } from 'crypto';
 import { createRequire } from 'module';
 import { SolidActionsConfig } from '../utils/env';
-import { Config } from '../utils/config';
+import { Config, findLocalConfigPath, getGlobalConfigPath } from '../utils/config';
 
 // ---------------------------------------------------------------------------
 // runDev — programmatic entry point (testable, no process.exit)
@@ -139,6 +139,57 @@ export interface RunDevOptions {
      *   "override shadows platform var: <KEY>"
      */
     varsOverride?: Record<string, string>;
+}
+
+/**
+ * Refuse to run `dev --env` against a config the user did not choose.
+ *
+ * `dev --env` builds its API client from `resolveConfig(process.cwd())`, which
+ * falls back to the GLOBAL `~/.solidactions/config.json` when no project-local
+ * `.solidactions/config.json` is reachable. That global config typically points
+ * at PRODUCTION, so a workflow run from outside its project's `.solidactions`
+ * tree used to silently fetch vars from — and target — the wrong tenant, with
+ * no diagnostic beyond a bare 404 (issue #30).
+ *
+ * Two situations are refused:
+ *   1. No project-local config above the cwd — the run WOULD fall back to the
+ *      global config.
+ *   2. The entry file's project-local config is NOT the one the cwd resolves to
+ *      — the run would target a different project's account.
+ *
+ * Explicit `SOLIDACTIONS_HOST` / `SOLIDACTIONS_API_KEY` env overrides are a
+ * deliberate choice of target and are always allowed through.
+ */
+export function assertProjectLocalConfig(entryPath: string, env: string): void {
+    if (process.env.SOLIDACTIONS_HOST || process.env.SOLIDACTIONS_API_KEY) {
+        return;
+    }
+
+    const entryLocal = findLocalConfigPath(path.dirname(path.resolve(entryPath)));
+    const cwdLocal = findLocalConfigPath(process.cwd());
+
+    if (!cwdLocal) {
+        const found = entryLocal
+            ? `The workflow's own project config is ${entryLocal}.\n`
+            : '';
+        throw new Error(
+            `no project-local .solidactions/config.json found from ${process.cwd()}.\n`
+            + `Refusing to run --env ${env} against the global config ${getGlobalConfigPath()}, `
+            + 'which usually points at production.\n'
+            + found
+            + 'Fix: cd into the project directory before running `solidactions dev`, '
+            + 'or run `solidactions init` there to create a project-local config.',
+        );
+    }
+
+    if (entryLocal && entryLocal !== cwdLocal) {
+        throw new Error(
+            `config mismatch: the workflow's project config is ${entryLocal}, `
+            + `but this directory resolves to ${cwdLocal}.\n`
+            + `Refusing to run --env ${env} against a config from a different project.\n`
+            + 'Fix: cd into the workflow\'s project directory before running `solidactions dev`.',
+        );
+    }
 }
 
 /**
@@ -348,6 +399,9 @@ export async function runDev(opts: RunDevOptions): Promise<RunDevResult> {
         if (opts.api) {
             apiClient = opts.api;
         } else {
+            // Refuse BEFORE any config resolution / network work when the only
+            // reachable config is the global (usually production) one — see #30.
+            assertProjectLocalConfig(opts.entry, opts.env);
             // Production path: build from CLI config.
             // Lazy-import to keep tests fast (no config resolution needed).
             const { requireConfigWithWorkspace } = await import('../utils/api');

--- a/tests/dev-config-guard.test.ts
+++ b/tests/dev-config-guard.test.ts
@@ -14,10 +14,11 @@
  * dev.test.ts / dev-env-404-hint.test.ts.
  */
 import * as fs from 'fs';
+import * as http from 'http';
 import * as os from 'os';
 import * as path from 'path';
-import { afterEach, describe, expect, it } from 'vitest';
-import { assertProjectLocalConfig, runDev, type PlatformVar, type SaApiClient } from '../src/commands/dev';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { assertProjectLocalConfig, buildSaApiClient, resolveDevProjectDir, runDev } from '../src/commands/dev';
 import { makeTmpEnv, writeLocal } from './helpers';
 
 const ECHO_FIXTURE = path.resolve(__dirname, '../fixtures/echo.ts');
@@ -31,13 +32,36 @@ function makeOrphanDir(): { dir: string; cleanup: () => void } {
     return { dir, cleanup: () => fs.rmSync(dir, { recursive: true, force: true }) };
 }
 
-function fakeApi(): SaApiClient {
-    return {
-        projectSlug: 'test-project',
-        async fetchVarsAndConnections(_env: string): Promise<PlatformVar[]> {
-            return [];
-        },
-    };
+// Real in-process HTTP server standing in for the SA API (repo convention —
+// same shape as env-set-global-guard.test.ts). The client under test is the
+// REAL buildSaApiClient(), so the request path, headers and response decoding
+// are all exercised; only the server on the other end is local.
+let server: http.Server;
+let port: number;
+
+beforeAll(async () => {
+    server = http.createServer((req, res) => {
+        if (req.method === 'GET' && req.url?.includes('/variable-mappings')) {
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify([]));
+            return;
+        }
+        res.writeHead(404, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ message: `unhandled ${req.method} ${req.url}` }));
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => {
+        port = (server.address() as any).port;
+        resolve();
+    }));
+});
+
+afterAll(() => new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve()))));
+
+function realApi() {
+    return buildSaApiClient(
+        { host: `http://127.0.0.1:${port}`, apiKey: 'sk_test' } as any,
+        'test-project',
+    );
 }
 
 describe('assertProjectLocalConfig — refusal', () => {
@@ -63,7 +87,10 @@ describe('assertProjectLocalConfig — refusal', () => {
             expect(msg).toContain(path.join(env.home, '.solidactions', 'config.json'));
             expect(msg).toContain('usually points at production');
             expect(msg).toContain('cd into the project directory');
-            expect(msg).toContain('solidactions init');
+            // `solidactions init` does NOT write .solidactions/config.json —
+            // `login --local` is the documented command (README "login flags").
+            expect(msg).toContain('solidactions login --local');
+            expect(msg).not.toContain('solidactions init');
         } finally { orphan.cleanup(); env.cleanup(); }
     });
 
@@ -208,6 +235,124 @@ describe('assertProjectLocalConfig — partial env override still refuses', () =
     }, 20_000);
 });
 
+/**
+ * Review round 2 (FALSE-NEGATIVE): a local config that EXISTS but is malformed
+ * passed the guard (the path is there) while readConfigFile() returned null, so
+ * resolution fell through to the global production config — #30 surviving.
+ */
+describe('assertProjectLocalConfig — malformed local config', () => {
+    it('refuses a present-but-unparseable local config, naming path and parse error', () => {
+        const env = makeTmpEnv();
+        try {
+            const dir = path.join(env.cwd, '.solidactions');
+            fs.mkdirSync(dir, { recursive: true });
+            const file = path.join(dir, 'config.json');
+            fs.writeFileSync(file, '{ "host": "https://proj.example", oops');
+            process.chdir(env.cwd);
+
+            let msg = '';
+            try { assertProjectLocalConfig(path.join(env.cwd, 'wf.mjs'), 'production'); }
+            catch (e: any) { msg = e.message; }
+
+            expect(msg).toContain(`local config at ${file} is malformed`);
+            expect(msg).toContain('would fall through to the global');
+            expect(msg).toContain('solidactions login --local');
+        } finally { env.cleanup(); }
+    });
+
+    it('an empty local config file is refused too (JSON.parse fails on "")', () => {
+        const env = makeTmpEnv();
+        try {
+            const dir = path.join(env.cwd, '.solidactions');
+            fs.mkdirSync(dir, { recursive: true });
+            fs.writeFileSync(path.join(dir, 'config.json'), '');
+            process.chdir(env.cwd);
+            expect(() => assertProjectLocalConfig(path.join(env.cwd, 'wf.mjs'), 'production'))
+                .toThrow(/is malformed/);
+        } finally { env.cleanup(); }
+    });
+
+    it('a well-formed local config is not affected', () => {
+        const env = makeTmpEnv();
+        try {
+            writeLocal(env.cwd, { host: 'https://proj.example', apiKey: 'sk_proj' });
+            process.chdir(env.cwd);
+            expect(() => assertProjectLocalConfig(path.join(env.cwd, 'wf.mjs'), 'production')).not.toThrow();
+        } finally { env.cleanup(); }
+    });
+});
+
+/**
+ * Review round 2 (FALSE-POSITIVE): the re-exec cwd used the nearest package.json
+ * parent, so in a monorepo (`/repo/package.json` + `/repo/apps/a/.solidactions/`)
+ * an entry under `apps/a` re-exec'd with cwd `/repo` — no local config reachable
+ * there, so the guard refused a legitimate run. The child cwd is now anchored to
+ * the entry's own local config.
+ */
+describe('resolveDevProjectDir — monorepo anchoring', () => {
+    it('prefers the directory owning the entry\'s local config over the nearest package.json', () => {
+        const env = makeTmpEnv();
+        try {
+            const repo = env.cwd;
+            const app = path.join(repo, 'apps', 'a');
+            fs.mkdirSync(path.join(app, 'src'), { recursive: true });
+            fs.writeFileSync(path.join(repo, 'package.json'), '{"name":"repo"}');
+            writeLocal(app, { host: 'https://a.example', apiKey: 'sk_a' });
+
+            expect(resolveDevProjectDir(path.join(app, 'src', 'wf.ts'))).toBe(app);
+        } finally { env.cleanup(); }
+    });
+
+    it('falls back to the nearest package.json parent when no local config exists', () => {
+        const env = makeTmpEnv();
+        try {
+            const repo = env.cwd;
+            const nested = path.join(repo, 'apps', 'b', 'src');
+            fs.mkdirSync(nested, { recursive: true });
+            fs.writeFileSync(path.join(repo, 'package.json'), '{"name":"repo"}');
+
+            expect(resolveDevProjectDir(path.join(nested, 'wf.ts'))).toBe(repo);
+        } finally { env.cleanup(); }
+    });
+
+    it('the guard passes from the anchored cwd in that monorepo layout', () => {
+        const env = makeTmpEnv();
+        try {
+            const repo = env.cwd;
+            const app = path.join(repo, 'apps', 'a');
+            fs.mkdirSync(path.join(app, 'src'), { recursive: true });
+            fs.writeFileSync(path.join(repo, 'package.json'), '{"name":"repo"}');
+            writeLocal(app, { host: 'https://a.example', apiKey: 'sk_a' });
+
+            const entry = path.join(app, 'src', 'wf.ts');
+            process.chdir(resolveDevProjectDir(entry)); // what the re-exec child does
+            expect(() => assertProjectLocalConfig(entry, 'production')).not.toThrow();
+        } finally { env.cleanup(); }
+    });
+});
+
+/**
+ * Review round 2 (mechanical): compare config identity by realpath so a project
+ * reached through a symlinked alias is not reported as a different project.
+ */
+describe('assertProjectLocalConfig — symlinked project alias', () => {
+    it('does not report a mismatch when entry and cwd reach the same config via a symlink', () => {
+        const env = makeTmpEnv();
+        try {
+            const real = path.join(env.cwd, 'real-project');
+            fs.mkdirSync(path.join(real, 'src'), { recursive: true });
+            writeLocal(real, { host: 'https://proj.example', apiKey: 'sk_proj' });
+
+            const alias = path.join(env.cwd, 'alias-project');
+            fs.symlinkSync(real, alias, 'dir');
+
+            process.chdir(real);
+            // Entry reached through the alias — same file, different path string.
+            expect(() => assertProjectLocalConfig(path.join(alias, 'src', 'wf.mjs'), 'production')).not.toThrow();
+        } finally { env.cleanup(); }
+    });
+});
+
 describe('runDev — guard wiring', () => {
     it('rejects an --env run from outside any project tree, before touching config', async () => {
         const env = makeTmpEnv();
@@ -223,7 +368,7 @@ describe('runDev — guard wiring', () => {
     // toolchain relative to the cwd), which has no project-local config of its
     // own — so the guard WOULD fire if it were reached.
     it('an injected api client (tests / embedders) bypasses the guard and the run completes', async () => {
-        const out = await runDev({ entry: ECHO_FIXTURE, input: '{"n":1}', env: 'production', api: fakeApi() });
+        const out = await runDev({ entry: ECHO_FIXTURE, input: '{"n":1}', env: 'production', api: realApi() });
         expect(out.result.status).toBe('completed');
     }, 20_000);
 

--- a/tests/dev-config-guard.test.ts
+++ b/tests/dev-config-guard.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Issue #30: `solidactions dev --env <env>` silently fell back to the GLOBAL
+ * `~/.solidactions/config.json` (usually production) when run outside the
+ * project's `.solidactions` tree — the user saw only "Loaded 0 vars" and a bare
+ * 404, with no hint that the wrong tenant had been targeted.
+ *
+ * runDev now refuses loudly (before any config resolution or network work)
+ * unless a project-local config is reachable from the cwd, naming the config
+ * that WOULD have been used and how to fix it.
+ *
+ * Test-double policy: no mock/spy/stub libraries. Real temp directories, real
+ * config files on disk, real process.cwd() changes. The happy-path run that
+ * needs an API client uses the same real SaApiClient injection seam as
+ * dev.test.ts / dev-env-404-hint.test.ts.
+ */
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { assertProjectLocalConfig, runDev, type PlatformVar, type SaApiClient } from '../src/commands/dev';
+import { makeTmpEnv, writeLocal } from './helpers';
+
+const ECHO_FIXTURE = path.resolve(__dirname, '../fixtures/echo.ts');
+
+const originalCwd = process.cwd();
+afterEach(() => process.chdir(originalCwd));
+
+/** A directory tree guaranteed to have no `.solidactions` in any parent. */
+function makeOrphanDir(): { dir: string; cleanup: () => void } {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sa-orphan-'));
+    return { dir, cleanup: () => fs.rmSync(dir, { recursive: true, force: true }) };
+}
+
+function fakeApi(): SaApiClient {
+    return {
+        projectSlug: 'test-project',
+        async fetchVarsAndConnections(_env: string): Promise<PlatformVar[]> {
+            return [];
+        },
+    };
+}
+
+describe('assertProjectLocalConfig — refusal', () => {
+    it('throws when neither the cwd nor the entry has a project-local config', () => {
+        const env = makeTmpEnv();
+        const orphan = makeOrphanDir();
+        try {
+            process.chdir(orphan.dir);
+            expect(() => assertProjectLocalConfig(path.join(orphan.dir, 'wf.ts'), 'production'))
+                .toThrow(/no project-local \.solidactions\/config\.json found/);
+        } finally { orphan.cleanup(); env.cleanup(); }
+    });
+
+    it('names the global config that WOULD have been used, and the two fixes', () => {
+        const env = makeTmpEnv();
+        const orphan = makeOrphanDir();
+        try {
+            process.chdir(orphan.dir);
+            let msg = '';
+            try { assertProjectLocalConfig(path.join(orphan.dir, 'wf.ts'), 'production'); }
+            catch (e: any) { msg = e.message; }
+
+            expect(msg).toContain(path.join(env.home, '.solidactions', 'config.json'));
+            expect(msg).toContain('usually points at production');
+            expect(msg).toContain('cd into the project directory');
+            expect(msg).toContain('solidactions init');
+        } finally { orphan.cleanup(); env.cleanup(); }
+    });
+
+    it('refuses — and points at the workflow\'s own config — when only the ENTRY has one', () => {
+        const env = makeTmpEnv();
+        const orphan = makeOrphanDir();
+        try {
+            const projectConfig = writeLocal(env.cwd, { host: 'https://proj.example', apiKey: 'sk_proj' });
+            process.chdir(orphan.dir); // cwd outside the project tree — the #30 scenario
+            let msg = '';
+            try { assertProjectLocalConfig(path.join(env.cwd, 'wf.ts'), 'production'); }
+            catch (e: any) { msg = e.message; }
+
+            expect(msg).toContain('Refusing to run --env production');
+            expect(msg).toContain(projectConfig);
+        } finally { orphan.cleanup(); env.cleanup(); }
+    });
+
+    it('refuses when the entry belongs to a DIFFERENT project than the cwd', () => {
+        const env = makeTmpEnv();
+        const other = makeOrphanDir();
+        try {
+            const cwdConfig = writeLocal(env.cwd, { host: 'https://a.example', apiKey: 'sk_a' });
+            const entryConfig = writeLocal(other.dir, { host: 'https://b.example', apiKey: 'sk_b' });
+            process.chdir(env.cwd);
+
+            let msg = '';
+            try { assertProjectLocalConfig(path.join(other.dir, 'wf.ts'), 'staging'); }
+            catch (e: any) { msg = e.message; }
+
+            expect(msg).toContain('config mismatch');
+            expect(msg).toContain(entryConfig);
+            expect(msg).toContain(cwdConfig);
+        } finally { other.cleanup(); env.cleanup(); }
+    });
+});
+
+describe('assertProjectLocalConfig — legitimate flows are preserved', () => {
+    it('passes when the cwd has a project-local config and the entry is in that tree', () => {
+        const env = makeTmpEnv();
+        try {
+            writeLocal(env.cwd, { host: 'https://proj.example', apiKey: 'sk_proj' });
+            process.chdir(env.cwd);
+            expect(() => assertProjectLocalConfig(path.join(env.cwd, 'src', 'wf.ts'), 'production')).not.toThrow();
+        } finally { env.cleanup(); }
+    });
+
+    it('passes with an explicit SOLIDACTIONS_HOST override even with no local config', () => {
+        const env = makeTmpEnv();
+        const orphan = makeOrphanDir();
+        try {
+            process.env.SOLIDACTIONS_HOST = 'https://explicit.example';
+            process.chdir(orphan.dir);
+            expect(() => assertProjectLocalConfig(path.join(orphan.dir, 'wf.ts'), 'production')).not.toThrow();
+        } finally { orphan.cleanup(); env.cleanup(); }
+    });
+
+    it('passes with an explicit SOLIDACTIONS_API_KEY override even with no local config', () => {
+        const env = makeTmpEnv();
+        const orphan = makeOrphanDir();
+        try {
+            process.env.SOLIDACTIONS_API_KEY = 'sk_explicit';
+            process.chdir(orphan.dir);
+            expect(() => assertProjectLocalConfig(path.join(orphan.dir, 'wf.ts'), 'production')).not.toThrow();
+        } finally { orphan.cleanup(); env.cleanup(); }
+    });
+});
+
+describe('runDev — guard wiring', () => {
+    it('rejects an --env run from outside any project tree, before touching config', async () => {
+        const env = makeTmpEnv();
+        const orphan = makeOrphanDir();
+        try {
+            process.chdir(orphan.dir);
+            await expect(runDev({ entry: ECHO_FIXTURE, input: '{"n":1}', env: 'production' }))
+                .rejects.toThrow(/no project-local \.solidactions\/config\.json found/);
+        } finally { orphan.cleanup(); env.cleanup(); }
+    }, 20_000);
+
+    // These two run from the repo root (the SDK mock-server shim resolves its
+    // toolchain relative to the cwd), which has no project-local config of its
+    // own — so the guard WOULD fire if it were reached.
+    it('an injected api client (tests / embedders) bypasses the guard and the run completes', async () => {
+        const out = await runDev({ entry: ECHO_FIXTURE, input: '{"n":1}', env: 'production', api: fakeApi() });
+        expect(out.result.status).toBe('completed');
+    }, 20_000);
+
+    it('a bare run (no --env) does no platform fetch and is never blocked by the guard', async () => {
+        const out = await runDev({ entry: ECHO_FIXTURE, input: '{"n":1}' });
+        expect(out.result.status).toBe('completed');
+        expect(out.stdout).toContain('running locally');
+    }, 20_000);
+});

--- a/tests/dev-config-guard.test.ts
+++ b/tests/dev-config-guard.test.ts
@@ -82,7 +82,12 @@ describe('assertProjectLocalConfig — refusal', () => {
         } finally { orphan.cleanup(); env.cleanup(); }
     });
 
-    it('refuses when the entry belongs to a DIFFERENT project than the cwd', () => {
+    // Review round 1 (MEDIUM): this branch is reachable only for entries run
+    // IN-PROCESS (.js/.mjs). A .ts entry is re-exec'd with the child cwd already
+    // at the entry's own project root, so entryLocal === cwdLocal by
+    // construction there and the mismatch cannot fire — correctly so: the child
+    // is anchored to the right project. Entry named .mjs to reflect that.
+    it('refuses when the entry belongs to a DIFFERENT project than the cwd (in-process entries)', () => {
         const env = makeTmpEnv();
         const other = makeOrphanDir();
         try {
@@ -91,7 +96,7 @@ describe('assertProjectLocalConfig — refusal', () => {
             process.chdir(env.cwd);
 
             let msg = '';
-            try { assertProjectLocalConfig(path.join(other.dir, 'wf.ts'), 'staging'); }
+            try { assertProjectLocalConfig(path.join(other.dir, 'wf.mjs'), 'staging'); }
             catch (e: any) { msg = e.message; }
 
             expect(msg).toContain('config mismatch');
@@ -111,25 +116,96 @@ describe('assertProjectLocalConfig — legitimate flows are preserved', () => {
         } finally { env.cleanup(); }
     });
 
-    it('passes with an explicit SOLIDACTIONS_HOST override even with no local config', () => {
+    it('passes with BOTH env overrides set and no local config — nothing can fall to global', () => {
         const env = makeTmpEnv();
         const orphan = makeOrphanDir();
         try {
             process.env.SOLIDACTIONS_HOST = 'https://explicit.example';
-            process.chdir(orphan.dir);
-            expect(() => assertProjectLocalConfig(path.join(orphan.dir, 'wf.ts'), 'production')).not.toThrow();
-        } finally { orphan.cleanup(); env.cleanup(); }
-    });
-
-    it('passes with an explicit SOLIDACTIONS_API_KEY override even with no local config', () => {
-        const env = makeTmpEnv();
-        const orphan = makeOrphanDir();
-        try {
             process.env.SOLIDACTIONS_API_KEY = 'sk_explicit';
             process.chdir(orphan.dir);
             expect(() => assertProjectLocalConfig(path.join(orphan.dir, 'wf.ts'), 'production')).not.toThrow();
         } finally { orphan.cleanup(); env.cleanup(); }
     });
+
+    it('a partial env override does NOT suppress the guard when a local config exists', () => {
+        const env = makeTmpEnv();
+        try {
+            process.env.SOLIDACTIONS_API_KEY = 'sk_explicit';
+            writeLocal(env.cwd, { host: 'https://proj.example', apiKey: 'sk_proj' });
+            process.chdir(env.cwd);
+            // The local config supplies `host`; nothing falls to global.
+            expect(() => assertProjectLocalConfig(path.join(env.cwd, 'wf.ts'), 'production')).not.toThrow();
+        } finally { env.cleanup(); }
+    });
+});
+
+/**
+ * Review round 1 (HIGH): the bypass was OR-based, so setting EITHER var skipped
+ * the guard entirely — but resolveConfig() picks host and apiKey independently,
+ * so the unset field still fell through to the global (production) config. The
+ * reviewer drove a real request to the global host (401) from an orphan dir
+ * with only SOLIDACTIONS_API_KEY set. The bypass now requires BOTH vars.
+ */
+describe('assertProjectLocalConfig — partial env override still refuses', () => {
+    it('refuses with only SOLIDACTIONS_API_KEY set, naming host as the field falling to global', () => {
+        const env = makeTmpEnv();
+        const orphan = makeOrphanDir();
+        try {
+            process.env.SOLIDACTIONS_API_KEY = 'sk_explicit';
+            process.chdir(orphan.dir);
+
+            let msg = '';
+            try { assertProjectLocalConfig(path.join(orphan.dir, 'wf.ts'), 'production'); }
+            catch (e: any) { msg = e.message; }
+
+            expect(msg).toContain('SOLIDACTIONS_API_KEY is set');
+            expect(msg).toContain('`host` would still come from the global config');
+            expect(msg).toContain('Set SOLIDACTIONS_HOST too');
+            expect(msg).toContain(path.join(env.home, '.solidactions', 'config.json'));
+        } finally { orphan.cleanup(); env.cleanup(); }
+    });
+
+    it('refuses with only SOLIDACTIONS_HOST set, naming apiKey as the field falling to global', () => {
+        const env = makeTmpEnv();
+        const orphan = makeOrphanDir();
+        try {
+            process.env.SOLIDACTIONS_HOST = 'https://explicit.example';
+            process.chdir(orphan.dir);
+
+            let msg = '';
+            try { assertProjectLocalConfig(path.join(orphan.dir, 'wf.ts'), 'production'); }
+            catch (e: any) { msg = e.message; }
+
+            expect(msg).toContain('SOLIDACTIONS_HOST is set');
+            expect(msg).toContain('`apiKey` would still come from the global config');
+            expect(msg).toContain('Set SOLIDACTIONS_API_KEY too');
+        } finally { orphan.cleanup(); env.cleanup(); }
+    });
+
+    it('the full-refusal path (no env vars at all) carries no partial-override line', () => {
+        const env = makeTmpEnv();
+        const orphan = makeOrphanDir();
+        try {
+            process.chdir(orphan.dir);
+            let msg = '';
+            try { assertProjectLocalConfig(path.join(orphan.dir, 'wf.ts'), 'production'); }
+            catch (e: any) { msg = e.message; }
+
+            expect(msg).toContain('Refusing to run --env production');
+            expect(msg).not.toContain('resolve independently');
+        } finally { orphan.cleanup(); env.cleanup(); }
+    });
+
+    it('runDev rejects an --env run with only SOLIDACTIONS_API_KEY set', async () => {
+        const env = makeTmpEnv();
+        const orphan = makeOrphanDir();
+        try {
+            process.env.SOLIDACTIONS_API_KEY = 'sk_explicit';
+            process.chdir(orphan.dir);
+            await expect(runDev({ entry: ECHO_FIXTURE, input: '{"n":1}', env: 'production' }))
+                .rejects.toThrow(/host` would still come from the global config/);
+        } finally { orphan.cleanup(); env.cleanup(); }
+    }, 20_000);
 });
 
 describe('runDev — guard wiring', () => {


### PR DESCRIPTION
Closes #30

## The bug

`solidactions dev --env <env>` builds its API client from `resolveConfig(process.cwd())`. When no project-local `.solidactions/config.json` is reachable from the cwd, that resolution falls back to the **global** `~/.solidactions/config.json` — which typically points at **production**.

`dev.ts`'s `findProjectRoot()` walks for the nearest `package.json`, not for `.solidactions/config.json`, and falls back to `process.cwd()` when it finds nothing within 10 levels. So a workflow run from outside its project's `.solidactions` tree silently fetched vars from (and targeted) the wrong tenant. The only symptom was `Loaded 0 vars + 0 connections` followed by a bare 404.

`config.ts` already exposed `sources` / `activePath`; `dev()` and `runDev()` never surfaced them.

## The fix

New `assertProjectLocalConfig(entry, env)` in `src/commands/dev.ts`, called from `runDev` inside the `opts.env && !opts.api` branch — **before** `requireConfigWithWorkspace()` and before any network work. It refuses in two cases:

1. **No project-local config reachable from the cwd.** The message names the global config path that *would* have been used, states that it usually points at production, and gives both fixes (`cd` into the project directory, or run `solidactions init` there). If the workflow's own tree *does* have a config, the message names that too.
2. **Entry/cwd config mismatch** — the workflow belongs to a different project than the cwd resolves to. Named in the issue as a fix idea; refusing here prevents cross-account targeting.

The guard lives in `runDev`, not in `dev()`'s pre-fork path, deliberately: `dev()` re-execs the child with `cwd = projectDir`, so the parent's cwd is not the cwd config will actually resolve against. Guarding in the child covers both the re-exec and the in-process path with one check.

### Legitimate flows preserved

- Explicit `SOLIDACTIONS_HOST` / `SOLIDACTIONS_API_KEY` env overrides are a deliberate choice of target and pass through untouched.
- An injected `api` client (tests, embedders) bypasses the guard entirely.
- Bare runs (no `--env`) do no platform fetch and are never blocked.

## Tests

`tests/dev-config-guard.test.ts` — 10 tests, no mock/spy/stub libraries. Real temp directories, real config files on disk, real `process.cwd()` changes; the one case needing an API client uses the existing real `SaApiClient` injection seam (same pattern as `dev.test.ts` / `dev-env-404-hint.test.ts`).

Covers both refusal branches (including exact message content — global path, production warning, both remediations), all three preserved flows, and the `runDev` wiring itself (rejects from outside any project tree; injected api and bare runs still complete).

## Verification

- `npm run build` — clean
- `npx vitest run` — **70 files, 671 tests, all passing**

No version bump, no publish, no merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)