### PR TITLE
ai init: pin SDK ref + oauth-actions test-gap closure (#39 #25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,44 @@ git clone https://github.com/SolidActions/solidactions-cli.git
 cd solidactions-cli
 npm install
 npm run build
+npm test          # vitest run
 ```
+
+## Release Checklist
+
+Run these before publishing a new version. `npm run check:release` covers the
+first three in one command.
+
+1. **Build** — `npm run build` (must be clean; `tsc` errors block the release).
+2. **Unit tests** — `npm test`. Covers config resolution, command wiring, and
+   the `oauth-actions show` snippet renderer (the highest-risk regression
+   surface — array query-param serialization and the proxy-managed header
+   filter both have fixture-backed tests under `tests/fixtures/`).
+3. **Init smoke** — `npm run smoke:init` scaffolds a project end to end.
+4. **oauth-actions smoke** — `bash scripts/smoke.sh` exercises
+   `oauth-actions list|search|show` (plus the 404 path) against a real local
+   stub server, so it needs no credentials:
+
+   ```bash
+   npm run build && bash scripts/smoke.sh
+   ```
+
+   To smoke a deployed server instead, pass `--live` with real credentials:
+
+   ```bash
+   SOLIDACTIONS_HOST=https://app.solidactions.com \
+   SOLIDACTIONS_API_KEY=... \
+   SOLIDACTIONS_WORKSPACE_ID=... \
+   bash scripts/smoke.sh --live
+   ```
+
+   The script exits non-zero on the first failed check.
+5. **SDK docs pin** — `ai init` fetches `docs/sdk-reference.md` from the
+   `solidactions-ts-sdk` tag named in `src/utils/sdk-version.ts`, not from that
+   repo's `main`. When bumping the `@solidactions/sdk` dependency, bump
+   `SDK_DOCS_REF` to the matching `vX.Y.Z` tag — `tests/sdk-docs-ref.test.ts`
+   fails if the two drift apart.
+6. **Version bump** — update `package.json`, then publish.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -329,12 +329,15 @@ first three in one command.
    ```
 
    The script exits non-zero on the first failed check.
-5. **SDK docs pin** — `ai init` fetches `docs/sdk-reference.md` from the
-   `solidactions-ts-sdk` tag named in `src/utils/sdk-version.ts`, not from that
-   repo's `main`. When bumping the `@solidactions/sdk` dependency, bump
-   `SDK_DOCS_REF` to the matching `vX.Y.Z` tag — `tests/sdk-docs-ref.test.ts`
-   fails if the two drift apart.
-6. **Version bump** — update `package.json`, then publish.
+5. **SDK docs pin** — `ai init` fetches `docs/sdk-reference.md` from a
+   `solidactions-ts-sdk` tag, not from that repo's `main`. The tag is derived
+   at runtime from the `@solidactions/sdk` version this package declares (see
+   `src/utils/sdk-version.ts`), so bumping that dependency moves the docs ref
+   with it — nothing to update by hand. `tests/sdk-docs-ref.test.ts` fails if
+   the declared range has no explicit minimum version to derive from.
+6. **Version bump** — update `package.json`, then publish. Once the publish
+   flow from PR #78 lands, the GitHub release **tag** drives the published npm
+   version (semver-guarded); the bump commit stays conventional.
 
 ## License
 

--- a/scripts/smoke-oauth-actions-server.mjs
+++ b/scripts/smoke-oauth-actions-server.mjs
@@ -1,0 +1,115 @@
+/**
+ * Stub SAA server for `scripts/smoke.sh`.
+ *
+ * A real HTTP server (repo convention — no mocking library), serving just the
+ * `/api/v1/oauth-actions` surface the smoke script exercises. Reuses the same
+ * JSON fixtures as the unit tests so the smoke run and the test suite can't
+ * disagree about what the API returns.
+ *
+ * Prints the chosen port to stdout as `PORT=<n>` once listening.
+ */
+import { createServer } from 'node:http';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const fixturesDir = path.join(scriptDir, '..', 'tests', 'fixtures');
+
+const loadFixture = (name) =>
+    JSON.parse(readFileSync(path.join(fixturesDir, `${name}.json`), 'utf8'));
+
+const CALENDAR = loadFixture('calendar-events-list');
+
+const GMAIL_ACTIONS = [
+    {
+        platform: 'gmail',
+        method: 'POST',
+        path: '/gmail/v1/users/me/messages/send',
+        title: 'Send Message',
+        action_id: 'conn_mod_def::GGSNOTZxFUU::ZWXBuJboTpS3Q_U06pF8gA',
+        tags: ['mail', 'send'],
+        io_schema: {
+            ioExample: { input: { body: { connectionKey: 'placeholder-key', raw: 'x' } } },
+        },
+    },
+    {
+        platform: 'gmail',
+        method: 'GET',
+        path: '/gmail/v1/users/me/messages',
+        title: 'List Messages',
+        action_id: 'conn_get::LIST::MSGS',
+        tags: ['mail', 'list'],
+        io_schema: { ioExample: { input: { query: { q: 'is:unread', maxResults: '5' } } } },
+    },
+];
+
+const BY_PLATFORM = {
+    gmail: GMAIL_ACTIONS,
+    'google-calendar': [CALENDAR],
+};
+
+const json = (res, status, body) => {
+    const payload = JSON.stringify(body);
+    res.writeHead(status, {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(payload),
+    });
+    res.end(payload);
+};
+
+const server = createServer((req, res) => {
+    const url = new URL(req.url, 'http://localhost');
+
+    // Every smoke request must carry the auth + workspace headers the CLI sends.
+    if (!(req.headers.authorization || '').startsWith('Bearer ')) {
+        return json(res, 401, { message: 'Missing bearer token' });
+    }
+    if (!req.headers['x-workspace-id']) {
+        return json(res, 400, { message: 'Missing X-Workspace-Id header' });
+    }
+
+    const segments = url.pathname.split('/').filter(Boolean);
+    // ['api','v1','oauth-actions', <platform>?, <action_id>?]
+    if (segments[0] !== 'api' || segments[1] !== 'v1' || segments[2] !== 'oauth-actions') {
+        return json(res, 404, { message: 'Not found' });
+    }
+
+    // GET /api/v1/oauth-actions?platform=&q=&limit=   (list + search)
+    if (segments.length === 3) {
+        const platform = url.searchParams.get('platform');
+        const actions = BY_PLATFORM[platform];
+        if (!actions) {
+            return json(res, 404, { code: 'platform_unknown', message: `Unknown platform ${platform}` });
+        }
+
+        let results = actions;
+        const q = url.searchParams.get('q');
+        if (q) {
+            const terms = q.toLowerCase().split(/\s+/).filter(Boolean);
+            results = results.filter((a) => {
+                const haystack = `${a.title} ${a.path} ${(a.tags || []).join(' ')}`.toLowerCase();
+                return terms.some((t) => haystack.includes(t));
+            });
+        }
+        const limit = Number(url.searchParams.get('limit'));
+        if (Number.isFinite(limit) && limit > 0) results = results.slice(0, limit);
+
+        return json(res, 200, { oauth_actions: results });
+    }
+
+    // GET /api/v1/oauth-actions/<platform>/<action_id>   (show)
+    if (segments.length === 5) {
+        const [, , , platform, rawActionId] = segments;
+        const actionId = decodeURIComponent(rawActionId);
+        const hit = (BY_PLATFORM[platform] || []).find((a) => a.action_id === actionId);
+        if (!hit) return json(res, 404, { message: `Action not found: ${platform}/${actionId}` });
+        return json(res, 200, { oauth_action: hit });
+    }
+
+    return json(res, 404, { message: 'Not found' });
+});
+
+server.listen(0, '127.0.0.1', () => {
+    process.stdout.write(`PORT=${server.address().port}\n`);
+});

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+#
+# Smoke-test `solidactions oauth-actions list|search|show` end to end.
+#
+# By default this runs the built CLI against a real local stub server
+# (scripts/smoke-oauth-actions-server.mjs), so it needs no credentials and is
+# safe in CI. Point it at a deployed server instead with:
+#
+#   SOLIDACTIONS_HOST=https://app.solidactions.com \
+#   SOLIDACTIONS_API_KEY=... \
+#   SOLIDACTIONS_WORKSPACE_ID=... \
+#   bash scripts/smoke.sh --live
+#
+# Exits non-zero on the first failed check.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+LIVE=0
+[[ "${1:-}" == "--live" ]] && LIVE=1
+
+CLI="node dist/index.js"
+SERVER_PID=""
+
+PORT_FILE=""
+
+cleanup() {
+  [[ -n "$SERVER_PID" ]] && kill "$SERVER_PID" 2>/dev/null || true
+  [[ -n "$PORT_FILE" ]] && rm -f "$PORT_FILE" || true
+}
+trap cleanup EXIT
+
+pass() { printf '  \033[32m✓\033[0m %s\n' "$1"; }
+fail() { printf '  \033[31m✗\033[0m %s\n' "$1"; exit 1; }
+
+check_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then pass "$label"; else
+    printf '\033[31mExpected output to contain:\033[0m %s\n' "$needle"
+    printf '\033[31mActual output:\033[0m\n%s\n' "$haystack"
+    fail "$label"
+  fi
+}
+
+check_absent() {
+  local haystack="$1" needle="$2" label="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then pass "$label"; else
+    printf '\033[31mExpected output NOT to contain:\033[0m %s\n' "$needle"
+    printf '\033[31mActual output:\033[0m\n%s\n' "$haystack"
+    fail "$label"
+  fi
+}
+
+if [[ ! -f dist/index.js ]]; then
+  echo "dist/index.js missing — run 'npm run build' first." >&2
+  exit 1
+fi
+
+if [[ "$LIVE" -eq 1 ]]; then
+  : "${SOLIDACTIONS_HOST:?SOLIDACTIONS_HOST required with --live}"
+  : "${SOLIDACTIONS_API_KEY:?SOLIDACTIONS_API_KEY required with --live}"
+  : "${SOLIDACTIONS_WORKSPACE_ID:?SOLIDACTIONS_WORKSPACE_ID required with --live}"
+  echo "Smoke: live server at $SOLIDACTIONS_HOST"
+  CALENDAR_ACTION_ID="conn_mod_def::GJ6RlnIYK20::YzuWSmaVQgurletRDNJavA"
+  GMAIL_ACTION_ID="conn_mod_def::GGSNOTZxFUU::ZWXBuJboTpS3Q_U06pF8gA"
+else
+  # Start the stub server on an ephemeral port and read back the port it bound.
+  PORT_FILE=$(mktemp)
+  node scripts/smoke-oauth-actions-server.mjs > "$PORT_FILE" &
+  SERVER_PID=$!
+
+  PORT_LINE=""
+  for _ in $(seq 1 50); do
+    PORT_LINE=$(head -n 1 "$PORT_FILE" 2>/dev/null || true)
+    [[ "$PORT_LINE" == PORT=* ]] && break
+    sleep 0.1
+  done
+  [[ "$PORT_LINE" == PORT=* ]] || fail "stub server did not report a port"
+  PORT="${PORT_LINE#PORT=}"
+
+  export SOLIDACTIONS_HOST="http://127.0.0.1:${PORT}"
+  export SOLIDACTIONS_API_KEY="smoke-test-key"
+  export SOLIDACTIONS_WORKSPACE_ID="smoke-workspace"
+  echo "Smoke: stub server at $SOLIDACTIONS_HOST"
+  CALENDAR_ACTION_ID="conn_mod_def::GJ6RlnIYK20::YzuWSmaVQgurletRDNJavA"
+  GMAIL_ACTION_ID="conn_mod_def::GGSNOTZxFUU::ZWXBuJboTpS3Q_U06pF8gA"
+fi
+
+echo
+echo "1. oauth-actions list gmail --limit 5"
+OUT=$($CLI oauth-actions list gmail --limit 5)
+check_contains "$OUT" "/gmail/v1/users/me/messages/send" "lists the send-message path"
+check_contains "$OUT" "POST" "renders the HTTP method"
+
+echo
+echo "2. oauth-actions search gmail 'list messages unread' --limit 3"
+OUT=$($CLI oauth-actions search gmail "list messages unread" --limit 3)
+check_contains "$OUT" "action_id:" "search output includes action_id lines"
+check_contains "$OUT" "List Messages" "search matches the List Messages action"
+
+echo
+echo "3. oauth-actions show gmail <modifier action>"
+OUT=$($CLI oauth-actions show gmail "$GMAIL_ACTION_ID")
+check_contains "$OUT" "Paste-ready snippet:" "show renders a paste-ready snippet"
+check_contains "$OUT" "connectionKey: ctx.vars" "modifier body wires connectionKey from ctx.vars"
+check_absent   "$OUT" "process.env" "default snippet uses ctx.vars, not process.env"
+
+echo
+echo "4. oauth-actions show google-calendar <array-query action> --json"
+OUT=$($CLI oauth-actions show google-calendar "$CALENDAR_ACTION_ID" --json)
+check_contains "$OUT" "eventTypes" "json output exposes the array query param"
+if command -v jq >/dev/null 2>&1; then
+  KEYS=$(printf '%s' "$OUT" | jq -r '.io_schema.ioExample.input.query | keys[]' | head -3)
+  [[ -n "$KEYS" ]] && pass "jq can enumerate query keys" || fail "jq found no query keys"
+else
+  pass "jq not installed — skipping key enumeration"
+fi
+
+echo
+echo "5. oauth-actions show google-calendar <array-query action> (human)"
+OUT=$($CLI oauth-actions show google-calendar "$CALENDAR_ACTION_ID")
+check_contains "$OUT" 'eventTypes=${encodeURIComponent("default")}&eventTypes=' "array query params repeat the key"
+check_absent   "$OUT" "encodeURIComponent([" "array is not stringified into one value"
+
+echo
+echo "6. oauth-actions show gmail no-such-action (404 path)"
+set +e
+OUT=$($CLI oauth-actions show gmail no-such-action 2>&1)
+CODE=$?
+set -e
+check_contains "$OUT" "Action not found" "404 renders the friendly not-found message"
+[[ "$CODE" -ne 0 ]] && pass "404 path exits non-zero" || fail "expected non-zero exit on 404"
+
+echo
+printf '\033[32mSmoke passed.\033[0m\n'

--- a/src/commands/ai-init.ts
+++ b/src/commands/ai-init.ts
@@ -4,6 +4,7 @@ import prompts from 'prompts';
 import fsExtra from 'fs-extra';
 import path from 'path';
 import { fetchRawFile } from '../utils/github';
+import { SDK_DOCS_REF } from '../utils/sdk-version';
 import { upsertMarkerSection } from '../utils/markers';
 import { AiHelperTarget, skillTargetDir, installSkills, fetchAiHelperContent } from '../utils/skills';
 
@@ -69,8 +70,15 @@ export async function aiInit(options: AiInitOptions = {}, resolvedTarget?: AiHel
         // Fetch slim helper content for the chosen target.
         const aiContent = await fetchAiHelperContent(targetFile);
 
-        // Fetch SDK reference (always).
-        const sdkContent = await fetchRawFile('SolidActions', 'solidactions-ts-sdk', 'docs/sdk-reference.md');
+        // Fetch SDK reference (always), pinned to the tag matching the declared
+        // @solidactions/sdk version so scaffolded projects never get docs for an
+        // SDK newer than the one they depend on.
+        const sdkContent = await fetchRawFile(
+            'SolidActions',
+            'solidactions-ts-sdk',
+            'docs/sdk-reference.md',
+            SDK_DOCS_REF,
+        );
 
         // Save SDK reference to .solidactions/sdk-reference.md.
         fsExtra.ensureDirSync('.solidactions');

--- a/src/commands/ai-init.ts
+++ b/src/commands/ai-init.ts
@@ -4,7 +4,7 @@ import prompts from 'prompts';
 import fsExtra from 'fs-extra';
 import path from 'path';
 import { fetchRawFile } from '../utils/github';
-import { SDK_DOCS_REF } from '../utils/sdk-version';
+import { sdkDocsRef } from '../utils/sdk-version';
 import { upsertMarkerSection } from '../utils/markers';
 import { AiHelperTarget, skillTargetDir, installSkills, fetchAiHelperContent } from '../utils/skills';
 
@@ -70,14 +70,14 @@ export async function aiInit(options: AiInitOptions = {}, resolvedTarget?: AiHel
         // Fetch slim helper content for the chosen target.
         const aiContent = await fetchAiHelperContent(targetFile);
 
-        // Fetch SDK reference (always), pinned to the tag matching the declared
-        // @solidactions/sdk version so scaffolded projects never get docs for an
-        // SDK newer than the one they depend on.
+        // Fetch SDK reference (always), pinned to the tag matching the
+        // @solidactions/sdk version this CLI declares, so scaffolded projects
+        // never get docs for an SDK newer than the one the CLI targets.
         const sdkContent = await fetchRawFile(
             'SolidActions',
             'solidactions-ts-sdk',
             'docs/sdk-reference.md',
-            SDK_DOCS_REF,
+            sdkDocsRef(),
         );
 
         // Save SDK reference to .solidactions/sdk-reference.md.

--- a/src/utils/sdk-version.ts
+++ b/src/utils/sdk-version.ts
@@ -1,0 +1,13 @@
+/**
+ * The git ref used when fetching SDK docs from the solidactions-ts-sdk repo.
+ *
+ * `ai init` used to fetch `docs/sdk-reference.md` from that repo's default
+ * branch, so a freshly-scaffolded project got whatever happened to be on SDK
+ * `main` — documenting APIs the pinned SDK dependency doesn't ship yet. This
+ * constant pins the fetch to the tag matching the `@solidactions/sdk` version
+ * declared in package.json.
+ *
+ * Keep it in lockstep with that dependency: `tests/sdk-docs-ref.test.ts`
+ * fails the build if this ref drifts from the declared range's minimum.
+ */
+export const SDK_DOCS_REF = 'v0.7.3';

--- a/src/utils/sdk-version.ts
+++ b/src/utils/sdk-version.ts
@@ -1,13 +1,66 @@
+import fs from 'fs';
+import path from 'path';
+
+const SDK_PACKAGE = '@solidactions/sdk';
+
 /**
- * The git ref used when fetching SDK docs from the solidactions-ts-sdk repo.
+ * Resolve the git ref used when fetching SDK docs from the solidactions-ts-sdk
+ * repo, derived from THIS CLI's own `package.json` declaration of
+ * `@solidactions/sdk`.
  *
  * `ai init` used to fetch `docs/sdk-reference.md` from that repo's default
  * branch, so a freshly-scaffolded project got whatever happened to be on SDK
- * `main` — documenting APIs the pinned SDK dependency doesn't ship yet. This
- * constant pins the fetch to the tag matching the `@solidactions/sdk` version
- * declared in package.json.
+ * `main` — documenting APIs the SDK version this CLI is built against doesn't
+ * ship yet. Deriving the ref from our own declared dependency means a future
+ * dependency bump moves the docs ref with it; there is no second constant to
+ * forget to update.
  *
- * Keep it in lockstep with that dependency: `tests/sdk-docs-ref.test.ts`
- * fails the build if this ref drifts from the declared range's minimum.
+ * Note this tracks the CLI's own declaration, NOT the SDK version in whatever
+ * project `ai init` is run against. Serving docs matched to the target
+ * project's installed SDK is a separate concern, tracked separately.
+ *
+ * The declared range's minimum is used (`^0.7.3` → `v0.7.3`), matching the
+ * `vX.Y.Z` tag format the SDK repo publishes.
  */
-export const SDK_DOCS_REF = 'v0.7.3';
+/**
+ * Convert a declared semver range into the SDK repo's `vX.Y.Z` tag format,
+ * using the range's minimum version (`^0.7.3` → `v0.7.3`).
+ *
+ * Exported so the conversion — including its rejection of ranges with no
+ * explicit minimum — is testable without touching the filesystem.
+ */
+export function sdkRefFromRange(declared: string): string {
+    // Strip a leading range operator (^, ~, >=, v) to get the minimum version.
+    const version = declared.replace(/^[\^~>=<\sv]*/, '');
+    if (!/^\d+\.\d+\.\d+/.test(version)) {
+        throw new Error(
+            `Cannot derive an SDK docs tag from ${SDK_PACKAGE} range "${declared}" — expected a range with an explicit minimum version (e.g. "^0.7.3").`,
+        );
+    }
+    return `v${version}`;
+}
+
+export function sdkDocsRef(): string {
+    // `__dirname` is <pkg>/src/utils under vitest and <pkg>/dist/utils once
+    // built, so `../..` is the package root in both cases — and in a published
+    // install, since npm always ships package.json alongside `dist`.
+    const packageJsonPath = path.join(__dirname, '..', '..', 'package.json');
+
+    let declared: string | undefined;
+    try {
+        const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+        declared = pkg.dependencies?.[SDK_PACKAGE] ?? pkg.devDependencies?.[SDK_PACKAGE];
+    } catch (error: any) {
+        throw new Error(
+            `Could not read ${packageJsonPath} to determine the SDK docs version: ${error.message}`,
+        );
+    }
+
+    if (!declared) {
+        throw new Error(
+            `No ${SDK_PACKAGE} dependency declared in ${packageJsonPath} — cannot determine which SDK docs version to fetch.`,
+        );
+    }
+
+    return sdkRefFromRange(declared);
+}

--- a/tests/fixtures/calendar-events-list.json
+++ b/tests/fixtures/calendar-events-list.json
@@ -1,0 +1,24 @@
+{
+  "platform": "google-calendar",
+  "method": "GET",
+  "path": "/calendar/v3/calendars/{{calendarId}}/events",
+  "title": "List Events",
+  "action_id": "conn_mod_def::GJ6RlnIYK20::YzuWSmaVQgurletRDNJavA",
+  "tags": ["calendar", "events"],
+  "io_schema": {
+    "inputSchema": {
+      "description": "Returns events on the specified calendar."
+    },
+    "ioExample": {
+      "input": {
+        "path": { "calendarId": "primary" },
+        "query": {
+          "maxResults": "10",
+          "eventTypes": ["default", "outOfOffice"],
+          "privateExtendedProperty": ["team=alpha", "tier=1"],
+          "singleEvents": "true"
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/synthetic-x-pica-leak.json
+++ b/tests/fixtures/synthetic-x-pica-leak.json
@@ -1,0 +1,28 @@
+{
+  "platform": "gmail",
+  "method": "POST",
+  "path": "/gmail/v1/users/me/messages/send",
+  "title": "Send Message (synthetic header-leak regression)",
+  "action_id": "conn_mod_def::SYNTHETIC::LEAK",
+  "tags": ["synthetic", "regression"],
+  "io_schema": {
+    "inputSchema": {
+      "description": "Hand-built fixture. Simulates the SAA API regressing and serving proxy-internal headers inside ioExample.input.headers. The CLI's defense-in-depth filter must strip every one of these before they reach a generated workflow snippet."
+    },
+    "ioExample": {
+      "input": {
+        "headers": {
+          "x-pica-secret": "sk_live_LEAKED_PICA_SECRET",
+          "X-Pica-Connection-Key": "leaked-pica-connection-key",
+          "x-one-api-key": "leaked-one-api-key",
+          "Authorization": "Bearer LEAKED_UPSTREAM_TOKEN",
+          "X-SA-Connection": "leaked-sa-connection",
+          "X-OAuth-Connection-Key": "leaked-oauth-connection-key",
+          "X-OAuth-Action-Id": "leaked-action-id",
+          "X-Request-Id": "safe-passthrough-header"
+        },
+        "body": { "raw": "x" }
+      }
+    }
+  }
+}

--- a/tests/oauth-actions-fixtures.test.ts
+++ b/tests/oauth-actions-fixtures.test.ts
@@ -1,0 +1,132 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+import { buildSnippet } from '../src/commands/oauth-actions-show';
+
+/**
+ * Fixture-driven coverage for the two `buildSnippet` behaviours that had no
+ * test: repeated-key array query-param serialization, and the proxy-managed
+ * header filter. Both are duplicated across the ctx.vars and --legacy-env
+ * renderers, so both renderers are asserted.
+ *
+ * Fixtures are read from disk (rather than inlined) so the JSON keeps the
+ * shape the SAA API actually serves.
+ */
+function loadFixture(name: string): any {
+    return JSON.parse(
+        fs.readFileSync(path.join(__dirname, 'fixtures', `${name}.json`), 'utf8'),
+    );
+}
+
+const CALENDAR_EVENTS_LIST = loadFixture('calendar-events-list');
+const X_PICA_LEAK = loadFixture('synthetic-x-pica-leak');
+
+// ---------------------------------------------------------------------------
+// Array query params — repeated-key serialization (oauth-actions-show.ts:157)
+// ---------------------------------------------------------------------------
+
+describe('buildSnippet — array query params serialize as repeated keys', () => {
+    for (const [label, legacyEnv] of [['ctx.vars', false], ['--legacy-env', true]] as const) {
+        describe(label, () => {
+            const snippet = buildSnippet(CALENDAR_EVENTS_LIST, 'CAL', legacyEnv);
+
+            it('emits one key=value pair per array element', () => {
+                expect(snippet).toContain(
+                    'eventTypes=${encodeURIComponent("default")}&eventTypes=${encodeURIComponent("outOfOffice")}',
+                );
+            });
+
+            it('repeats the key for a second array-valued param', () => {
+                expect(snippet).toContain(
+                    'privateExtendedProperty=${encodeURIComponent("team=alpha")}&privateExtendedProperty=${encodeURIComponent("tier=1")}',
+                );
+            });
+
+            it('does NOT stringify the array as a single value (the regression)', () => {
+                // The pre-fix bug rendered the whole array into one encodeURIComponent
+                // call, producing `eventTypes=default,outOfOffice`.
+                expect(snippet).not.toContain('encodeURIComponent([');
+                expect(snippet).not.toContain('default,outOfOffice');
+            });
+
+            it('still emits scalar query params exactly once', () => {
+                expect(snippet).toContain('maxResults=${encodeURIComponent("10")}');
+                expect(snippet.match(/maxResults=/g)).toHaveLength(1);
+                expect(snippet).toContain('singleEvents=${encodeURIComponent("true")}');
+            });
+
+            it('joins all query params after a single leading ?', () => {
+                expect(snippet.match(/\?/g)).toHaveLength(1);
+                expect(snippet).toContain('/events?maxResults=');
+            });
+
+            it('percent-encodes the key itself, not just the value', () => {
+                // Keys go through encodeURIComponent at render time; these are
+                // already-safe keys, so they must appear verbatim.
+                expect(snippet).toContain('?maxResults=');
+            });
+
+            it('expands the {{calendarId}} path placeholder alongside the query string', () => {
+                expect(snippet).toContain('${calendarId}');
+                expect(snippet).not.toContain('{{calendarId}}');
+            });
+        });
+    }
+});
+
+// ---------------------------------------------------------------------------
+// Proxy-managed header filter (oauth-actions-show.ts:301-308)
+// ---------------------------------------------------------------------------
+
+describe('buildSnippet — proxy-managed header filter strips leaked internals', () => {
+    for (const [label, legacyEnv] of [['ctx.vars', false], ['--legacy-env', true]] as const) {
+        describe(label, () => {
+            const snippet = buildSnippet(X_PICA_LEAK, 'GMAIL', legacyEnv);
+
+            it('strips x-pica-secret', () => {
+                expect(snippet).not.toContain('x-pica-secret');
+                expect(snippet).not.toContain('sk_live_LEAKED_PICA_SECRET');
+            });
+
+            it('strips x-pica-* case-insensitively', () => {
+                expect(snippet.toLowerCase()).not.toContain('x-pica-');
+                expect(snippet).not.toContain('leaked-pica-connection-key');
+            });
+
+            it('strips x-one-* headers', () => {
+                expect(snippet.toLowerCase()).not.toContain('x-one-');
+                expect(snippet).not.toContain('leaked-one-api-key');
+            });
+
+            it('does not emit the upstream Authorization value from the example', () => {
+                expect(snippet).not.toContain('LEAKED_UPSTREAM_TOKEN');
+            });
+
+            it('strips the OAuth routing headers so the example cannot override them', () => {
+                expect(snippet).not.toContain('leaked-oauth-connection-key');
+                expect(snippet).not.toContain('leaked-action-id');
+                expect(snippet).not.toContain('leaked-sa-connection');
+            });
+
+            it('still emits exactly one Authorization header — the proxy-managed one', () => {
+                expect(snippet.match(/'Authorization':/g)).toHaveLength(1);
+            });
+
+            it('passes through headers that are NOT proxy-managed', () => {
+                expect(snippet).toContain('"X-Request-Id": "safe-passthrough-header"');
+            });
+        });
+    }
+
+    it('emits the proxy-managed Authorization from ctx.vars, not the example', () => {
+        const snippet = buildSnippet(X_PICA_LEAK, 'GMAIL');
+        expect(snippet).toContain("'Authorization': `Bearer ${ctx.vars.GMAIL.proxyToken}`");
+    });
+
+    it('does not auto-add Content-Type when the example already leaked one is absent', () => {
+        // The fixture has a body but no content-type header, so exactly one
+        // Content-Type should be auto-added.
+        const snippet = buildSnippet(X_PICA_LEAK, 'GMAIL');
+        expect(snippet.match(/'Content-Type': 'application\/json'/g)).toHaveLength(1);
+    });
+});

--- a/tests/sdk-docs-ref.test.ts
+++ b/tests/sdk-docs-ref.test.ts
@@ -1,40 +1,90 @@
 import fs from 'fs';
 import path from 'path';
 import { describe, expect, it } from 'vitest';
-import { SDK_DOCS_REF } from '../src/utils/sdk-version';
+import { sdkDocsRef, sdkRefFromRange } from '../src/utils/sdk-version';
 import { rawContentUrl } from '../src/utils/github';
 
-const packageJson = JSON.parse(
-    fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8'),
-);
+const packageJsonPath = path.join(__dirname, '..', 'package.json');
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+const declaredSdkRange: string =
+    packageJson.dependencies?.['@solidactions/sdk']
+    ?? packageJson.devDependencies?.['@solidactions/sdk'];
 
-describe('SDK docs ref pinning', () => {
-    it('matches the @solidactions/sdk version declared in package.json', () => {
-        const declared: string = packageJson.devDependencies['@solidactions/sdk'];
-        // Strip the range operator (^, ~, >=) to get the minimum satisfying version.
-        const minVersion = declared.replace(/^[^\d]*/, '');
+// ---------------------------------------------------------------------------
+// The range → tag conversion, isolated from the filesystem.
+// ---------------------------------------------------------------------------
 
-        expect(SDK_DOCS_REF).toBe(`v${minVersion}`);
+describe('sdkRefFromRange', () => {
+    it('uses the minimum version of a caret range', () => {
+        expect(sdkRefFromRange('^0.7.3')).toBe('v0.7.3');
     });
 
-    it('is a version tag, not a moving branch', () => {
-        // `main` was the old default — the whole point of the pin is that a
-        // branch name must never reappear here.
-        expect(SDK_DOCS_REF).toMatch(/^v\d+\.\d+\.\d+$/);
+    it('uses the minimum version of a tilde range', () => {
+        expect(sdkRefFromRange('~1.2.0')).toBe('v1.2.0');
     });
 
-    it('builds a raw-content URL against the pinned tag rather than main', () => {
+    it('handles an exact pin with no range operator', () => {
+        expect(sdkRefFromRange('2.0.1')).toBe('v2.0.1');
+    });
+
+    it('handles a >= range', () => {
+        expect(sdkRefFromRange('>=3.4.5')).toBe('v3.4.5');
+    });
+
+    it('does not double up the v prefix if one is already present', () => {
+        expect(sdkRefFromRange('v0.7.3')).toBe('v0.7.3');
+    });
+
+    it('preserves a prerelease suffix', () => {
+        expect(sdkRefFromRange('^1.0.0-beta.2')).toBe('v1.0.0-beta.2');
+    });
+
+    // Failure paths: a range with no explicit minimum must fail loudly rather
+    // than silently degrading to a moving ref like `main`.
+    for (const bad of ['*', 'latest', '', 'workspace:*', 'github:SolidActions/solidactions-ts-sdk']) {
+        it(`throws on a range with no explicit minimum: ${JSON.stringify(bad)}`, () => {
+            expect(() => sdkRefFromRange(bad)).toThrow(/explicit minimum version/);
+        });
+    }
+
+    it('never returns a moving branch name', () => {
+        expect(sdkRefFromRange(declaredSdkRange)).not.toBe('main');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// The derivation itself — asserted against package.json, not a copied literal.
+// ---------------------------------------------------------------------------
+
+describe('sdkDocsRef', () => {
+    it('derives the ref from the @solidactions/sdk range declared in package.json', () => {
+        // Both sides read the same source, so bumping the dependency moves the
+        // docs ref automatically — there is no literal here to drift.
+        expect(sdkDocsRef()).toBe(sdkRefFromRange(declaredSdkRange));
+    });
+
+    it('produces a vX.Y.Z tag, never a branch name', () => {
+        expect(sdkDocsRef()).toMatch(/^v\d+\.\d+\.\d+/);
+        expect(sdkDocsRef()).not.toBe('main');
+    });
+
+    it('declares an SDK dependency at all (the derivation has a source)', () => {
+        expect(declaredSdkRange).toBeTruthy();
+    });
+
+    it('builds a raw-content URL against the derived tag rather than main', () => {
         delete process.env.SOLIDACTIONS_RAW_CONTENT_BASE_URL;
 
+        const ref = sdkDocsRef();
         const url = rawContentUrl(
             'SolidActions',
             'solidactions-ts-sdk',
             'docs/sdk-reference.md',
-            SDK_DOCS_REF,
+            ref,
         );
 
         expect(url).toBe(
-            `https://raw.githubusercontent.com/SolidActions/solidactions-ts-sdk/${SDK_DOCS_REF}/docs/sdk-reference.md`,
+            `https://raw.githubusercontent.com/SolidActions/solidactions-ts-sdk/${ref}/docs/sdk-reference.md`,
         );
         expect(url).not.toContain('/main/');
     });

--- a/tests/sdk-docs-ref.test.ts
+++ b/tests/sdk-docs-ref.test.ts
@@ -1,0 +1,41 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+import { SDK_DOCS_REF } from '../src/utils/sdk-version';
+import { rawContentUrl } from '../src/utils/github';
+
+const packageJson = JSON.parse(
+    fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8'),
+);
+
+describe('SDK docs ref pinning', () => {
+    it('matches the @solidactions/sdk version declared in package.json', () => {
+        const declared: string = packageJson.devDependencies['@solidactions/sdk'];
+        // Strip the range operator (^, ~, >=) to get the minimum satisfying version.
+        const minVersion = declared.replace(/^[^\d]*/, '');
+
+        expect(SDK_DOCS_REF).toBe(`v${minVersion}`);
+    });
+
+    it('is a version tag, not a moving branch', () => {
+        // `main` was the old default — the whole point of the pin is that a
+        // branch name must never reappear here.
+        expect(SDK_DOCS_REF).toMatch(/^v\d+\.\d+\.\d+$/);
+    });
+
+    it('builds a raw-content URL against the pinned tag rather than main', () => {
+        delete process.env.SOLIDACTIONS_RAW_CONTENT_BASE_URL;
+
+        const url = rawContentUrl(
+            'SolidActions',
+            'solidactions-ts-sdk',
+            'docs/sdk-reference.md',
+            SDK_DOCS_REF,
+        );
+
+        expect(url).toBe(
+            `https://raw.githubusercontent.com/SolidActions/solidactions-ts-sdk/${SDK_DOCS_REF}/docs/sdk-reference.md`,
+        );
+        expect(url).not.toContain('/main/');
+    });
+});


### PR DESCRIPTION
Closes #39
Closes #25

Two small, independent issues in one branch.

## #39 — `ai init` pulled SDK-repo HEAD unpinned

`src/commands/ai-init.ts` fetched `docs/sdk-reference.md` with no ref, and `fetchRawFile()` defaults `branch='main'` — so a freshly-scaffolded project got whatever was on SDK `main` while `package.json` declares `@solidactions/sdk ^0.7.3`. That drift is already real: the SDK repo has both `v0.7.3` and `v0.7.4` tags.

**Approach (revised after review):** `sdkDocsRef()` in `src/utils/sdk-version.ts` derives the tag **at runtime** from this package's own declared `@solidactions/sdk` range, converting it to the SDK repo's `vX.Y.Z` tag format. Bumping the dependency moves the docs ref with it — there is no second constant to forget.

The first revision used a hardcoded `SDK_DOCS_REF` constant guarded by a test. Both reviewers correctly flagged that as a second source of truth; runtime derivation removes the drift class entirely rather than merely detecting it.

The pure range→tag conversion is extracted as `sdkRefFromRange()` so its failure paths are testable without filesystem games. Ranges with no explicit minimum (`*`, `latest`, `""`, `workspace:*`) throw rather than silently degrading to a moving ref like `main`.

To be explicit about scope: this tracks **the CLI's own** declared SDK version, not the SDK version in whatever project `ai init` is run against. Serving docs matched to the target project's installed SDK is a separate concern, tracked separately.

`__dirname` resolves to the package root from `src/utils` (vitest), `dist/utils` (built), and a published install alike — npm always ships `package.json` alongside `dist`. Verified the built artifact resolves correctly: `node -e "require('./dist/utils/sdk-version').sdkDocsRef()"` → `v0.7.3`.

## #25 — residual acceptance items only

The vitest infra already exists, so this adds only the items that were still open:

- **`tests/fixtures/`** — `calendar-events-list.json` (GET with two array-valued query params) and `synthetic-x-pica-leak.json` (hand-built: the API regressing and serving `x-pica-secret`, `x-one-*`, and an upstream `Authorization` inside `ioExample.input.headers`).
- **Array query-param serialization** (`oauth-actions-show.ts:157`) — was untested. Asserts each array element becomes a repeated key, and that the array is never collapsed into one `encodeURIComponent([...])` call.
- **`x-pica-secret` header filter** (`oauth-actions-show.ts:301-308`) — was untested. Asserts every proxy-managed header is stripped, non-proxy-managed headers still pass through, and exactly one `Authorization` (the proxy-managed one) survives.

Both behaviours are duplicated across the ctx.vars and `--legacy-env` renderers, so both renderers are asserted.

- **`scripts/smoke.sh`** — exercises `oauth-actions list | search | show` plus the 404 path against a real local stub HTTP server (`scripts/smoke-oauth-actions-server.mjs`), per the repo's no-mocks convention. Needs no credentials, so it's CI-safe; `--live` runs the same checks against a deployed server. Exits non-zero on the first failed check. The stub reads the same JSON fixtures as the unit tests, so smoke and tests can't disagree about the API shape.
- **README "Release Checklist"** section covering build, tests, both smoke scripts, the SDK-pin behaviour, and the version bump. Step 6 notes that once #78's publish flow lands, the GitHub release **tag** drives the published npm version (semver-guarded), with the bump commit remaining conventional.

## Verification (local — no CI in this environment)

- `npm run build` — clean.
- `npx vitest run` — **707 passed / 71 files**, against a clean `main` baseline of **661 passed / 69 files**. Net-new: **46 tests, 2 files**.

  **Correction:** an earlier revision of this PR body claimed "694, up from 633, +61". That was wrong — 633 was a broken-dependency run (the worktree had no `node_modules`, so `ignore` was missing and the build cascaded into spurious failures), and 694 predated the review round. The 661 baseline above was measured in a clean worktree checked out at `main` (c4f0902).
- `bash scripts/smoke.sh` — all 14 checks pass against the stub server.
- **Mutation-tested the assertions** rather than just asserting they pass:
  - reverting the array-flattening fix → 6 failures
  - removing the `x-pica-` branch of the header filter → 4 failures
  - ranges with no explicit minimum → conversion throws (asserted directly)
- **Derivation verified to track a bump:** temporarily setting the declared dependency to `^0.7.4` moves the ref to `v0.7.4` with no code change; restored afterwards.

**Known unrelated failure:** `npm run check:release` fails at its `smoke:init` step in this environment. Pre-existing and not caused by this branch — confirmed by `git stash`-ing all changes and reproducing the identical failure on a clean tree. It needs sibling `solidactions-examples` / `solidactions-ts-sdk` checkouts, and still fails even when pointed at them. Not addressed here.

**Also out of scope:** the unpinned examples-repo `TEMPLATE_FILES` fetch in `init.ts` is the same bug class as #39, but is filed as its own CLI issue and deliberately not fixed here.

No version bump, no publish, no merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
