### PR TITLE
Device login: bare verification URL + clearer default-workspace prompt

### DIFF
--- a/src/commands/device-login.ts
+++ b/src/commands/device-login.ts
@@ -101,11 +101,13 @@ export async function deviceLogin(
     console.log(chalk.blue('Requesting device authorization...'));
     const code = await requestDeviceCode(host);
 
-    const verifyUrl = code.verification_uri_complete || code.verification_uri;
+    // Deliberately the bare verification_uri, never verification_uri_complete:
+    // the server ignores prefilled codes (phishing defense) — the user types
+    // the code shown here.
     console.log('');
     console.log(chalk.green('To finish signing in, visit:'));
-    console.log('  ' + chalk.blue.underline(verifyUrl));
-    console.log(chalk.gray('  Enter code: ') + chalk.bold(code.user_code));
+    console.log('  ' + chalk.blue.underline(code.verification_uri));
+    console.log(chalk.gray('  and enter code: ') + chalk.bold(code.user_code));
     console.log('');
     console.log(chalk.gray('Waiting for approval in your browser...'));
 

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -153,7 +153,7 @@ async function selectWorkspaceInteractively(
         return workspaces[0];
     }
 
-    console.log(chalk.blue('\nSelect a workspace:\n'));
+    console.log(chalk.blue('\nSelect your default workspace (change anytime with `solidactions workspace set`):\n'));
     workspaces.forEach((ws, i) => {
         console.log(`  ${chalk.white(`${i + 1}.`)} ${ws.name}`);
     });

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -202,7 +202,7 @@ export async function ensureWorkspaceSelected(config: Config): Promise<Config> {
         selected = workspaces[0];
         console.log(chalk.gray(`Auto-selected workspace: ${selected.name}`));
     } else {
-        console.log(chalk.blue('\nSelect a workspace:\n'));
+        console.log(chalk.blue('\nSelect your default workspace (change anytime with `solidactions workspace set`):\n'));
         workspaces.forEach((ws, i) => {
             console.log(`  ${chalk.white(`${i + 1}.`)} ${ws.name} ${chalk.gray(`(${ws.org_name}, ${ws.role})`)}`);
         });


### PR DESCRIPTION
Companion to solidactions-app#840's typed-code flow: the server now ignores prefilled `?user_code=` links (device-flow phishing defense), so the CLI prints the bare `verification_uri` and tells the user to enter the code shown in the terminal. Also reworded the post-auth workspace prompt (both call sites) to say what it actually does — pick the CLI's default workspace (`solidactions workspace set` changes it later) — since it read like part of the authorization ceremony.

Full suite: 666 passed locally (no PR CI in this repo). Live smoke against the dev stack shows the new output; the old prefilled link still works against the new server (it just lands on the code-entry form).

Merge after the app-side PR deploys — against an older server this output change is harmless (the entry page has always existed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)