### PR TITLE
cli maintenance: check:release smoke, dev relative path, pinned init templates (#83 #85 #86)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -39,7 +39,15 @@ jobs:
           cache-dependency-path: cli/package-lock.json
       - run: npm ci --ignore-scripts
         working-directory: cli
+      # smoke:init SKIPs (exit 0) when the sibling checkouts are missing, which
+      # keeps `check:release` usable on a clean local clone. That must never be
+      # able to false-green the release gate here, where the checkouts are
+      # cloned above and are always expected: make a missing one a hard failure.
       - run: npm run check:release
         working-directory: cli
+        env:
+          SOLIDACTIONS_SMOKE_REQUIRE_SOURCES: '1'
+          SOLIDACTIONS_EXAMPLES_DIR: ${{ github.workspace }}/examples
+          SOLIDACTIONS_SDK_DIR: ${{ github.workspace }}/ts-sdk
       - run: npm audit --omit=dev --audit-level=high
         working-directory: cli

--- a/README.md
+++ b/README.md
@@ -311,6 +311,25 @@ first three in one command.
    surface — array query-param serialization and the proxy-managed header
    filter both have fixture-backed tests under `tests/fixtures/`).
 3. **Init smoke** — `npm run smoke:init` scaffolds a project end to end.
+
+   It serves template content from local `solidactions-examples` /
+   `solidactions-ts-sdk` checkouts, discovered beside your `solidactions-cli`
+   checkout (override with `SOLIDACTIONS_EXAMPLES_DIR` /
+   `SOLIDACTIONS_SDK_DIR`). Files are read from git **at the ref the CLI pins
+   to**, not from the checkout's working tree, so the branch a sibling happens
+   to be parked on does not affect the result; a pinned ref the checkout lacks
+   is fetched on demand.
+
+   **If a checkout is missing, the smoke SKIPs with a notice and exits 0** so a
+   clean clone can still run `check:release`. That means a local green does not
+   by itself prove the smoke ran. Set `SOLIDACTIONS_SMOKE_REQUIRE_SOURCES=1` to
+   turn a missing checkout back into a hard failure — CI's `release-candidate`
+   job sets it, so the release gate can never be skipped silently. Use it
+   locally too when you are verifying a release:
+
+   ```bash
+   SOLIDACTIONS_SMOKE_REQUIRE_SOURCES=1 npm run check:release
+   ```
 4. **oauth-actions smoke** — `bash scripts/smoke.sh` exercises
    `oauth-actions list|search|show` (plus the 404 path) against a real local
    stub server, so it needs no credentials:
@@ -335,7 +354,18 @@ first three in one command.
    `src/utils/sdk-version.ts`), so bumping that dependency moves the docs ref
    with it — nothing to update by hand. `tests/sdk-docs-ref.test.ts` fails if
    the declared range has no explicit minimum version to derive from.
-6. **Version bump** — update `package.json`, then publish. Once the publish
+6. **Examples pin** — every `solidactions-examples` fetch (`init`'s project
+   template, the installed skills, the `CLAUDE.md`/`AGENTS.md` helper content,
+   and `ai examples`) goes through `EXAMPLES_REF` in
+   `src/utils/examples-ref.ts`, so a scaffold never drifts with that repo's
+   `main`. Unlike the SDK pin above this is **not** derived — the examples repo
+   does not tag in step with the SDK — so it is a commit SHA that must be
+   bumped by hand when you want a newer template. To bump: set the constant to
+   the new commit and run `SOLIDACTIONS_SMOKE_REQUIRE_SOURCES=1 npm run
+   check:release`, which serves content at exactly that ref and so fails on a
+   bad or unreachable pin. `tests/examples-ref.test.ts` fails if any call site
+   stops passing the ref.
+7. **Version bump** — update `package.json`, then publish. Once the publish
    flow from PR #78 lands, the GitHub release **tag** drives the published npm
    version (semver-guarded); the bump commit stays conventional.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@solidactions/cli",
-  "version": "1.31.1",
+  "version": "1.33.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@solidactions/cli",
-      "version": "1.31.1",
+      "version": "1.33.0",
       "license": "MIT",
       "dependencies": {
         "archiver": "^7.0.0",

--- a/scripts/smoke-init.mjs
+++ b/scripts/smoke-init.mjs
@@ -4,12 +4,49 @@ import { mkdtemp, mkdir, readFile, readdir, rm, stat, writeFile } from 'node:fs/
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { spawn } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
+import { existsSync, statSync } from 'node:fs';
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const cliDir = path.resolve(scriptDir, '..');
-const examplesDir = path.resolve(process.env.SOLIDACTIONS_EXAMPLES_DIR ?? path.join(cliDir, '..', 'examples'));
-const sdkDir = path.resolve(process.env.SOLIDACTIONS_SDK_DIR ?? path.join(cliDir, '..', 'ts-sdk'));
+
+// The smoke serves the examples/SDK repos from local sibling checkouts. Two
+// things used to break this: the defaults assumed directory names ("examples",
+// "ts-sdk") that nobody actually clones under, and `cliDir/..` is the worktree
+// container — not the checkout root — whenever the CLI is worked on from a git
+// worktree. Resolve the real checkout root via the shared git dir, then probe
+// the names people actually use.
+function checkoutRoot() {
+  const result = spawnSync('git', ['rev-parse', '--path-format=absolute', '--git-common-dir'], {
+    cwd: cliDir,
+    encoding: 'utf8',
+  });
+  if (result.status !== 0 || !result.stdout.trim()) return path.resolve(cliDir, '..');
+  // <root>/<repo>/.git -> <root>
+  return path.resolve(result.stdout.trim(), '..', '..');
+}
+
+function isDirectory(candidate) {
+  return existsSync(candidate) && statSync(candidate).isDirectory();
+}
+
+function findSibling(override, candidateNames) {
+  // An explicit override that does not exist is reported as missing rather than
+  // trusted, so a typo surfaces here instead of as a confusing failure later.
+  if (override) {
+    const resolved = path.resolve(override);
+    return isDirectory(resolved) ? resolved : null;
+  }
+  const root = checkoutRoot();
+  for (const name of candidateNames) {
+    const candidate = path.join(root, name);
+    if (isDirectory(candidate)) return candidate;
+  }
+  return null;
+}
+
+const examplesDir = findSibling(process.env.SOLIDACTIONS_EXAMPLES_DIR, ['solidactions-examples', 'examples']);
+const sdkDir = findSibling(process.env.SOLIDACTIONS_SDK_DIR, ['solidactions-ts-sdk', 'ts-sdk']);
 const packageJson = JSON.parse(await readFile(path.join(cliDir, 'package.json'), 'utf8'));
 const skillNames = [
   'solidactions-getting-started',
@@ -52,15 +89,56 @@ function run(command, args, options = {}) {
   });
 }
 
-async function ensureDirectory(directory, label) {
-  const value = await stat(directory).catch(() => null);
-  assert(value?.isDirectory(), `${label} not found at ${directory}`);
+// The smoke needs local examples/SDK checkouts to serve template content from.
+// On a clean clone (CI, a fresh contributor box) those siblings do not exist,
+// and hard-failing there turned check:release into a gate nobody could pass.
+// Skip with a loud notice instead. Set SOLIDACTIONS_SMOKE_REQUIRE_SOURCES=1
+// (release builds) to turn a missing checkout back into a failure.
+function skipUnlessSourcesPresent() {
+  const missing = [];
+  if (!examplesDir) missing.push('solidactions-examples');
+  if (!sdkDir) missing.push('solidactions-ts-sdk');
+  if (missing.length === 0) return false;
+
+  const detail = `missing sibling checkout(s): ${missing.join(', ')}`;
+  if (process.env.SOLIDACTIONS_SMOKE_REQUIRE_SOURCES === '1') {
+    throw new Error(
+      `smoke:init requires local source checkouts (${detail}). ` +
+      'Clone them next to solidactions-cli, or point SOLIDACTIONS_EXAMPLES_DIR / SOLIDACTIONS_SDK_DIR at them.',
+    );
+  }
+  console.log(`SKIP smoke:init — ${detail}.`);
+  console.log('  Clone them beside solidactions-cli, or set SOLIDACTIONS_EXAMPLES_DIR / SOLIDACTIONS_SDK_DIR.');
+  console.log('  Set SOLIDACTIONS_SMOKE_REQUIRE_SOURCES=1 to make this a hard failure instead.');
+  return true;
 }
 
-function safeSourcePath(root, relativePath) {
+function assertSafeSourcePath(root, relativePath) {
   const resolved = path.resolve(root, relativePath);
   assert(resolved === root || resolved.startsWith(`${root}${path.sep}`), `unsafe source path: ${relativePath}`);
-  return resolved;
+  return relativePath;
+}
+
+// Read a file at the ref the CLI actually asked for, out of the checkout's git
+// object store — NOT the working tree. Serving the working tree meant the smoke
+// silently tested whatever branch the sibling checkout happened to be parked on
+// (a feature branch, a stale main), which is why it failed even against real
+// checkouts. Reading by ref also makes the smoke a genuine check on the refs the
+// CLI pins to. Remote-tracking refs win over local ones so a stale local `main`
+// does not shadow the fetched one.
+function readAtRef(root, ref, relativePath) {
+  const candidates = [`origin/${ref}`, ref];
+  const failures = [];
+  for (const candidate of candidates) {
+    const result = spawnSync('git', ['show', `${candidate}:${relativePath}`], {
+      cwd: root,
+      encoding: 'buffer',
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    if (result.status === 0) return result.stdout;
+    failures.push(`${candidate}: ${String(result.stderr ?? '').trim()}`);
+  }
+  throw new Error(`could not read ${relativePath} at ref ${ref} in ${root}\n${failures.join('\n')}`);
 }
 
 async function startSourceServer() {
@@ -73,9 +151,10 @@ async function startSourceServer() {
       const parts = decodeURIComponent(new URL(request.url, 'http://localhost').pathname).split('/').filter(Boolean);
       const root = repositories.get(`${parts[0]}/${parts[1]}`);
       assert(root, 'unknown source repository');
-      assert(parts[2], 'missing source ref');
-      const file = safeSourcePath(root, parts.slice(3).join('/'));
-      const content = await readFile(file);
+      const ref = parts[2];
+      assert(ref, 'missing source ref');
+      const file = assertSafeSourcePath(root, parts.slice(3).join('/'));
+      const content = readAtRef(root, ref, file);
       response.writeHead(200, { 'content-type': 'text/plain; charset=utf-8' });
       response.end(content);
     } catch (error) {
@@ -129,8 +208,17 @@ async function verifyScaffold(projectDir, target) {
   assert.equal(generatedPackage.engines?.node, '>=24');
 }
 
-await ensureDirectory(examplesDir, 'examples checkout');
-await ensureDirectory(sdkDir, 'SDK checkout');
+if (skipUnlessSourcesPresent()) {
+  process.exit(0);
+}
+
+// `npm pack` only ships "dist" (see package.json files), so running this smoke
+// without a build produces a tarball with no binary and fails much later with
+// an opaque ENOENT on node_modules/.bin/solidactions. Say so up front.
+assert(
+  existsSync(path.join(cliDir, 'dist', 'index.js')),
+  'dist/index.js is missing — run `npm run build` before smoke:init (check:release does this for you).',
+);
 
 const tempRoot = await mkdtemp(path.join(tmpdir(), 'solidactions-cli-release-'));
 const artifactDir = path.join(tempRoot, 'artifacts');

--- a/scripts/smoke-init.mjs
+++ b/scripts/smoke-init.mjs
@@ -119,26 +119,88 @@ function assertSafeSourcePath(root, relativePath) {
   return relativePath;
 }
 
+// Resolved commit-ish per (checkout, ref). Resolution can hit the network, and
+// a run reads a dozen files per repo — resolve once, reuse.
+const resolvedRefs = new Map();
+
+function revParse(root, candidate) {
+  const result = spawnSync('git', ['rev-parse', '--verify', '--quiet', `${candidate}^{commit}`], {
+    cwd: root,
+    encoding: 'utf8',
+  });
+  return result.status === 0 ? result.stdout.trim() : null;
+}
+
+/**
+ * Resolve a ref to a commit inside a sibling checkout, fetching it if the
+ * checkout does not already have it.
+ *
+ * CI clones the sibling repos at depth 1 with no tags, so a pinned ref the CLI
+ * asks for — the SDK's `v0.7.3` tag, or an EXAMPLES_REF SHA that is not the tip
+ * of the cloned branch — simply is not present locally, and the smoke failed
+ * with "File not found ... (branch: v0.7.3)". Fetching on demand keeps the CI
+ * checkouts cheap while still serving exactly the ref the CLI pins to.
+ *
+ * Remote-tracking refs are preferred over local ones so a stale local `main`
+ * cannot shadow the fetched one.
+ */
+function resolveRef(root, ref) {
+  const cacheKey = `${root}\0${ref}`;
+  const cached = resolvedRefs.get(cacheKey);
+  if (cached) return cached;
+
+  const attempts = [];
+  for (const candidate of [`origin/${ref}`, ref]) {
+    const commit = revParse(root, candidate);
+    if (commit) {
+      resolvedRefs.set(cacheKey, commit);
+      return commit;
+    }
+    attempts.push(candidate);
+  }
+
+  // Not present locally — ask the remote for it. Tags and SHAs both work as
+  // fetch arguments; FETCH_HEAD then names whatever came back.
+  const fetch = spawnSync('git', ['fetch', '--quiet', '--depth=1', 'origin', ref], {
+    cwd: root,
+    encoding: 'utf8',
+  });
+  if (fetch.status === 0) {
+    const commit = revParse(root, 'FETCH_HEAD');
+    if (commit) {
+      resolvedRefs.set(cacheKey, commit);
+      return commit;
+    }
+  }
+
+  throw new Error(
+    `could not resolve ref "${ref}" in ${root}\n` +
+    `  tried locally: ${attempts.join(', ')}\n` +
+    `  git fetch origin ${ref}: ${fetch.status === 0 ? 'succeeded but FETCH_HEAD was unusable' : String(fetch.stderr ?? '').trim()}\n` +
+    '  If this ref is a pin in the CLI (EXAMPLES_REF, or the SDK tag derived from package.json), ' +
+    'check that it exists and is pushed in the source repo.',
+  );
+}
+
 // Read a file at the ref the CLI actually asked for, out of the checkout's git
 // object store — NOT the working tree. Serving the working tree meant the smoke
 // silently tested whatever branch the sibling checkout happened to be parked on
 // (a feature branch, a stale main), which is why it failed even against real
 // checkouts. Reading by ref also makes the smoke a genuine check on the refs the
-// CLI pins to. Remote-tracking refs win over local ones so a stale local `main`
-// does not shadow the fetched one.
+// CLI pins to.
 function readAtRef(root, ref, relativePath) {
-  const candidates = [`origin/${ref}`, ref];
-  const failures = [];
-  for (const candidate of candidates) {
-    const result = spawnSync('git', ['show', `${candidate}:${relativePath}`], {
-      cwd: root,
-      encoding: 'buffer',
-      maxBuffer: 64 * 1024 * 1024,
-    });
-    if (result.status === 0) return result.stdout;
-    failures.push(`${candidate}: ${String(result.stderr ?? '').trim()}`);
+  const commit = resolveRef(root, ref);
+  const result = spawnSync('git', ['show', `${commit}:${relativePath}`], {
+    cwd: root,
+    encoding: 'buffer',
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `could not read ${relativePath} at ref ${ref} (${commit}) in ${root}\n${String(result.stderr ?? '').trim()}`,
+    );
   }
-  throw new Error(`could not read ${relativePath} at ref ${ref} in ${root}\n${failures.join('\n')}`);
+  return result.stdout;
 }
 
 async function startSourceServer() {

--- a/src/commands/ai-examples.ts
+++ b/src/commands/ai-examples.ts
@@ -4,6 +4,7 @@ import chalk from 'chalk';
 import prompts from 'prompts';
 import fsExtra from 'fs-extra';
 import { fetchRawFile, listRepoContents } from '../utils/github';
+import { EXAMPLES_REF } from '../utils/examples-ref';
 import { findAiHelperFile, upsertMarkerSection } from '../utils/markers';
 
 interface AiExamplesOptions {
@@ -11,15 +12,23 @@ interface AiExamplesOptions {
     overwrite?: boolean;
 }
 
+/**
+ * Recursively download a directory from the examples repo.
+ *
+ * Every listing and fetch is pinned to EXAMPLES_REF (#86) so `ai examples`
+ * installs a consistent snapshot rather than whatever is on that repo's default
+ * branch mid-walk. Only ever called against solidactions-examples; the
+ * owner/repo parameters are structural, not a second supported source.
+ */
 async function downloadDirectory(owner: string, repo: string, remotePath: string, localPath: string): Promise<void> {
-    const contents = await listRepoContents(owner, repo, remotePath);
+    const contents = await listRepoContents(owner, repo, remotePath, EXAMPLES_REF);
     fsExtra.ensureDirSync(localPath);
 
     for (const item of contents) {
         const localItemPath = path.join(localPath, item.name);
 
         if (item.type === 'file') {
-            const content = await fetchRawFile(owner, repo, `${remotePath}/${item.name}`);
+            const content = await fetchRawFile(owner, repo, `${remotePath}/${item.name}`, EXAMPLES_REF);
             fs.writeFileSync(localItemPath, content, 'utf8');
         } else if (item.type === 'dir') {
             await downloadDirectory(owner, repo, `${remotePath}/${item.name}`, localItemPath);
@@ -32,7 +41,7 @@ export async function aiExamples(names: string[], options: AiExamplesOptions = {
         console.log(chalk.blue('Discovering available examples...'));
 
         // Discover available examples
-        const repoContents = await listRepoContents('SolidActions', 'solidactions-examples');
+        const repoContents = await listRepoContents('SolidActions', 'solidactions-examples', '', EXAMPLES_REF);
         const availableExamples = repoContents.filter(
             (item) => item.type === 'dir' && !item.name.startsWith('.')
         );

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -777,7 +777,13 @@ function hasTsLoader(): boolean {
 function reexecUnderTsx(file: string, env: string | undefined, input: string, projectDir: string): number {
     // dist/src/commands/dev.js → CLI entry is dist/index.js (two dirs up).
     const cliEntry = path.resolve(__dirname, '..', 'index.js');
-    const args = ['tsx', cliEntry, 'dev', file, '--input', input];
+    // This function sets the child's cwd to projectDir, so the entry MUST be
+    // absolute by the time it is forwarded — a relative path would resolve
+    // against the parent's cwd here and the child's cwd there, yielding a
+    // doubled path when the run started outside the project root (#85).
+    // Resolved against the caller's cwd, which is still current.
+    const entry = path.resolve(file);
+    const args = ['tsx', cliEntry, 'dev', entry, '--input', input];
     if (env) {
         args.push('--env', env);
     }
@@ -843,7 +849,10 @@ export async function dev(file: string, options: DevOptions): Promise<void> {
                 process.exit(1);
             }
         }
-        process.exit(reexecUnderTsx(file, env, input, projectDir));
+        // Forward the RESOLVED path, not the original argument: the child's cwd
+        // is projectDir, so a relative arg would be resolved a second time
+        // against a different directory (#85).
+        process.exit(reexecUnderTsx(filePath, env, input, projectDir));
     }
 
     // In-process path (already under a TS loader, or a .js/.mjs entry).

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import chalk from 'chalk';
 import fsExtra from 'fs-extra';
 import { fetchRawFile } from '../utils/github';
+import { EXAMPLES_REF } from '../utils/examples-ref';
 import { aiInit, resolveAiHelperTarget } from './ai-init';
 import type { AiHelperTarget } from '../utils/skills';
 
@@ -77,7 +78,10 @@ export async function init(directory: string | undefined, options: InitOptions =
 
         for (const [remoteSuffix, localSuffix] of TEMPLATE_FILES) {
             const remotePath = `${TEMPLATE_PREFIX}/${remoteSuffix}`;
-            let content = await fetchRawFile(EXAMPLES_OWNER, EXAMPLES_REPO, remotePath);
+            // Pinned to EXAMPLES_REF: unpinned, this loop scaffolded whatever
+            // was on the examples repo's default branch — including the
+            // @solidactions/sdk version the new project declares (#86).
+            let content = await fetchRawFile(EXAMPLES_OWNER, EXAMPLES_REPO, remotePath, EXAMPLES_REF);
             content = content.replace(/__PROJECT_NAME__/g, projectName);
 
             const outPath = path.join(targetDir, localSuffix);

--- a/src/utils/examples-ref.ts
+++ b/src/utils/examples-ref.ts
@@ -1,0 +1,31 @@
+/**
+ * The git ref used for every fetch from the solidactions-examples repo:
+ * `init`'s project template (TEMPLATE_FILES) and the AI skills / helper content
+ * installed alongside it.
+ *
+ * These fetches previously defaulted to `main`, so the scaffold a user got —
+ * including the `@solidactions/sdk` version their new project depends on — was
+ * whatever happened to be on that repo's default branch at that moment. That is
+ * the same unpinned-fetch class as the SDK docs fetch fixed in #39; see
+ * {@link ./sdk-version.ts}.
+ *
+ * WHY A COMMIT SHA AND NOT A TAG: the SDK pin derives its ref from this CLI's
+ * declared `@solidactions/sdk` range, because the SDK repo tags `vX.Y.Z` in step
+ * with the package it publishes. solidactions-examples does NOT version in
+ * lockstep with the SDK — its newest tag (v0.7.0) predates the current template
+ * by a wide margin: it declares `@solidactions/sdk` ^0.6.0 (this CLI declares
+ * ^0.7.3) and lacks skills/solidactions-crew-skills.md entirely. Pinning to that
+ * tag would regress every new scaffold, so the same derived-version scheme cannot
+ * apply here. A commit SHA is immutable and gives the property that actually
+ * matters — the scaffold no longer moves under us.
+ *
+ * TO UPDATE: point this at the new solidactions-examples commit and re-run
+ * `npm run check:release`; smoke:init serves template content at exactly this
+ * ref, so a bad or unreachable SHA fails the release check rather than reaching
+ * users. If solidactions-examples ever starts publishing tags in step with the
+ * SDK, replace this with a derivation the way sdk-version.ts does.
+ *
+ * Currently: solidactions-examples main @ 3ca5fd4 "docs: publish examples and AI
+ * skill guidance (#23)".
+ */
+export const EXAMPLES_REF = '3ca5fd4d3107659b27889775791f6691cf173303';

--- a/src/utils/skills.ts
+++ b/src/utils/skills.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import fsExtra from 'fs-extra';
 import { fetchRawFile } from './github';
+import { EXAMPLES_REF } from './examples-ref';
 
 export const SOLIDACTIONS_SKILL_NAMES = [
     'solidactions-getting-started',
@@ -45,7 +46,7 @@ export async function installSkills(targetDir: string): Promise<{ written: strin
 
     for (const skillName of SOLIDACTIONS_SKILL_NAMES) {
         const remotePath = `${SKILLS_PATH_PREFIX}/${skillName}.md`;
-        const content = await fetchRawFile(EXAMPLES_OWNER, EXAMPLES_REPO, remotePath);
+        const content = await fetchRawFile(EXAMPLES_OWNER, EXAMPLES_REPO, remotePath, EXAMPLES_REF);
 
         const filePath = path.join(targetDir, `${skillName}.md`);
         fs.writeFileSync(filePath, content, 'utf8');
@@ -60,7 +61,7 @@ export async function installSkills(targetDir: string): Promise<{ written: strin
  * repo. Single source per target — no legacy fallback.
  */
 export async function fetchAiHelperContent(targetFile: AiHelperTarget): Promise<string> {
-    return fetchRawFile(EXAMPLES_OWNER, EXAMPLES_REPO, targetFile);
+    return fetchRawFile(EXAMPLES_OWNER, EXAMPLES_REPO, targetFile, EXAMPLES_REF);
 }
 
 /**

--- a/tests/dev-relative-entry.test.ts
+++ b/tests/dev-relative-entry.test.ts
@@ -1,0 +1,75 @@
+/**
+ * #85 — `solidactions dev <relative-path>` run from OUTSIDE the project root.
+ *
+ * reexecUnderTsx() forwards the entry path to the tsx child while setting the
+ * child's cwd to the entry's own project root. Forwarding the ORIGINAL, possibly
+ * relative, argument therefore made the child resolve it a second time against a
+ * different cwd, so `cd /tmp && solidactions dev project_b/src/workflow.ts` died
+ * with `File not found: /tmp/project_b/project_b/src/workflow.ts`.
+ *
+ * Test-double policy: no mocks. This spawns the real built CLI under plain
+ * `node` (not tsx) from a cwd outside the fixture project, which is the only way
+ * to exercise the re-exec path end to end.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as childProcess from 'child_process';
+import { describe, expect, it, beforeAll, afterAll } from 'vitest';
+
+const CLI_BINARY = path.resolve(__dirname, '../dist/index.js');
+
+let workRoot: string;
+let projectDir: string;
+
+beforeAll(() => {
+    if (!fs.existsSync(CLI_BINARY)) {
+        throw new Error(`CLI not built — run \`npm run build\` first (expected: ${CLI_BINARY})`);
+    }
+
+    // <workRoot>/project_b/src/workflow.ts — the CLI is invoked FROM workRoot
+    // with the relative path "project_b/src/workflow.ts".
+    workRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'solidactions-dev-relative-'));
+    projectDir = path.join(workRoot, 'project_b');
+    fs.mkdirSync(path.join(projectDir, 'src'), { recursive: true });
+    fs.writeFileSync(
+        path.join(projectDir, 'package.json'),
+        JSON.stringify({ name: 'project_b', type: 'module' }) + '\n',
+    );
+    fs.writeFileSync(
+        path.join(projectDir, 'src', 'workflow.ts'),
+        'export default { name: "relative-entry", run: async () => 42 };\n',
+    );
+});
+
+afterAll(() => {
+    if (workRoot) fs.rmSync(workRoot, { recursive: true, force: true });
+});
+
+function runDevCli(entryArg: string, cwd: string) {
+    return childProcess.spawnSync(
+        process.execPath,
+        [CLI_BINARY, 'dev', entryArg, '--input', '{}'],
+        { encoding: 'utf8', cwd, env: { ...process.env }, timeout: 60_000 },
+    );
+}
+
+describe('solidactions dev — relative entry path from outside the project root', () => {
+    it('does not double-resolve the entry against the re-exec child cwd', () => {
+        const result = runDevCli(path.join('project_b', 'src', 'workflow.ts'), workRoot);
+        const output = `${result.stdout ?? ''}${result.stderr ?? ''}`;
+
+        // The bug's signature: the project directory segment appearing twice.
+        expect(output).not.toMatch(/project_b[\\/]project_b/);
+        // And more generally, the entry must be found at all.
+        expect(output).not.toMatch(/File not found/);
+    }, 90_000);
+
+    it('still resolves an absolute entry path from outside the project root', () => {
+        const result = runDevCli(path.join(projectDir, 'src', 'workflow.ts'), workRoot);
+        const output = `${result.stdout ?? ''}${result.stderr ?? ''}`;
+
+        expect(output).not.toMatch(/File not found/);
+    }, 90_000);
+});

--- a/tests/dev-relative-entry.test.ts
+++ b/tests/dev-relative-entry.test.ts
@@ -37,9 +37,28 @@ beforeAll(() => {
         path.join(projectDir, 'package.json'),
         JSON.stringify({ name: 'project_b', type: 'module' }) + '\n',
     );
+    // The fixture must actually RUN, not merely get past path resolution, so the
+    // assertions below can require exit 0 and real output. That needs
+    // @solidactions/sdk resolvable from the fixture: link this repo's
+    // node_modules rather than paying an npm install per test run.
+    fs.symlinkSync(
+        path.resolve(__dirname, '../node_modules'),
+        path.join(projectDir, 'node_modules'),
+        'dir',
+    );
     fs.writeFileSync(
         path.join(projectDir, 'src', 'workflow.ts'),
-        'export default { name: "relative-entry", run: async () => 42 };\n',
+        [
+            "import { defineWorkflow } from '@solidactions/sdk';",
+            'export default defineWorkflow({',
+            "    name: 'relative-entry',",
+            '    run: async (ctx) => {',
+            '        const input = ctx.input as { n?: number };',
+            '        return (input.n ?? 0) + 1;',
+            '    },',
+            '});',
+            '',
+        ].join('\n'),
     );
 });
 
@@ -50,26 +69,41 @@ afterAll(() => {
 function runDevCli(entryArg: string, cwd: string) {
     return childProcess.spawnSync(
         process.execPath,
-        [CLI_BINARY, 'dev', entryArg, '--input', '{}'],
+        [CLI_BINARY, 'dev', entryArg, '--input', '{"n":41}'],
         { encoding: 'utf8', cwd, env: { ...process.env }, timeout: 60_000 },
     );
+}
+
+/**
+ * Assert the run actually SUCCEEDED.
+ *
+ * Asserting only the absence of "File not found" is too weak: a spawn error, a
+ * timeout, or a nonzero exit for some unrelated reason would all sail through.
+ * This fixture is built to run for real, so require the whole contract — no
+ * spawn error, exit 0, and the workflow's own output (41 + 1 = 42).
+ */
+function expectSuccessfulRun(result: childProcess.SpawnSyncReturns<string>) {
+    const output = `${result.stdout ?? ''}${result.stderr ?? ''}`;
+
+    expect(result.error).toBeUndefined();
+    expect(output).not.toMatch(/File not found/);
+    expect(result.status, `dev exited ${result.status}\n${output}`).toBe(0);
+    expect(output).toMatch(/completed/);
+    expect(output).toMatch(/Output:.*\b42\b/);
 }
 
 describe('solidactions dev — relative entry path from outside the project root', () => {
     it('does not double-resolve the entry against the re-exec child cwd', () => {
         const result = runDevCli(path.join('project_b', 'src', 'workflow.ts'), workRoot);
-        const output = `${result.stdout ?? ''}${result.stderr ?? ''}`;
 
         // The bug's signature: the project directory segment appearing twice.
-        expect(output).not.toMatch(/project_b[\\/]project_b/);
-        // And more generally, the entry must be found at all.
-        expect(output).not.toMatch(/File not found/);
+        expect(`${result.stdout ?? ''}${result.stderr ?? ''}`).not.toMatch(/project_b[\\/]project_b/);
+        expectSuccessfulRun(result);
     }, 90_000);
 
     it('still resolves an absolute entry path from outside the project root', () => {
         const result = runDevCli(path.join(projectDir, 'src', 'workflow.ts'), workRoot);
-        const output = `${result.stdout ?? ''}${result.stderr ?? ''}`;
 
-        expect(output).not.toMatch(/File not found/);
+        expectSuccessfulRun(result);
     }, 90_000);
 });

--- a/tests/doc-push.test.ts
+++ b/tests/doc-push.test.ts
@@ -2389,7 +2389,7 @@ describe('docPushWithConfig — untracked binaries', () => {
         try {
             let caughtExit: ProcessExitError | null = null;
             try {
-                await docsPushWithConfig(dir, { onConflict: 'skip' }, stubConfig());
+                await docPushWithConfig(dir, { onConflict: 'skip' }, stubConfig());
             } catch (e) {
                 if (e instanceof ProcessExitError) caughtExit = e;
                 else throw e;

--- a/tests/examples-ref.test.ts
+++ b/tests/examples-ref.test.ts
@@ -137,3 +137,21 @@ describe('init TEMPLATE_FILES fetch', () => {
         expect(fetchCall![0]).toContain('EXAMPLES_REF');
     });
 });
+
+// `ai examples` walks the repo with listRepoContents + fetchRawFile. It is
+// interactive and network-driven, so it is guarded at the source level like
+// init's loop: every call in the file must carry the ref. The first pass at #86
+// missed this file entirely.
+describe('ai examples fetches', () => {
+    const source = fs.readFileSync(path.resolve(__dirname, '../src/commands/ai-examples.ts'), 'utf8');
+
+    it('pins every listRepoContents and fetchRawFile call to EXAMPLES_REF', () => {
+        const calls = source.match(/(?:listRepoContents|fetchRawFile)\([^;]*?\)/gs) ?? [];
+        // Guard the guard: if the calls are ever restructured away, fail loudly
+        // rather than vacuously passing over an empty list.
+        expect(calls.length).toBeGreaterThanOrEqual(3);
+        for (const call of calls) {
+            expect(call).toContain('EXAMPLES_REF');
+        }
+    });
+});

--- a/tests/examples-ref.test.ts
+++ b/tests/examples-ref.test.ts
@@ -1,0 +1,139 @@
+/**
+ * #86 — every solidactions-examples fetch must be pinned to an explicit ref.
+ *
+ * `init`'s TEMPLATE_FILES loop (and the skills/AI-helper fetches beside it) used
+ * fetchRawFile() with no ref, which defaults to `main`. That made the scaffold a
+ * user receives — including the `@solidactions/sdk` version their new project
+ * declares — depend on whatever was on that repo's default branch at that
+ * moment. Same unpinned-fetch class as the SDK docs fetch fixed in #39.
+ *
+ * These tests assert the pinned URL directly, so any regression to a moving ref
+ * fails here rather than silently shipping a drifting scaffold.
+ */
+
+import * as fs from 'fs';
+import * as http from 'http';
+import * as os from 'os';
+import * as path from 'path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { EXAMPLES_REF } from '../src/utils/examples-ref';
+import { rawContentUrl } from '../src/utils/github';
+import { installSkills, fetchAiHelperContent } from '../src/utils/skills';
+
+describe('EXAMPLES_REF', () => {
+    it('is an immutable ref, not a moving branch', () => {
+        expect(EXAMPLES_REF).not.toBe('main');
+        expect(EXAMPLES_REF).not.toBe('master');
+        expect(EXAMPLES_REF).not.toBe('HEAD');
+    });
+
+    it('is a full 40-character commit SHA', () => {
+        // A short SHA or a tag would still be pinned, but a full SHA is what the
+        // constant documents and what smoke:init resolves against. If this pin
+        // ever moves to a tag, update this assertion deliberately.
+        expect(EXAMPLES_REF).toMatch(/^[0-9a-f]{40}$/);
+    });
+});
+
+describe('solidactions-examples fetch URLs', () => {
+    const templateUrl = (suffix: string) =>
+        rawContentUrl('SolidActions', 'solidactions-examples', `templates/minimal/${suffix}`, EXAMPLES_REF);
+
+    it('builds template URLs against the pinned ref, not main', () => {
+        const url = templateUrl('package.json');
+        expect(url).toBe(
+            `https://raw.githubusercontent.com/SolidActions/solidactions-examples/${EXAMPLES_REF}/templates/minimal/package.json`,
+        );
+        expect(url).not.toContain('/main/');
+    });
+
+    it('pins package.json, which determines the scaffolded SDK version', () => {
+        // This is the file the issue is actually about: an unpinned fetch here
+        // means a new project's @solidactions/sdk range is set by whatever is on
+        // the examples repo's default branch.
+        expect(templateUrl('package.json')).toContain(`/${EXAMPLES_REF}/`);
+        expect(templateUrl('package-lock.json')).toContain(`/${EXAMPLES_REF}/`);
+    });
+
+    it('pins skill and AI-helper fetches from the same repo', () => {
+        for (const remotePath of ['skills/solidactions-getting-started.md', 'CLAUDE.md', 'AGENTS.md']) {
+            const url = rawContentUrl('SolidActions', 'solidactions-examples', remotePath, EXAMPLES_REF);
+            expect(url).toContain(`/${EXAMPLES_REF}/`);
+            expect(url).not.toContain('/main/');
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Behavioural: a real local HTTP server records what the fetch code ACTUALLY
+// requests. Asserting the URL builder alone would not catch a call site that
+// simply stops passing the ref. No mocks — same policy as dev.test.ts.
+// ---------------------------------------------------------------------------
+
+describe('solidactions-examples fetches pass the pinned ref at the call site', () => {
+    let server: http.Server;
+    let requested: string[];
+    let previousBaseUrl: string | undefined;
+    let tmpDir: string;
+
+    beforeAll(async () => {
+        requested = [];
+        server = http.createServer((req, res) => {
+            requested.push(req.url ?? '');
+            res.writeHead(200, { 'content-type': 'text/plain' });
+            res.end('stub content');
+        });
+        await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+        const address = server.address() as { port: number };
+        previousBaseUrl = process.env.SOLIDACTIONS_RAW_CONTENT_BASE_URL;
+        process.env.SOLIDACTIONS_RAW_CONTENT_BASE_URL = `http://127.0.0.1:${address.port}`;
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'solidactions-examples-ref-'));
+    });
+
+    afterAll(async () => {
+        if (previousBaseUrl === undefined) {
+            delete process.env.SOLIDACTIONS_RAW_CONTENT_BASE_URL;
+        } else {
+            process.env.SOLIDACTIONS_RAW_CONTENT_BASE_URL = previousBaseUrl;
+        }
+        if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+    });
+
+    it('installSkills requests every skill at the pinned ref', async () => {
+        requested = [];
+        await installSkills(path.join(tmpDir, 'skills'));
+
+        expect(requested.length).toBeGreaterThan(0);
+        for (const url of requested) {
+            expect(url).toContain(`/${EXAMPLES_REF}/`);
+            expect(url).not.toMatch(/solidactions-examples\/main\//);
+        }
+    });
+
+    it('fetchAiHelperContent requests the helper file at the pinned ref', async () => {
+        requested = [];
+        await fetchAiHelperContent('CLAUDE.md');
+
+        expect(requested).toHaveLength(1);
+        expect(requested[0]).toContain(`/${EXAMPLES_REF}/`);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Source guard for init's TEMPLATE_FILES loop, which cannot be driven in
+// isolation (init() prompts, chdir's, and exits). Asserts the loop's
+// fetchRawFile call passes a ref rather than relying on the `main` default.
+// ---------------------------------------------------------------------------
+
+describe('init TEMPLATE_FILES fetch', () => {
+    it('passes EXAMPLES_REF to fetchRawFile', () => {
+        const source = fs.readFileSync(path.resolve(__dirname, '../src/commands/init.ts'), 'utf8');
+
+        expect(source).toContain('EXAMPLES_REF');
+        // The fetch must name the ref argument; a bare 3-arg call falls back to main.
+        const fetchCall = source.match(/fetchRawFile\([^;]*?\);/s);
+        expect(fetchCall).not.toBeNull();
+        expect(fetchCall![0]).toContain('EXAMPLES_REF');
+    });
+});


### PR DESCRIPTION
Three independent CLI maintenance issues, one commit each.

## #83 — `check:release` fails at `smoke:init` on a clean tree

`smoke:init` could not go green on any real box, so `check:release` provided no gate at all. Three distinct defects, all fixed:

1. **Sibling resolution.** Defaults assumed directory names nobody clones under (`examples`, `ts-sdk` rather than `solidactions-examples`, `solidactions-ts-sdk`), and derived the search root from `cliDir/..` — which is the *worktree container*, not the checkout root, whenever the CLI is worked on from a git worktree. Now resolves the root via the shared git dir and probes both naming conventions.
2. **Stale-branch serving — this is the "fails even with real checkouts" half.** The source server read files from the sibling checkout's **working tree** while ignoring the ref in the request URL, so the smoke tested whatever branch the checkout happened to be parked on. Locally, `solidactions-examples` sat on a feature branch predating `skills/solidactions-crew-skills.md`, and the smoke failed on a missing skill. It now reads from the git object store at the requested ref, preferring remote-tracking refs so a stale local `main` can't shadow the fetched one. This also makes the smoke a genuine check on the refs the CLI pins — see #86.
3. **Clean clone.** Missing siblings hard-failed, which is the normal state on a fresh clone/CI. Now skips with a loud notice; `SOLIDACTIONS_SMOKE_REQUIRE_SOURCES=1` restores the hard failure for release builds. A nonexistent explicit `*_DIR` override counts as missing, so a typo surfaces immediately rather than as a confusing later error.

Also asserts `dist/index.js` up front — `npm pack` only ships `dist`, so running the smoke without a build previously failed deep in with an opaque ENOENT on `node_modules/.bin/solidactions`.

Verified: full run green with siblings, clean skip (exit 0) without them, hard failure under the strict env var.

## #85 — `dev` double-resolves a relative entry path

`reexecUnderTsx()` sets the tsx child's cwd to the entry's project root but forwarded the *original*, possibly relative, argument, so the child resolved it a second time. Live repro before the fix:

```
$ cd $SCRATCH && solidactions dev project_b/src/workflow.ts
File not found: $SCRATCH/project_b/project_b/src/workflow.ts
```

`dev()` already computes the resolved `filePath` for its own existence check — that's what now gets forwarded. `reexecUnderTsx()` also resolves defensively, since it's the function that changes cwd and therefore owns the "entry must be absolute" invariant.

Regression test (`tests/dev-relative-entry.test.ts`) spawns the real built CLI under plain `node` from a cwd outside the fixture project. Confirmed red before the fix, green after; absolute entries from outside the root stay covered.

## #86 — unpinned `solidactions-examples` fetches

`TEMPLATE_FILES` fetched the scaffold with no ref, so `fetchRawFile()` defaulted to `main` — meaning the `@solidactions/sdk` range a new project declares was set by whatever sat on that repo's default branch. Now pinned via a new `EXAMPLES_REF` constant.

**Scope note:** the issue names `TEMPLATE_FILES`, but `skills.ts` fetches the skill files and the `CLAUDE.md`/`AGENTS.md` helper content from the same repo, equally unpinned. Pinning only the templates would leave `init` assembling one project from two different snapshots of one repo, so both call sites use the single constant.

**Worth a reviewer's attention — why a SHA, not #82's derived scheme.** #82 derives the SDK docs ref from this CLI's declared `@solidactions/sdk` range, which works because the SDK repo tags `vX.Y.Z` in step with the package it publishes. `solidactions-examples` does **not** version in lockstep: its newest tag `v0.7.0` declares `@solidactions/sdk` `^0.6.0` (this CLI declares `^0.7.3`) and predates `solidactions-crew-skills.md` entirely — pinning there would regress every new scaffold. So the pin is the current `main` commit SHA, which is immutable and delivers the property that matters. The tradeoff is a manual bump when examples ships; the constant documents how, and how to switch to a derivation if that repo ever starts tagging in step. **If you'd rather cut a proper `v0.7.3` tag in `solidactions-examples` and derive from it, say so and I'll rework this commit.**

Tests assert the pinned URL, plus a local stub server recording what the skills/helper fetches actually request (a URL-builder assertion alone wouldn't catch a call site dropping the argument), plus a source guard on init's loop, which can't be driven in isolation.

## Two incidental fixes

- **Stale test reference.** PR #81's `docs`→`doc` rename missed a call site *inside* a test body, so "never pushes untracked .md files under node_modules or dot-directories" threw `ReferenceError` instead of running. Pre-existing on `main` and unrelated to these issues, but it blocked a green suite. The assertion passes once it actually executes — the behavior was fine, the test wasn't.
- **Lockfile drift.** `package-lock.json` still recorded 1.31.1 while `package.json` declares 1.33.0; the 1.32/1.33 bumps never updated it.

## Verification

`npm run check:release` green end to end: build, **79 test files / 754 tests passing**, and `smoke:init` scaffolding both agent targets then building and auditing the generated quickstart. The #83 skip and strict paths were each exercised directly.

Closes #83
Closes #85
Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)
