### PR TITLE
feat!: rename `oauth-actions` → `oauth-action` + `show` → `view` (ADR 0001 conformance)

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,9 +365,26 @@ first three in one command.
    check:release`, which serves content at exactly that ref and so fails on a
    bad or unreachable pin. `tests/examples-ref.test.ts` fails if any call site
    stops passing the ref.
-7. **Version bump** — update `package.json`, then publish. Once the publish
-   flow from PR #78 lands, the GitHub release **tag** drives the published npm
-   version (semver-guarded); the bump commit stays conventional.
+7. **Version** — the GitHub release **tag** is the single source of truth for
+   the published npm version. The publish flow from #78 has landed:
+   `.github/workflows/publish.yml` asserts the tag is a literal semver, then
+   derives the version from it with `npm version --no-git-tag-version`
+   immediately before publishing — deliberately *not* relying on a
+   `package.json` bump commit, so a release whose `package.json` was never
+   bumped can no longer collide with the registry and fail `npm publish`
+   silently (#77).
+
+   Consequences worth knowing before you cut a release:
+
+   - **`package.json`'s version is not the source of truth** and has drifted
+     from the published one. Read the registry (`npm view @solidactions/cli
+     version`) or the tag list, not the file.
+   - **Feature PRs do not bump it** — see PR #81, the `docs` → `doc` breaking
+     rename, which shipped without touching `package.json`.
+   - **A breaking change ships as a major tag.** Nothing in `check:release`
+     enforces this — the release destination is recorded in the PR and its
+     issue, and the releaser applies it when tagging. There is no changelog
+     file in this repo.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ first three in one command.
 
 1. **Build** — `npm run build` (must be clean; `tsc` errors block the release).
 2. **Unit tests** — `npm test`. Covers config resolution, command wiring, and
-   the `oauth-actions show` snippet renderer (the highest-risk regression
+   the `oauth-action view` snippet renderer (the highest-risk regression
    surface — array query-param serialization and the proxy-managed header
    filter both have fixture-backed tests under `tests/fixtures/`).
 3. **Init smoke** — `npm run smoke:init` scaffolds a project end to end.
@@ -330,8 +330,8 @@ first three in one command.
    ```bash
    SOLIDACTIONS_SMOKE_REQUIRE_SOURCES=1 npm run check:release
    ```
-4. **oauth-actions smoke** — `bash scripts/smoke.sh` exercises
-   `oauth-actions list|search|show` (plus the 404 path) against a real local
+4. **oauth-action smoke** — `bash scripts/smoke.sh` exercises
+   `oauth-action list|search|view` (plus the 404 path) against a real local
    stub server, so it needs no credentials:
 
    ```bash

--- a/docs/decisions/0001-cli-command-taxonomy.md
+++ b/docs/decisions/0001-cli-command-taxonomy.md
@@ -15,7 +15,7 @@
 3. **`push`/`pull` are the bridge verbs; `add` collapses into `push`.** CRUD (`create`/`edit`/`delete`) is a later, orthogonal axis: `push`/`pull` = "I have files," `create`/`edit`/`delete` = "I don't."
 4. **Flatten the SOP surface** to three peer top-level nouns — `skill` / `crew` / `role`, **no umbrella**. Role-scoping is a `--role <name>` flag. (`crews skill add <dir>` → `skill push <dir>`.)
 5. **Pillars are `--help` section headers + mental model only — never typed path segments** (the `gh` model; needs a Commander `configureHelp` customization).
-6. **Verb canon = `view`** for "show one"; migrate `oauth-actions show` → `view`.
+6. **Verb canon = `view`** for "show one"; migrate `oauth-actions show` → `view`. *(Executed in #84 — see the conformance table below.)*
 7. **Hot-path promotion** to bare top-level is limited to unambiguous actions (`deploy`, `dev`); `push`/`pull`/`list` stay noun-scoped.
 8. **Verbs come in families; each noun declares its family** — file-sync (`push`/`pull`), content-CRUD (`create`/`edit`/`delete`/`list`/`view`), execution-lifecycle (`start`/`invoke`/…), KV-upsert (`set`, e.g. `env`). "Full CRUD" is not "bolt create/edit/delete onto everything."
 
@@ -37,6 +37,8 @@
 | --- | --- | --- |
 | `project` / `run` / `env` / `schedule` / `webhook` / `skill` / `role` / `crew` / `workspace` | Conformant | Singular from the start |
 | `doc` | Conformant since #63 | Shipped plural as `docs`; renamed `docs` → `doc` (BREAKING, no deprecation alias) per decision (2). Old `docs push` / `docs pull` / `docs upload` are gone — Commander emits an "unknown command" error with a `Did you mean doc?` hint. The `"docs"` OAuth ability, the `SA-Docs` product name, the `/mcp/docs` + `docs_*` API surface, and the `.solidactions-docs.json` sidecar are **not** part of this rename and stay as-is |
-| `oauth-actions` | **Not conformant** | Still plural. Out of scope for #63 (which was sanctioned for `docs` → `doc` only) and needs its own decision: unlike `docs`, the singular `oauth-action` reads awkwardly for a discovery surface, and decision (6) already has a pending `show` → `view` migration for this noun that a rename should ride along with. Tracked separately (cli#84) |
+| `oauth-action` | Conformant since #84 | Shipped plural as `oauth-actions`; renamed `oauth-actions` → `oauth-action` (BREAKING, no deprecation alias) per decision (2), and the `show` subcommand migrated to `view` per decision (6) — both in one pass, as the #63 deferral anticipated. Old `oauth-actions <anything>` and `oauth-action show` are gone; Commander emits an "unknown command" error. The `/api/v1/oauth-actions` REST paths, the `oauth_actions` JSON response key, and the `solidactions-oauth-actions` bundled skill filename are **not** part of this rename and stay as-is |
 
-`doc` was the last unconsidered plural; `oauth-actions` is the one remaining known exception, deliberately deferred rather than blessed.
+Both known plurals are now reconciled: `doc` (#63) and `oauth-action` (#84). No
+top-level noun is currently non-conformant to decision (2), and decision (6) has
+no remaining pending migration.

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Smoke-test `solidactions oauth-actions list|search|show` end to end.
+# Smoke-test `solidactions oauth-action list|search|view` end to end.
 #
 # By default this runs the built CLI against a real local stub server
 # (scripts/smoke-oauth-actions-server.mjs), so it needs no credentials and is
@@ -88,27 +88,27 @@ else
 fi
 
 echo
-echo "1. oauth-actions list gmail --limit 5"
-OUT=$($CLI oauth-actions list gmail --limit 5)
+echo "1. oauth-action list gmail --limit 5"
+OUT=$($CLI oauth-action list gmail --limit 5)
 check_contains "$OUT" "/gmail/v1/users/me/messages/send" "lists the send-message path"
 check_contains "$OUT" "POST" "renders the HTTP method"
 
 echo
-echo "2. oauth-actions search gmail 'list messages unread' --limit 3"
-OUT=$($CLI oauth-actions search gmail "list messages unread" --limit 3)
+echo "2. oauth-action search gmail 'list messages unread' --limit 3"
+OUT=$($CLI oauth-action search gmail "list messages unread" --limit 3)
 check_contains "$OUT" "action_id:" "search output includes action_id lines"
 check_contains "$OUT" "List Messages" "search matches the List Messages action"
 
 echo
-echo "3. oauth-actions show gmail <modifier action>"
-OUT=$($CLI oauth-actions show gmail "$GMAIL_ACTION_ID")
-check_contains "$OUT" "Paste-ready snippet:" "show renders a paste-ready snippet"
+echo "3. oauth-action view gmail <modifier action>"
+OUT=$($CLI oauth-action view gmail "$GMAIL_ACTION_ID")
+check_contains "$OUT" "Paste-ready snippet:" "view renders a paste-ready snippet"
 check_contains "$OUT" "connectionKey: ctx.vars" "modifier body wires connectionKey from ctx.vars"
 check_absent   "$OUT" "process.env" "default snippet uses ctx.vars, not process.env"
 
 echo
-echo "4. oauth-actions show google-calendar <array-query action> --json"
-OUT=$($CLI oauth-actions show google-calendar "$CALENDAR_ACTION_ID" --json)
+echo "4. oauth-action view google-calendar <array-query action> --json"
+OUT=$($CLI oauth-action view google-calendar "$CALENDAR_ACTION_ID" --json)
 check_contains "$OUT" "eventTypes" "json output exposes the array query param"
 if command -v jq >/dev/null 2>&1; then
   KEYS=$(printf '%s' "$OUT" | jq -r '.io_schema.ioExample.input.query | keys[]' | head -3)
@@ -118,15 +118,15 @@ else
 fi
 
 echo
-echo "5. oauth-actions show google-calendar <array-query action> (human)"
-OUT=$($CLI oauth-actions show google-calendar "$CALENDAR_ACTION_ID")
+echo "5. oauth-action view google-calendar <array-query action> (human)"
+OUT=$($CLI oauth-action view google-calendar "$CALENDAR_ACTION_ID")
 check_contains "$OUT" 'eventTypes=${encodeURIComponent("default")}&eventTypes=' "array query params repeat the key"
 check_absent   "$OUT" "encodeURIComponent([" "array is not stringified into one value"
 
 echo
-echo "6. oauth-actions show gmail no-such-action (404 path)"
+echo "6. oauth-action view gmail no-such-action (404 path)"
 set +e
-OUT=$($CLI oauth-actions show gmail no-such-action 2>&1)
+OUT=$($CLI oauth-action view gmail no-such-action 2>&1)
 CODE=$?
 set -e
 check_contains "$OUT" "Action not found" "404 renders the friendly not-found message"

--- a/src/commands/oauth-action-list.ts
+++ b/src/commands/oauth-action-list.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import chalk from 'chalk';
 import { getApiHeaders, requireConfigWithWorkspace } from '../utils/api';
 
-interface OAuthActionsListOptions {
+interface OAuthActionListOptions {
     json?: boolean;
     limit?: number;
 }
@@ -16,7 +16,7 @@ interface OAuthAction {
     tags?: string[];
 }
 
-export async function oauthActionsList(platform: string, options: OAuthActionsListOptions) {
+export async function oauthActionList(platform: string, options: OAuthActionListOptions) {
     const config = await requireConfigWithWorkspace();
 
     try {
@@ -45,10 +45,10 @@ export async function oauthActionsList(platform: string, options: OAuthActionsLi
             console.log(`${chalk.cyan(method)} ${chalk.white(a.path.padEnd(50))} ${chalk.gray('— ' + (a.title || ''))}`);
         }
         console.log('');
-        console.log(chalk.gray(`${actions.length} action(s) — use "solidactions oauth-actions search ${platform} <query>" to narrow, or "oauth-actions show ${platform} <action_id>" for detail.`));
+        console.log(chalk.gray(`${actions.length} action(s) — use "solidactions oauth-action search ${platform} <query>" to narrow, or "oauth-action view ${platform} <action_id>" for detail.`));
     } catch (error: any) {
         if (error.response?.status === 404 && error.response.data?.code === 'platform_unknown') {
-            console.error(chalk.red(`Unknown platform "${platform}". Run \`solidactions oauth-actions platforms\` to see available platforms.`));
+            console.error(chalk.red(`Unknown platform "${platform}". Run \`solidactions oauth-action platforms\` to see available platforms.`));
         } else if (error.response?.status === 401) {
             console.error(chalk.red('Authentication failed. Run "solidactions login --global".'));
         } else if (error.response) {

--- a/src/commands/oauth-action-platforms.ts
+++ b/src/commands/oauth-action-platforms.ts
@@ -2,11 +2,11 @@ import axios from 'axios';
 import chalk from 'chalk';
 import { getApiHeaders, requireConfigWithWorkspace } from '../utils/api';
 
-interface OAuthActionsPlatformsOptions {
+interface OAuthActionPlatformsOptions {
     json?: boolean;
 }
 
-export async function oauthActionsPlatforms(options: OAuthActionsPlatformsOptions) {
+export async function oauthActionPlatforms(options: OAuthActionPlatformsOptions) {
     const config = await requireConfigWithWorkspace();
 
     try {

--- a/src/commands/oauth-action-search.ts
+++ b/src/commands/oauth-action-search.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import chalk from 'chalk';
 import { getApiHeaders, requireConfigWithWorkspace } from '../utils/api';
 
-interface OAuthActionsSearchOptions {
+interface OAuthActionSearchOptions {
     method?: string;
     json?: boolean;
     limit?: number;
@@ -17,7 +17,7 @@ interface OAuthAction {
     tags?: string[];
 }
 
-export async function oauthActionsSearch(platform: string, query: string | undefined, options: OAuthActionsSearchOptions) {
+export async function oauthActionSearch(platform: string, query: string | undefined, options: OAuthActionSearchOptions) {
     const config = await requireConfigWithWorkspace();
 
     try {
@@ -56,10 +56,10 @@ export async function oauthActionsSearch(platform: string, query: string | undef
         }
 
         console.log(chalk.gray(`${actions.length} action(s) found.`));
-        console.log(chalk.gray(`Run 'solidactions oauth-actions show ${platform} <action_id>' for full schema + paste-ready snippet.`));
+        console.log(chalk.gray(`Run 'solidactions oauth-action view ${platform} <action_id>' for full schema + paste-ready snippet.`));
     } catch (error: any) {
         if (error.response?.status === 404 && error.response.data?.code === 'platform_unknown') {
-            console.error(chalk.red(`Unknown platform "${platform}". Run \`solidactions oauth-actions platforms\` to see available platforms.`));
+            console.error(chalk.red(`Unknown platform "${platform}". Run \`solidactions oauth-action platforms\` to see available platforms.`));
         } else if (error.response?.status === 401) {
             console.error(chalk.red('Authentication failed. Run "solidactions login --global" to re-configure.'));
         } else if (error.response) {

--- a/src/commands/oauth-action-view.ts
+++ b/src/commands/oauth-action-view.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import chalk from 'chalk';
 import { getApiHeaders, requireConfigWithWorkspace } from '../utils/api';
 
-interface OAuthActionsShowOptions {
+interface OAuthActionViewOptions {
     json?: boolean;
     var?: string;
     legacyEnv?: boolean;
@@ -32,7 +32,7 @@ interface OAuthActionDetail {
     io_schema?: IoSchema;
 }
 
-export async function oauthActionsShow(platform: string, actionId: string, options: OAuthActionsShowOptions) {
+export async function oauthActionView(platform: string, actionId: string, options: OAuthActionViewOptions) {
     const config = await requireConfigWithWorkspace();
 
     try {
@@ -62,7 +62,7 @@ export async function oauthActionsShow(platform: string, actionId: string, optio
     }
 }
 
-function renderHumanReadable(action: OAuthActionDetail, options: OAuthActionsShowOptions) {
+function renderHumanReadable(action: OAuthActionDetail, options: OAuthActionViewOptions) {
     const method = (action.method || 'GET').toUpperCase();
     const ioSchema = action.io_schema || {};
     const example = ioSchema.ioExample?.input;

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,10 +25,10 @@ import { webhookSecret } from './commands/webhook-secret';
 import { dev } from './commands/dev';
 import { aiInit } from './commands/ai-init';
 import { aiExamples } from './commands/ai-examples';
-import { oauthActionsSearch } from './commands/oauth-actions-search';
-import { oauthActionsList } from './commands/oauth-actions-list';
-import { oauthActionsShow } from './commands/oauth-actions-show';
-import { oauthActionsPlatforms } from './commands/oauth-actions-platforms';
+import { oauthActionSearch } from './commands/oauth-action-search';
+import { oauthActionList } from './commands/oauth-action-list';
+import { oauthActionView } from './commands/oauth-action-view';
+import { oauthActionPlatforms } from './commands/oauth-action-platforms';
 import { workspacesList, workspaceSet } from './commands/workspaces';
 import { skillPush } from './commands/skill-push';
 import { skillPublish } from './commands/skill-publish';
@@ -512,46 +512,46 @@ Where the pin is saved (--local / --global):
     });
 
 // =============================================================================
-// oauth-actions <subcommand>
+// oauth-action <subcommand>
 // =============================================================================
 
-const oauthActionsCmd = program.command('oauth-actions').description('Discover OAuth-backed API operations callable via the SA proxy');
+const oauthActionCmd = program.command('oauth-action').description('Discover OAuth-backed API operations callable via the SA proxy');
 
-oauthActionsCmd
+oauthActionCmd
     .command('search <platform> [query]')
     .description('Search available actions for a connected platform')
     .option('--method <method>', 'Filter by HTTP method (GET, POST, etc.)')
     .option('--limit <n>', 'Maximum results to return', (v) => parseInt(v, 10))
     .option('--json', 'Emit raw JSON for AI/script consumption')
     .action((platform, query, options) => {
-        oauthActionsSearch(platform, query, options);
+        oauthActionSearch(platform, query, options);
     });
 
-oauthActionsCmd
+oauthActionCmd
     .command('list <platform>')
     .description('List actions for a connected platform')
     .option('--limit <n>', 'Maximum results to return', (v) => parseInt(v, 10))
     .option('--json', 'Emit raw JSON for AI/script consumption')
     .action((platform, options) => {
-        oauthActionsList(platform, options);
+        oauthActionList(platform, options);
     });
 
-oauthActionsCmd
-    .command('show <platform> <action-id>')
+oauthActionCmd
+    .command('view <platform> <action-id>')
     .description('Show full schema, example body, and a paste-ready fetch snippet for one action')
     .option('--json', 'Emit raw JSON for AI/script consumption')
     .option('--var <NAME>', 'ctx.vars variable name for the connection (default: YOUR_CONNECTION)')
     .option('--legacy-env', 'Emit the deprecated process.env-based snippet (will be removed in a future release)')
     .action((platform, actionId, options) => {
-        oauthActionsShow(platform, actionId, options);
+        oauthActionView(platform, actionId, options);
     });
 
-oauthActionsCmd
+oauthActionCmd
     .command('platforms')
     .description('List available OAuth-backed platforms')
     .option('--json', 'Emit raw JSON for AI/script consumption')
     .action((options) => {
-        oauthActionsPlatforms(options);
+        oauthActionPlatforms(options);
     });
 
 // =============================================================================

--- a/tests/oauth-action-fixtures.test.ts
+++ b/tests/oauth-action-fixtures.test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { describe, expect, it } from 'vitest';
-import { buildSnippet } from '../src/commands/oauth-actions-show';
+import { buildSnippet } from '../src/commands/oauth-action-view';
 
 /**
  * Fixture-driven coverage for the two `buildSnippet` behaviours that had no
@@ -22,7 +22,7 @@ const CALENDAR_EVENTS_LIST = loadFixture('calendar-events-list');
 const X_PICA_LEAK = loadFixture('synthetic-x-pica-leak');
 
 // ---------------------------------------------------------------------------
-// Array query params — repeated-key serialization (oauth-actions-show.ts:157)
+// Array query params — repeated-key serialization (oauth-action-view.ts:157)
 // ---------------------------------------------------------------------------
 
 describe('buildSnippet — array query params serialize as repeated keys', () => {
@@ -75,7 +75,7 @@ describe('buildSnippet — array query params serialize as repeated keys', () =>
 });
 
 // ---------------------------------------------------------------------------
-// Proxy-managed header filter (oauth-actions-show.ts:301-308)
+// Proxy-managed header filter (oauth-action-view.ts:301-308)
 // ---------------------------------------------------------------------------
 
 describe('buildSnippet — proxy-managed header filter strips leaked internals', () => {

--- a/tests/oauth-action-noun-rename.test.ts
+++ b/tests/oauth-action-noun-rename.test.ts
@@ -92,3 +92,71 @@ describe('oauth-action noun + view verb rename (ADR 0001 decisions 2 and 6)', ()
         expect(result.stderr).toMatch(/unknown command 'show'/);
     });
 });
+
+/**
+ * Positive half: the assertions above prove the OLD forms are gone, which a
+ * broken build would also satisfy — "unknown command" is what you get when a
+ * command fails to register at all. These prove the NEW form actually parses
+ * and dispatches.
+ *
+ * Each case asserts on Commander's rendered usage line, which echoes the full
+ * resolved command path (`solidactions oauth-action view`). That string only
+ * appears if the parser walked the new noun *and* the new verb — so a
+ * dispatch regression fails here, not just in scripts/smoke.sh.
+ *
+ * Option text is asserted on flag names only. Descriptions wrap at the
+ * terminal width (`--var <NAME>`'s "(default: YOUR_CONNECTION)" splits across
+ * two lines), so matching prose would be brittle.
+ */
+describe('oauth-action subcommands positively parse and dispatch', () => {
+    it('`oauth-action view --help` exits 0 with the view usage line and its options', () => {
+        const result = runCli(['oauth-action', 'view', '--help']);
+
+        expect(result.status).toBe(0);
+        expect(result.stdout).toContain('Usage: solidactions oauth-action view [options] <platform> <action-id>');
+        expect(result.stdout).toContain('--json');
+        expect(result.stdout).toContain('--var <NAME>');
+        expect(result.stdout).toContain('--legacy-env');
+    });
+
+    it('`oauth-action list --help` exits 0 with the list usage line and its options', () => {
+        const result = runCli(['oauth-action', 'list', '--help']);
+
+        expect(result.status).toBe(0);
+        expect(result.stdout).toContain('Usage: solidactions oauth-action list [options] <platform>');
+        expect(result.stdout).toContain('--limit <n>');
+        expect(result.stdout).toContain('--json');
+    });
+
+    it('`oauth-action search --help` exits 0 with the search usage line and its options', () => {
+        const result = runCli(['oauth-action', 'search', '--help']);
+
+        expect(result.status).toBe(0);
+        expect(result.stdout).toContain('Usage: solidactions oauth-action search [options] <platform> [query]');
+        expect(result.stdout).toContain('--method <method>');
+        expect(result.stdout).toContain('--limit <n>');
+        expect(result.stdout).toContain('--json');
+    });
+
+    it('`oauth-action platforms --help` exits 0 with the platforms usage line', () => {
+        const result = runCli(['oauth-action', 'platforms', '--help']);
+
+        expect(result.status).toBe(0);
+        expect(result.stdout).toContain('Usage: solidactions oauth-action platforms [options]');
+        expect(result.stdout).toContain('--json');
+    });
+
+    /**
+     * Dispatch proof that does not go through --help (which Commander handles
+     * before argument validation) and needs no network or credentials: reaching
+     * `view`'s OWN argument parser produces a missing-argument error. Contrast
+     * with `oauth-action show`, which dies earlier at "unknown command 'show'".
+     */
+    it('`oauth-action view` with no args reaches view\'s argument parser', () => {
+        const result = runCli(['oauth-action', 'view']);
+
+        expect(result.status).not.toBe(0);
+        expect(result.stderr).toMatch(/missing required argument 'platform'/);
+        expect(result.stderr).not.toMatch(/unknown command/);
+    });
+});

--- a/tests/oauth-action-noun-rename.test.ts
+++ b/tests/oauth-action-noun-rename.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Boundary pin for the BREAKING `oauth-actions` -> `oauth-action` rename plus
+ * the `show` -> `view` verb migration (#84).
+ *
+ * ADR 0001 decision (2) mandates singular top-level nouns and decision (6)
+ * makes `view` the canonical "show one" verb. `oauth-actions show` violated
+ * both and was migrated with NO deprecation alias for either the old noun or
+ * the old verb. These assertions are the automated pin for that contract —
+ * without them, a well-meaning "restore backward compatibility" alias could
+ * reintroduce either old form silently.
+ *
+ * Note the word "oauth-actions" legitimately survives elsewhere in the CLI: the
+ * `/api/v1/oauth-actions` REST paths, the `oauth_actions` JSON response key,
+ * and the bundled `solidactions-oauth-actions` skill filename. So the
+ * no-plural assertion anchors on the help output's command column, not on a
+ * whole-source grep.
+ *
+ * Test-double policy: spawns the real built CLI binary (dist/index.js) — no
+ * mock/spy/stub libraries. Matches tests/doc-noun-rename.test.ts.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import * as childProcess from 'child_process';
+import { describe, expect, it } from 'vitest';
+
+const CLI_BINARY = path.resolve(__dirname, '../dist/index.js');
+
+function runCli(args: string[]): childProcess.SpawnSyncReturns<string> {
+    return childProcess.spawnSync(process.execPath, [CLI_BINARY, ...args], {
+        encoding: 'utf8',
+        timeout: 15_000,
+    });
+}
+
+describe('oauth-action noun + view verb rename (ADR 0001 decisions 2 and 6)', () => {
+    it('CLI is built', () => {
+        expect(fs.existsSync(CLI_BINARY)).toBe(true);
+    });
+
+    it('top-level --help lists `oauth-action` as a command', () => {
+        const result = runCli(['--help']);
+
+        // Command column: leading indent, the noun, then padding before the
+        // description. `oauth-actions` would not match (next char is `s`).
+        expect(result.stdout).toMatch(/^\s+oauth-action\s+\S/m);
+    });
+
+    it('top-level --help does NOT list `oauth-actions` as a command', () => {
+        const result = runCli(['--help']);
+
+        expect(result.stdout).not.toMatch(/^\s+oauth-actions\s/m);
+    });
+
+    it('`oauth-action --help` renders search/list/view/platforms', () => {
+        const result = runCli(['oauth-action', '--help']);
+
+        expect(result.status).toBe(0);
+        expect(result.stdout).toMatch(/^\s+search\s/m);
+        expect(result.stdout).toMatch(/^\s+list\s/m);
+        expect(result.stdout).toMatch(/^\s+view\s/m);
+        expect(result.stdout).toMatch(/^\s+platforms\s/m);
+    });
+
+    it('`oauth-action --help` does NOT list a `show` subcommand', () => {
+        const result = runCli(['oauth-action', '--help']);
+
+        expect(result.stdout).not.toMatch(/^\s+show\s/m);
+    });
+
+    // The no-alias half of the breaking change: the old noun must genuinely not
+    // exist, not be a hidden passthrough. Commander's "did you mean" hint is a
+    // suggestion on an unknown command, not a working alias.
+    it('`oauth-actions list` fails as an unknown command (no noun alias)', () => {
+        const result = runCli(['oauth-actions', 'list', 'gmail']);
+
+        expect(result.status).not.toBe(0);
+        expect(result.stderr).toMatch(/unknown command 'oauth-actions'/);
+    });
+
+    it('`oauth-actions show` fails as an unknown command (old noun AND old verb)', () => {
+        const result = runCli(['oauth-actions', 'show', 'gmail', 'some-action-id']);
+
+        expect(result.status).not.toBe(0);
+        expect(result.stderr).toMatch(/unknown command 'oauth-actions'/);
+    });
+
+    // The verb half, isolated: even under the NEW noun, `show` is gone.
+    it('`oauth-action show` fails as an unknown subcommand (no verb alias)', () => {
+        const result = runCli(['oauth-action', 'show', 'gmail', 'some-action-id']);
+
+        expect(result.status).not.toBe(0);
+        expect(result.stderr).toMatch(/unknown command 'show'/);
+    });
+});

--- a/tests/oauth-action-platform-errors.test.ts
+++ b/tests/oauth-action-platform-errors.test.ts
@@ -1,9 +1,9 @@
 /**
- * oauth-actions: distinguish an unknown platform (404, forward-compatible
+ * oauth-action: distinguish an unknown platform (404, forward-compatible
  * with the app-side `platform_unknown` error code) from a known platform
  * with zero matching actions (200, empty array) — both `list` and `search`
  * previously printed the same "No actions found." for both cases. Also
- * covers the new `oauth-actions platforms` subcommand.
+ * covers the `oauth-action platforms` subcommand.
  *
  * Test-double policy: real in-process HTTP server (Node's http.createServer),
  * ProcessExitError-throw pattern for process.exit, real console.log/error
@@ -12,9 +12,9 @@
  */
 import * as http from 'http';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
-import { oauthActionsList } from '../src/commands/oauth-actions-list';
-import { oauthActionsSearch } from '../src/commands/oauth-actions-search';
-import { oauthActionsPlatforms } from '../src/commands/oauth-actions-platforms';
+import { oauthActionList } from '../src/commands/oauth-action-list';
+import { oauthActionSearch } from '../src/commands/oauth-action-search';
+import { oauthActionPlatforms } from '../src/commands/oauth-action-platforms';
 import { makeTmpEnv, writeGlobal } from './helpers';
 
 class ProcessExitError extends Error {
@@ -47,7 +47,7 @@ afterAll(() => {
     });
 });
 
-describe('oauth-actions: unknown platform vs. 0 matches', () => {
+describe('oauth-action: unknown platform vs. 0 matches', () => {
     let env: ReturnType<typeof makeTmpEnv>;
     let originalExit: typeof process.exit;
     let logLines: string[];
@@ -87,7 +87,7 @@ describe('oauth-actions: unknown platform vs. 0 matches', () => {
         nextStatus = 200;
         nextBody = { oauth_actions: [] };
 
-        await oauthActionsList('gmail', {});
+        await oauthActionList('gmail', {});
 
         expect(logLines.some((l) => l.includes('No actions found'))).toBe(true);
         expect(errLines.join('\n')).not.toContain('Unknown platform');
@@ -99,7 +99,7 @@ describe('oauth-actions: unknown platform vs. 0 matches', () => {
 
         let caught: ProcessExitError | null = null;
         try {
-            await oauthActionsList('not-a-platform', {});
+            await oauthActionList('not-a-platform', {});
         } catch (e) {
             if (e instanceof ProcessExitError) caught = e;
             else throw e;
@@ -107,7 +107,7 @@ describe('oauth-actions: unknown platform vs. 0 matches', () => {
 
         expect(caught?.code).toBe(1);
         expect(errLines.join('\n')).toContain('Unknown platform "not-a-platform"');
-        expect(errLines.join('\n')).toContain('oauth-actions platforms');
+        expect(errLines.join('\n')).toContain('oauth-action platforms');
         expect(logLines.some((l) => l.includes('No actions found'))).toBe(false);
     });
 
@@ -115,7 +115,7 @@ describe('oauth-actions: unknown platform vs. 0 matches', () => {
         nextStatus = 200;
         nextBody = { oauth_actions: [] };
 
-        await oauthActionsSearch('gmail', 'send', {});
+        await oauthActionSearch('gmail', 'send', {});
 
         expect(logLines.some((l) => l.includes('No actions found'))).toBe(true);
         expect(errLines.join('\n')).not.toContain('Unknown platform');
@@ -127,7 +127,7 @@ describe('oauth-actions: unknown platform vs. 0 matches', () => {
 
         let caught: ProcessExitError | null = null;
         try {
-            await oauthActionsSearch('not-a-platform', 'send', {});
+            await oauthActionSearch('not-a-platform', 'send', {});
         } catch (e) {
             if (e instanceof ProcessExitError) caught = e;
             else throw e;
@@ -135,7 +135,7 @@ describe('oauth-actions: unknown platform vs. 0 matches', () => {
 
         expect(caught?.code).toBe(1);
         expect(errLines.join('\n')).toContain('Unknown platform "not-a-platform"');
-        expect(errLines.join('\n')).toContain('oauth-actions platforms');
+        expect(errLines.join('\n')).toContain('oauth-action platforms');
     });
 
     it('list: a genuine 404 that is NOT platform_unknown still falls through to the generic "Failed: 404" path', async () => {
@@ -144,7 +144,7 @@ describe('oauth-actions: unknown platform vs. 0 matches', () => {
 
         let caught: ProcessExitError | null = null;
         try {
-            await oauthActionsList('gmail', {});
+            await oauthActionList('gmail', {});
         } catch (e) {
             if (e instanceof ProcessExitError) caught = e;
             else throw e;
@@ -161,7 +161,7 @@ describe('oauth-actions: unknown platform vs. 0 matches', () => {
 
         let caught: ProcessExitError | null = null;
         try {
-            await oauthActionsSearch('gmail', 'send', {});
+            await oauthActionSearch('gmail', 'send', {});
         } catch (e) {
             if (e instanceof ProcessExitError) caught = e;
             else throw e;
@@ -176,7 +176,7 @@ describe('oauth-actions: unknown platform vs. 0 matches', () => {
         nextStatus = 200;
         nextBody = { platforms: ['gmail', 'slack', 'hubspot'] };
 
-        await oauthActionsPlatforms({});
+        await oauthActionPlatforms({});
 
         expect(logLines).toContain('gmail');
         expect(logLines).toContain('slack');
@@ -187,7 +187,7 @@ describe('oauth-actions: unknown platform vs. 0 matches', () => {
         nextStatus = 200;
         nextBody = { platforms: ['gmail', 'slack'] };
 
-        await oauthActionsPlatforms({ json: true });
+        await oauthActionPlatforms({ json: true });
 
         const parsed = JSON.parse(stdoutChunks.join(''));
         expect(parsed).toEqual(['gmail', 'slack']);

--- a/tests/oauth-action-view.test.ts
+++ b/tests/oauth-action-view.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildSnippet } from '../src/commands/oauth-actions-show';
+import { buildSnippet } from '../src/commands/oauth-action-view';
 
 // ---------------------------------------------------------------------------
 // Fixtures

--- a/tests/proxy-contract.test.ts
+++ b/tests/proxy-contract.test.ts
@@ -14,7 +14,7 @@
 
 import * as http from 'http';
 import { describe, expect, it, beforeAll, afterAll } from 'vitest';
-import { buildSnippet } from '../src/commands/oauth-actions-show';
+import { buildSnippet } from '../src/commands/oauth-action-view';
 
 // ---------------------------------------------------------------------------
 // Stub HTTP server that mirrors ProxyController's header validation


### PR DESCRIPTION
Closes #84

ADR 0001 decision (2) mandates **singular top-level nouns**; decision (6) makes **`view`** the canonical "show one" verb. `oauth-actions show` violated both. PR #81 recorded it as *deferred-not-blessed*; this executes it in one pass, as that deferral anticipated.

Sanctioned by Peter on the issue (2026-07-23): *"do 1, no need to keep an alias of the olde names or verb... besure to update exmaples docs and skills"* — breaking, **no alias for the old noun or the old verb**.

---

## ⚠️ BREAKING CHANGE

**`oauth-actions` → `oauth-action`, and the `show` subcommand → `view`.** No aliases, no deprecation period. Old invocations fail immediately.

| Old (removed) | New |
| --- | --- |
| `solidactions oauth-actions search <platform> [query]` | `solidactions oauth-action search <platform> [query]` |
| `solidactions oauth-actions list <platform>` | `solidactions oauth-action list <platform>` |
| `solidactions oauth-actions show <platform> <action-id>` | `solidactions oauth-action view <platform> <action-id>` |
| `solidactions oauth-actions platforms` | `solidactions oauth-action platforms` |

All flags, arguments, and behavior are unchanged — only the noun and the one verb move.

```
$ solidactions oauth-actions list gmail
error: unknown command 'oauth-actions'
(Did you mean oauth-action?)

$ solidactions oauth-action show gmail <id>
error: unknown command 'show'
```

Commander's "did you mean" is a suggestion on an unknown command, **not** an alias — both old forms genuinely do not exist.

**Who this breaks:** any script, CI job, cron, workflow, or agent skill invoking `solidactions oauth-actions …` or `… show …`. See the cross-repo sweep below — there are live callers outside this repo.

---

## Deliberately NOT renamed

`oauth-actions` survives in this repo in senses that are *not* the CLI noun:

- the **`/api/v1/oauth-actions`** REST paths (`list`, `search`, `platforms`, `{platform}/{actionId}`) — server contract, renaming would 404 every call
- the **`oauth_actions`** JSON response key — API contract
- the **`solidactions-oauth-actions`** bundled skill filename (`src/utils/skills.ts`, `scripts/smoke-init.mjs`, `tests/skills-manifest.test.ts`, README §"Verify the generated AI tooling") — this is fetched by path from the **`solidactions-examples`** repo. Renaming it here without renaming it there makes `solidactions ai init` 404. Cross-repo, listed below.
- **`scripts/smoke-oauth-actions-server.mjs`** — the stub *server* implementing the (unchanged) REST path; its name still describes what it mocks
- **`docs/superpowers/plans/2026-05-26-cli-sop-conformer-248.md`** — a dated historical plan artifact recording what the command was called at the time. Rewriting it would falsify the record.

## What changed

- `src/commands/oauth-actions-{list,search,platforms}.ts` → `oauth-action-*.ts`, and `oauth-actions-show.ts` → **`oauth-action-view.ts`**; exports `oauthActionsList/Search/Platforms/Show` → `oauthActionList/Search/Platforms/**View**`, and the `OAuthActions*Options` types → `OAuthAction*Options` / `OAuthActionViewOptions`
- `src/index.ts` — the `oauth-action` command group and its four subcommands
- help text and error hints inside the commands (e.g. *"Run `solidactions oauth-action platforms` to see available platforms"*, *"use `oauth-action view <platform> <action_id>` for detail"*)
- `tests/oauth-actions-*.test.ts` → `tests/oauth-action-*.test.ts` — **updated, not deleted**; assertions on user-facing strings now expect the new forms
- `scripts/smoke.sh` — all six steps now invoke `oauth-action list|search|view`
- `README.md` — release-checklist items 2 and 4
- `docs/decisions/0001-cli-command-taxonomy.md` — see below

## ADR conformance (item 3)

The conformance table PR #81 added under *Consequences* had `oauth-actions` as **Not conformant / deferred**. That row is now **`oauth-action` — Conformant since #84**, recording both the noun rename and the verb migration, and naming the three things deliberately left alone. Decision (6) is annotated *(Executed in #84)*.

The closing line changed from *"`oauth-actions` is the one remaining known exception, deliberately deferred rather than blessed"* to a statement that both known plurals (`doc` #63, `oauth-action` #84) are reconciled and decision (6) has no pending migration.

## Tests (item 5)

Existing tests migrated to the new names. **New: `tests/oauth-action-noun-rename.test.ts`** — 8 assertions spawning the real built binary (`dist/index.js`), modeled on `tests/doc-noun-rename.test.ts`:

- `--help` lists `oauth-action`, and does **not** list `oauth-actions`
- `oauth-action --help` renders `search`/`list`/`view`/`platforms`, and does **not** list `show`
- `oauth-actions list …` → non-zero + `unknown command 'oauth-actions'`
- `oauth-actions show …` → non-zero (old noun *and* old verb together)
- `oauth-action show …` → non-zero + `unknown command 'show'` (verb half, isolated)

**Falsification-checked.** Reintroducing `.alias('oauth-actions')` and `.alias('show')` turns **5 of the 8 red**, including `oauth-action show` reaching the API and returning `Action not found` — proof the verb alias would have silently worked. Reverted after checking.

## Verification

```
$ npm run build          # clean (tsc)
$ npm test               # Test Files 80 passed (80) / Tests 763 passed (763)
$ bash scripts/smoke.sh  # Smoke passed — all 6 steps, 13 checks
```

The smoke exercises `oauth-action list|search|view` (including `--json`, the array-query-param path, and the 404 branch) against the local stub server.

### Live smoke — NOT run, needs the review pair ⚠️

Item 6 asked for a live `oauth-action list <platform>` / `view` against the dev stack *if available*. Taking the documented fallback:

- **`https://e2e.formup.cc`** (the dev/e2e stack) is **reachable but not authenticable** — `/api/v1/oauth-actions/platforms` returns `401` both anonymously and with the key stored in `solidactions-app/.solidactions/config.json`, which is stale. No `SOLIDACTIONS_API_KEY` in the app's `.env`.
- A local stack answers on `:8000` (401, so routed) but I have no credential for it.
- Production (`app.solidactions.com`) *is* reachable with valid configured credentials, but the sanctioned scope named the dev stack, so I did not substitute a production run on my own initiative.

**Ask for the review pair:** run these two against any authenticated stack and confirm real API-shaped output:

```bash
solidactions oauth-action list gmail --limit 5
solidactions oauth-action view gmail <action_id> --json
```

The stub smoke covers the full command path and response parsing; what is missing is only confirmation against a live server's real payload.

## Version (item 6)

**This is a breaking release: next tag is `v3.0.0`.** No tag, no publish, no version bump in this PR.

Note for the releaser: `package.json` says `1.33.0`, but publishing is **tag-derived** (#78) and the live npm version is **`2.0.2`** — so the major bump from what users actually have is 2.x → **3.0.0**, matching the sanction comment. `package.json`'s number is not the source of truth here.

---

## Cross-repo sweep (item 4) — READ-ONLY, nothing committed outside this repo

Every `oauth-actions` hit in the sibling repos. **No edits were made to any of these.** Routing is the PM's call.

### 🔴 `solidactions-examples` — highest priority, user-facing

Peter's sanction explicitly named examples and skills. This repo is fetched at runtime by `solidactions ai init`.

| File | Lines | What |
| --- | --- | --- |
| `skills/solidactions-oauth-actions.md` | frontmatter `name:`/`description:`, and body lines 9, 12, 53, 69, 86, 89, 92, 99, 102, 105, 108, 227 | **The bundled skill AI agents actually follow.** Teaches `oauth-actions search`/`show` as the discovery flow — every one of those commands is now dead. This is the single highest-impact straggler: agents will emit commands that hard-fail. |
| `features-examples/src/oauth-workflow.ts` | 21, 22, 56 | Doc comments telling users to run `oauth-actions search`/`show` |
| `features-examples/README.md` | 84 | `solidactions oauth-actions search github <query>` |
| `google-calendar-sync/src/google-calendar.ts` | 13 | `oauth-actions search google-calendar <query>` |
| `google-calendar-sync/src/sheets.ts` | 25 | `oauth-actions search google-sheets <query>` |

⚠️ **Filename coupling:** the skill file is `skills/solidactions-oauth-actions.md`, fetched by exact path from `src/utils/skills.ts:11`. If that file is renamed, `solidactions-cli`, `solidactions-ts-sdk/scripts/check-docs.mjs`, and `scripts/smoke-init.mjs` must change in the same release or `ai init` 404s. Recommend: **update the skill's body commands now** (safe, decoupled), and treat the *filename* rename as a separate coordinated change — or leave the filename alone, which is what this PR assumes.

### 🟠 `solidactions-app` — one live runtime string

| File | Lines | What |
| --- | --- | --- |
| `app/Http/Controllers/ProxyController.php` | **52, 59** | 🔴 **Live user-facing error hint**: `'hint' => 'run \`solidactions oauth-actions show <platform> <action-id>\` to see required headers'`. Served on a real 4xx — will instruct users to run a dead command. **Should ship alongside the v3.0.0 CLI.** |
| `routes/api.php` | 252–254 | REST routes — **correctly unchanged**, this PR does not touch the API surface |
| `tests/Feature/Api/Actions/{ShowActionTest,ListPlatformsTest,SearchActionsTest}.php`, `tests/Feature/Api/PicaActionControllerTest.php` | many | Assert `/api/v1/oauth-actions` paths — **correctly unchanged** |
| `docs/decisions.md` | 312 | Prose: "Use `solidactions oauth-actions show` to find an action_id" — stale instruction |
| `docs/platform-reference.md` | 841, 864, 865, 866, 873 | Live how-to docs with `oauth-actions list/search/show` command blocks — **stale, should update** |
| `docs/superpowers/specs/2026-07-04-scoped-api-keys-design.md` | 28 | Prose "`oauth-actions` discovery reads" (API sense) |
| `docs/superpowers/specs/2026-07-04-ux-sweep-b-design.md` | 205 | References the skill filename |
| `docs/superpowers/specs/2026-04-30-pica-action-discovery-design.md` | 41, 51, 52, 82, 272–274, 309, 311, 315, 319, 321, 346, 347, 452, 453, 485–488 | Dated design spec — historical, recommend leaving |
| `docs/superpowers/plans/2026-04-30-pica-action-discovery.md` | 9, 1411–1785 (many), 2661, 2673, 2778–2785, 2840–3193 | Dated plan artifact — historical, recommend leaving |
| `docs/superpowers/plans/2026-07-05-stress-test-fixes-spec.md` | 55 | Dated plan — historical |

### 🟡 `solidactions-ts-sdk` — skill-name references only

| File | Lines | What |
| --- | --- | --- |
| `README.md` | 216 | Lists `solidactions-oauth-actions` among installed skills — skill *filename*, tracks whatever `solidactions-examples` does |
| `scripts/check-docs.mjs` | 14 | Hardcoded skill filename in the manifest check — **breaks if the skill file is renamed** |
| `__worktrees/issues/github-190/{README.md,scripts/check-docs.mjs}` | 216, 14 | Same, in a stale worktree — ignore |

No SDK code, MCP tool description, or test references the CLI *command*. **The TS SDK needs no change unless the skill filename is renamed.**

### Suggested routing

1. **Ship with v3.0.0:** `solidactions-app` `ProxyController.php:52,59` (live hint string).
2. **Ship with v3.0.0:** `solidactions-examples` `skills/solidactions-oauth-actions.md` body commands — this is what agents read.
3. **Follow-up:** `solidactions-app/docs/platform-reference.md`, `docs/decisions.md:312`; remaining `solidactions-examples` example files.
4. **Separate coordinated change (or never):** the `solidactions-oauth-actions` *filename*, which spans all three repos.
5. **Leave alone:** every dated spec/plan under `docs/superpowers/`, and all `/api/v1/oauth-actions` REST paths and their tests.

---

No merge, no tag, no publish performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
