### PR TITLE
Report deployed workflow Git provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,13 @@ deploy:
 
 The CLI prints a one-line summary of what it bundled, e.g. `Bundling 312 files (.env excluded; .gitignore applied; 2 exclude rules)`, and warns about any symlinks it skipped.
 
+Deploys also transmit client-reported Git provenance when it can be collected:
+commit, branch/tag, subject/date, sanitized remote, and whether the deployed
+subtree was dirty. The CLI prints the local revision before upload and confirms
+the server-recorded revision after the build. Use `--no-git-metadata` or
+`SOLIDACTIONS_NO_GIT_METADATA=1` to opt out. Deploying a non-Git directory
+continues normally without revision metadata.
+
 ## Commands
 
 Use `solidactions <command> --help` for full flag details on any command.
@@ -161,10 +168,17 @@ Use `solidactions <command> --help` for full flag details on any command.
 | Command | Key Flags | Description |
 |---------|-----------|-------------|
 | `project create <name>` | `-e` | Create an empty project (no source/build); `-e` defaults to `production` |
-| `project deploy <name> [path]` | `-e`, `--create`, `--config-only` | Deploy or sync config only |
+| `project deploy <name> [path]` | `-e`, `--create`, `--config-only`, `--no-git-metadata` | Deploy or sync config only |
+| `project view <project>` | `-e` | View status and client-reported deployed revision |
 | `project pull <name> [path]` | `-y` | Pull source (warns before overwriting) |
 | `project logs <name>` | | View build logs |
 | `project list` | | List all projects |
+
+For `project view`, omitting `--env` treats `<project>` as an exact slug.
+Passing `--env production` uses the supplied production name/slug unchanged;
+`--env staging` and `--env dev` derive the same suffixed slug as deploy. This
+is deliberately different from historical commands such as `run start`,
+which default to dev.
 
 ### run
 

--- a/README.md
+++ b/README.md
@@ -143,9 +143,10 @@ deploy:
 The CLI prints a one-line summary of what it bundled, e.g. `Bundling 312 files (.env excluded; .gitignore applied; 2 exclude rules)`, and warns about any symlinks it skipped.
 
 Deploys also transmit client-reported Git provenance when it can be collected:
-commit, branch/tag, subject/date, sanitized remote, and whether the deployed
-subtree was dirty. The CLI prints the local revision before upload and confirms
-the server-recorded revision after the build. Use `--no-git-metadata` or
+commit, branch/tag, subject/date, sanitized remote repository URL (with
+credentials stripped), and whether the deployed subtree was dirty. The CLI
+prints the local revision before upload and confirms the server-recorded
+revision after the build. Use `--no-git-metadata` or
 `SOLIDACTIONS_NO_GIT_METADATA=1` to opt out. Deploying a non-Git directory
 continues normally without revision metadata.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "vitest": "^4.1.5"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@solidactions/cli",
-  "version": "1.34.0",
+  "version": "1.33.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@solidactions/cli",
-      "version": "1.34.0",
+      "version": "1.33.0",
       "license": "MIT",
       "dependencies": {
         "archiver": "^8.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.34.0",
       "license": "MIT",
       "dependencies": {
-        "archiver": "^7.0.0",
+        "archiver": "^8.0.0",
         "axios": "^1.18.1",
         "chalk": "^4.1.2",
         "commander": "^11.0.0",
@@ -19,14 +19,14 @@
         "ignore": "^7.0.5",
         "js-yaml": "^4.3.0",
         "prompts": "^2.4.2",
-        "tar": "^7.5.20"
+        "tar": "^7.5.22"
       },
       "bin": {
         "solidactions": "dist/index.js"
       },
       "devDependencies": {
         "@solidactions/sdk": "^0.7.3",
-        "@types/archiver": "^6.0.0",
+        "@types/archiver": "^8.0.0",
         "@types/fs-extra": "^11.0.0",
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^20.0.0",
@@ -71,23 +71,6 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/@isaacs/fs-minipass": {
@@ -136,16 +119,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
-      }
-    },
-    "node_modules/@pkgjs/parseargs": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -496,12 +469,13 @@
       }
     },
     "node_modules/@types/archiver": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-6.0.4.tgz",
-      "integrity": "sha512-ULdQpARQ3sz9WH4nb98mJDYA0ft2A8C4f4fovvUcFwINa1cgGjY36JCAYuP5YypRq4mco1lJp1/7jEMS2oR0Hg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-8.0.0.tgz",
+      "integrity": "sha512-YpXPbEuv9+eUIPPQWUPahj3cvs9isWRuF+J4z+KbdYVDO3rWorWQFxUVHnwPu2AgKwvgpki5F2VMX0Xx+mX45A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@types/node": "*",
         "@types/readdir-glob": "*"
       }
     },
@@ -910,18 +884,6 @@
         "node": ">= 6.0.0"
       }
     },
-    "node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -938,39 +900,23 @@
       }
     },
     "node_modules/archiver": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
-      "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-8.0.0.tgz",
+      "integrity": "sha512-fV1orZfsnPn9BaSByR/qE67rJCLJEy2Ox5bq7nJh+jquWaNh6Sfec75kJ2T6PtdGUbPQlrVoSVCEOa5SdiTQ1g==",
       "license": "MIT",
       "dependencies": {
-        "archiver-utils": "^5.0.2",
         "async": "^3.2.4",
         "buffer-crc32": "^1.0.0",
-        "readable-stream": "^4.0.0",
-        "readdir-glob": "^1.1.2",
-        "tar-stream": "^3.0.0",
-        "zip-stream": "^6.0.1"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/archiver-utils": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
-      "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
-      "license": "MIT",
-      "dependencies": {
-        "glob": "^10.0.0",
-        "graceful-fs": "^4.2.0",
-        "is-stream": "^2.0.1",
+        "is-stream": "^4.0.0",
         "lazystream": "^1.0.0",
-        "lodash": "^4.17.15",
         "normalize-path": "^3.0.0",
-        "readable-stream": "^4.0.0"
+        "readable-stream": "^4.0.0",
+        "readdir-glob": "^3.0.0",
+        "tar-stream": "^3.0.0",
+        "zip-stream": "^7.0.2"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">=18"
       }
     },
     "node_modules/argparse": {
@@ -1028,10 +974,13 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/bare-events": {
       "version": "2.8.2",
@@ -1068,12 +1017,15 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/buffer": {
@@ -1197,19 +1149,19 @@
       }
     },
     "node_modules/compress-commons": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
-      "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-7.0.1.tgz",
+      "integrity": "sha512-g0S8KAD8qf4+V//pr3BfB1aBnARLXNz2Gx+jmHU0LEriUuoQUOPOulVquHKTJ8+EAIIO7fhseNDr9wK5Q9FKBQ==",
       "license": "MIT",
       "dependencies": {
         "crc-32": "^1.2.0",
-        "crc32-stream": "^6.0.0",
-        "is-stream": "^2.0.1",
+        "crc32-stream": "^7.0.1",
+        "is-stream": "^4.0.0",
         "normalize-path": "^3.0.0",
         "readable-stream": "^4.0.0"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">=18"
       }
     },
     "node_modules/content-disposition": {
@@ -1292,30 +1244,16 @@
       }
     },
     "node_modules/crc32-stream": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
-      "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-7.0.1.tgz",
+      "integrity": "sha512-IBWsY8xznyQrcHn8h4bC8/4ErNke5elzgG8GcqF4RFPw6aHkWWRc7Tgw6upjaTX/CT/yQgqYENkxYsTYN+hW2g==",
       "license": "MIT",
       "dependencies": {
         "crc-32": "^1.2.0",
         "readable-stream": "^4.0.0"
       },
       "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/cross-spawn": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
+        "node": ">=18"
       }
     },
     "node_modules/debug": {
@@ -1415,23 +1353,11 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/eastasianwidth": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "license": "MIT"
-    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -1594,22 +1520,6 @@
         }
       }
     },
-    "node_modules/foreground-child": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "license": "ISC",
-      "dependencies": {
-        "cross-spawn": "^7.0.6",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/form-data": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
@@ -1709,27 +1619,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/gopd": {
@@ -1918,22 +1807,13 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -1957,27 +1837,6 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
-    },
-    "node_modules/isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "license": "ISC"
-    },
-    "node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
     },
     "node_modules/js-yaml": {
       "version": "4.3.0",
@@ -2414,18 +2273,6 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "license": "MIT"
-    },
-    "node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "license": "ISC"
-    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2477,15 +2324,15 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "license": "ISC",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.2"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -2580,12 +2427,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/package-json-from-dist": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "license": "BlueOak-1.0.0"
-    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -2594,31 +2435,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/path-key": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/pathe": {
@@ -2731,24 +2547,18 @@
       }
     },
     "node_modules/readdir-glob": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
-      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-3.0.0.tgz",
+      "integrity": "sha512-AhNB2KgKeVJr16nK9LLZbJNWnYoT23ZrumNKFDebHBdkC8KHSqWo871JAUhoWC/RtjEVdqNMFpM6qrwRbaUqpw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "minimatch": "^5.1.0"
-      }
-    },
-    "node_modules/readdir-glob/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "minimatch": "^10.2.2"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/yqnn"
       }
     },
     "node_modules/rolldown": {
@@ -2828,45 +2638,12 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/shebang-command": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "license": "MIT",
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -2928,102 +2705,6 @@
         "safe-buffer": "~5.2.0"
       }
     },
-    "node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/string-width-cjs": {
-      "name": "string-width",
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT"
-    },
-    "node_modules/string-width-cjs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/strip-ansi-cjs": {
-      "name": "strip-ansi",
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/superjson": {
       "version": "1.13.3",
       "resolved": "https://registry.npmjs.org/superjson/-/superjson-1.13.3.tgz",
@@ -3050,9 +2731,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.20",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
-      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -3444,21 +3125,6 @@
         }
       }
     },
-    "node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -3474,94 +3140,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs": {
-      "name": "wrap-ansi",
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT"
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/ws": {
@@ -3612,17 +3190,17 @@
       }
     },
     "node_modules/zip-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
-      "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-7.0.5.tgz",
+      "integrity": "sha512-dSvYKdvLsAHCDqPOhIwk/q5CvuWtTB3Dgpoe0uVEFjTzIOAmsQpprX25InCvrvJsirEbu1OHyy67n/kAj1Sw/w==",
       "license": "MIT",
       "dependencies": {
-        "archiver-utils": "^5.0.0",
-        "compress-commons": "^6.0.2",
+        "compress-commons": "^7.0.0",
+        "normalize-path": "^3.0.0",
         "readable-stream": "^4.0.0"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">=18"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@solidactions/cli",
-  "version": "1.33.0",
+  "version": "1.34.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@solidactions/cli",
-      "version": "1.33.0",
+      "version": "1.34.0",
       "license": "MIT",
       "dependencies": {
         "archiver": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solidactions/cli",
-  "version": "1.34.0",
+  "version": "1.33.0",
   "description": "SolidActions CLI - Deploy and manage workflow automation",
   "main": "dist/index.js",
   "bin": {
@@ -22,7 +22,7 @@
   },
   "license": "MIT",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "keywords": [
     "solidactions",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solidactions/cli",
-  "version": "1.33.0",
+  "version": "1.34.0",
   "description": "SolidActions CLI - Deploy and manage workflow automation",
   "main": "dist/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "deploy"
   ],
   "scripts": {
-    "build": "tsc && cp src/commands/dev-shim.mjs dist/commands/dev-shim.mjs",
+    "build": "tsc && cp src/commands/dev-shim.mjs dist/commands/dev-shim.mjs && cp src/utils/archiver-loader.cjs dist/utils/archiver-loader.cjs",
     "check:release": "npm run build && npm run test && npm run smoke:init",
     "prepublishOnly": "npm run build",
     "smoke:init": "node scripts/smoke-init.mjs",
@@ -40,7 +40,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "archiver": "^7.0.0",
+    "archiver": "^8.0.0",
     "axios": "^1.18.1",
     "chalk": "^4.1.2",
     "commander": "^11.0.0",
@@ -50,11 +50,11 @@
     "ignore": "^7.0.5",
     "js-yaml": "^4.3.0",
     "prompts": "^2.4.2",
-    "tar": "^7.5.20"
+    "tar": "^7.5.22"
   },
   "devDependencies": {
     "@solidactions/sdk": "^0.7.3",
-    "@types/archiver": "^6.0.0",
+    "@types/archiver": "^8.0.0",
     "@types/fs-extra": "^11.0.0",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.0.0",

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -8,6 +8,7 @@ import yaml from 'js-yaml';
 import prompts from 'prompts';
 import { SolidActionsConfig, parseYamlEnvVars } from '../utils/env';
 import { getApiHeaders, requireConfigWithWorkspace } from '../utils/api';
+import type { Config } from '../utils/config';
 import { planDeployFiles } from '../utils/deploy-ignore';
 import { buildProjectSlug } from '../utils/slug';
 import { hasSolidActionsSkills } from '../utils/skills';
@@ -15,9 +16,15 @@ import {
     buildDeployForm,
     collectSourceMetadata,
     createDeployArchiveLocation,
+    formatRevisionSummary,
     parseDeployAcceptance,
+    sanitizeDisplayText,
     shouldCollectGitMetadata,
 } from '../utils/source-provenance';
+import {
+    formatDeploymentRevision,
+    type ProjectDeploymentDetail,
+} from './project-view';
 
 /** Printed when a deploy target has no SolidActions skill files installed. */
 export const SKILLS_TIP_LINES = [
@@ -132,6 +139,48 @@ interface DeployOptions {
     configOnly?: boolean;
     noCache?: boolean;
     gitMetadata?: boolean;
+}
+
+export function projectStatusUrl(host: string, projectSlug: string): string {
+    return `${host}/api/v1/projects/${encodeURIComponent(projectSlug)}`;
+}
+
+export async function fetchDeploymentConfirmation(
+    config: Config,
+    projectSlug: string,
+): Promise<ProjectDeploymentDetail> {
+    const response = await axios.get(
+        `${projectStatusUrl(config.host, projectSlug)}?include=deployment`,
+        { headers: getApiHeaders(config) },
+    );
+    return response.data;
+}
+
+export function formatDeploymentConfirmation(
+    project: ProjectDeploymentDetail,
+    acceptedDeploymentId: string | null,
+    sourceMetadataRejected: string | null,
+): string[] {
+    if (!acceptedDeploymentId) {
+        return ['Build finished; revision confirmation unavailable (legacy server response).'];
+    }
+
+    const deployment = project.latest_successful_deployment ?? null;
+    if (
+        project.deployment_matches_deployed_hash !== true
+        || !deployment
+        || deployment.id !== acceptedDeploymentId
+    ) {
+        return ['Build finished, but this deployment was not the recorded successful deployment.'];
+    }
+
+    const lines = ['Deployment revision confirmed.'];
+    if (sourceMetadataRejected) {
+        const safeReason = sanitizeDisplayText(sourceMetadataRejected, 100) ?? 'invalid_metadata';
+        lines.push(`Optional source metadata was rejected by the server (${safeReason}).`);
+    }
+    lines.push(...formatDeploymentRevision(deployment));
+    return lines;
 }
 
 /**
@@ -465,6 +514,9 @@ export async function deploy(projectName: string, sourcePath?: string, options: 
     const sourceMetadata = shouldCollectGitMetadata(options)
         ? collectSourceMetadata(sourceDir)
         : null;
+    if (sourceMetadata) {
+        console.log(chalk.gray(`Revision to upload (client-reported): ${formatRevisionSummary(sourceMetadata)}`));
+    }
 
     // Plan the file list BEFORE creating the archive write stream so a walk error
     // (permission error, unreadable dir) aborts cleanly with no orphan tarball.
@@ -549,7 +601,7 @@ export async function deploy(projectName: string, sourcePath?: string, options: 
             const poll = setInterval(async () => {
                 try {
                     attempts++;
-                    const statusRes = await axios.get(`${config.host}/api/v1/projects/${projectSlug}`, {
+                    const statusRes = await axios.get(projectStatusUrl(config.host, projectSlug), {
                         headers: getApiHeaders(config),
                     });
                     const { status, build_log } = statusRes.data;
@@ -573,6 +625,21 @@ export async function deploy(projectName: string, sourcePath?: string, options: 
                     if (status === 'deployed') {
                         clearInterval(poll);
                         console.log(chalk.green(`\n✓ Deployed to ${projectSlug}${envLabel}!`));
+
+                        try {
+                            const confirmedProject = await fetchDeploymentConfirmation(config, projectSlug);
+                            for (const line of formatDeploymentConfirmation(
+                                confirmedProject,
+                                acceptedDeployment.deploymentId,
+                                acceptedDeployment.sourceMetadataRejected,
+                            )) {
+                                console.log(line);
+                            }
+                        } catch {
+                            console.log(chalk.yellow(
+                                'Build finished; server revision confirmation was unavailable.',
+                            ));
+                        }
 
                         // Always sync YAML declarations (registers variables and their mappings)
                         if (yamlConfig) {

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -3,7 +3,6 @@ import path from 'path';
 import { randomUUID } from 'crypto';
 import archiver from 'archiver';
 import axios from 'axios';
-import FormData from 'form-data';
 import chalk from 'chalk';
 import yaml from 'js-yaml';
 import prompts from 'prompts';
@@ -12,6 +11,13 @@ import { getApiHeaders, requireConfigWithWorkspace } from '../utils/api';
 import { planDeployFiles } from '../utils/deploy-ignore';
 import { buildProjectSlug } from '../utils/slug';
 import { hasSolidActionsSkills } from '../utils/skills';
+import {
+    buildDeployForm,
+    collectSourceMetadata,
+    createDeployArchiveLocation,
+    parseDeployAcceptance,
+    shouldCollectGitMetadata,
+} from '../utils/source-provenance';
 
 /** Printed when a deploy target has no SolidActions skill files installed. */
 export const SKILLS_TIP_LINES = [
@@ -125,6 +131,7 @@ interface DeployOptions {
     create?: boolean;
     configOnly?: boolean;
     noCache?: boolean;
+    gitMetadata?: boolean;
 }
 
 /**
@@ -453,7 +460,11 @@ export async function deploy(projectName: string, sourcePath?: string, options: 
         return;
     }
 
-    const archivePath = path.join(sourceDir, '.steps-deploy.tar.gz');
+    // Provenance is optional, best effort, and collected before archiving so
+    // the deploy artifact itself can never make the source look dirty.
+    const sourceMetadata = shouldCollectGitMetadata(options)
+        ? collectSourceMetadata(sourceDir)
+        : null;
 
     // Plan the file list BEFORE creating the archive write stream so a walk error
     // (permission error, unreadable dir) aborts cleanly with no orphan tarball.
@@ -465,6 +476,16 @@ export async function deploy(projectName: string, sourcePath?: string, options: 
         console.error(error.message);
         process.exit(1);
     }
+
+    const archiveLocation = createDeployArchiveLocation();
+    const archivePath = archiveLocation.archivePath;
+    let archiveCleaned = false;
+    const cleanupArchive = () => {
+        if (!archiveCleaned) {
+            archiveCleaned = true;
+            archiveLocation.cleanup();
+        }
+    };
 
     // Summary line so silent truncation never reads as "shipped everything".
     const parts: string[] = ['.env excluded'];
@@ -487,15 +508,14 @@ export async function deploy(projectName: string, sourcePath?: string, options: 
         console.log(chalk.gray(`Archived ${archive.pointer()} total bytes`));
 
         try {
-            const form = new FormData();
-            form.append('source', fs.createReadStream(archivePath));
+            const form = buildDeployForm(archivePath, sourceMetadata);
 
             console.log(chalk.yellow('Uploading...'));
             if (process.env.SOLIDACTIONS_DEPLOY_DEBUG === '1') {
                 process.stderr.write(`[deploy-debug] POST ${config.host}/api/v1/projects/${projectSlug}/deploy (workspace=${config.workspaceId ?? '(none)'})\n`);
             }
 
-            await axios.post(`${config.host}/api/v1/projects/${projectSlug}/deploy`, form, {
+            const deployResponse = await axios.post(`${config.host}/api/v1/projects/${projectSlug}/deploy`, form, {
                 headers: {
                     ...form.getHeaders(),
                     ...getApiHeaders(config),
@@ -503,6 +523,17 @@ export async function deploy(projectName: string, sourcePath?: string, options: 
                 maxContentLength: Infinity,
                 maxBodyLength: Infinity
             });
+            const acceptedDeployment = parseDeployAcceptance(deployResponse.data);
+            if (acceptedDeployment.sourceMetadataRejected) {
+                console.log(chalk.yellow(
+                    `Warning: optional source metadata was not accepted (${acceptedDeployment.sourceMetadataRejected}); deployment continues.`,
+                ));
+            }
+            if (process.env.SOLIDACTIONS_DEPLOY_DEBUG === '1') {
+                process.stderr.write(
+                    `[deploy-debug] accepted deployment=${acceptedDeployment.deploymentId ?? '(legacy response)'} metadata=${acceptedDeployment.sourceMetadata ? 'normalized' : 'none'}\n`,
+                );
+            }
 
             console.log(chalk.green('Deployment successfully queued!'));
             console.log(chalk.yellow('Waiting for build to complete...\n'));
@@ -555,7 +586,7 @@ export async function deploy(projectName: string, sourcePath?: string, options: 
                             console.log(chalk.gray(`   Set the same value in your sender (e.g. Telegram setWebhook secret_token).`));
                         }
 
-                        fs.unlinkSync(archivePath);
+                        cleanupArchive();
                         process.exit(0);
                     } else if (status === 'error') {
                         clearInterval(poll);
@@ -565,12 +596,12 @@ export async function deploy(projectName: string, sourcePath?: string, options: 
                             console.log(chalk.gray(build_log));
                             console.log(chalk.yellow('--- End Build Log ---\n'));
                         }
-                        fs.unlinkSync(archivePath);
+                        cleanupArchive();
                         process.exit(1);
                     } else if (attempts >= maxAttempts) {
                         clearInterval(poll);
                         console.error(chalk.red('\nTimeout waiting for build. It might still finish.'));
-                        fs.unlinkSync(archivePath);
+                        cleanupArchive();
                         process.exit(1);
                     }
                 } catch {
@@ -589,13 +620,23 @@ export async function deploy(projectName: string, sourcePath?: string, options: 
             } else {
                 console.error(error.message);
             }
-            if (fs.existsSync(archivePath)) fs.unlinkSync(archivePath);
+            cleanupArchive();
             process.exit(1);
         }
     });
 
     archive.on('error', (err) => {
-        throw err;
+        cleanupArchive();
+        console.error(chalk.red('Deployment failed:'));
+        console.error(err.message);
+        process.exit(1);
+    });
+
+    output.on('error', (err) => {
+        cleanupArchive();
+        console.error(chalk.red('Deployment failed:'));
+        console.error(err.message);
+        process.exit(1);
     });
 
     archive.pipe(output);

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -20,6 +20,7 @@ import {
     parseDeployAcceptance,
     sanitizeDisplayText,
     shouldCollectGitMetadata,
+    type SourceMetadata,
 } from '../utils/source-provenance';
 import {
     formatDeploymentRevision,
@@ -156,6 +157,52 @@ export async function fetchDeploymentConfirmation(
     return response.data;
 }
 
+/**
+ * True when the fetched project's recorded latest successful deployment is
+ * the one this deploy produced. A null `acceptedDeploymentId` (legacy server
+ * response) has nothing to confirm against, so it counts as a match.
+ */
+export function isConfirmationMatch(
+    project: ProjectDeploymentDetail,
+    acceptedDeploymentId: string | null,
+): boolean {
+    if (!acceptedDeploymentId) {
+        return true;
+    }
+    const deployment = project.latest_successful_deployment ?? null;
+    return project.deployment_matches_deployed_hash === true
+        && deployment !== null
+        && deployment.id === acceptedDeploymentId;
+}
+
+/**
+ * Rebuild provenance can lag server-side (app #972): the instant status
+ * flips to "deployed", the confirmation record may not have caught up yet,
+ * so a healthy deploy can transiently look like a mismatch. Retries a short,
+ * bounded number of times before accepting whatever the last fetch reported.
+ * Exit code is unaffected either way — this only changes which message prints.
+ */
+export async function confirmDeploymentWithRetry(
+    acceptedDeploymentId: string | null,
+    fetcher: () => Promise<ProjectDeploymentDetail>,
+    options: { attempts?: number; delayMs?: number; wait?: (ms: number) => Promise<void> } = {},
+): Promise<ProjectDeploymentDetail> {
+    const attempts = options.attempts ?? 3;
+    const delayMs = options.delayMs ?? 500;
+    const wait = options.wait ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+
+    let result: ProjectDeploymentDetail;
+    for (let attempt = 1; attempt <= attempts; attempt++) {
+        result = await fetcher();
+        if (isConfirmationMatch(result, acceptedDeploymentId) || attempt === attempts) {
+            return result;
+        }
+        await wait(delayMs);
+    }
+    // Unreachable: the loop always returns on its final iteration.
+    return result!;
+}
+
 export function formatDeploymentConfirmation(
     project: ProjectDeploymentDetail,
     acceptedDeploymentId: string | null,
@@ -166,21 +213,53 @@ export function formatDeploymentConfirmation(
     }
 
     const deployment = project.latest_successful_deployment ?? null;
-    if (
-        project.deployment_matches_deployed_hash !== true
-        || !deployment
-        || deployment.id !== acceptedDeploymentId
-    ) {
-        return ['Build finished, but this deployment was not the recorded successful deployment.'];
+
+    if (!deployment) {
+        return ['Build finished, but the server has no successful deployment recorded yet for this project.'];
     }
 
-    const lines = ['Deployment revision confirmed.'];
+    if (project.deployment_matches_deployed_hash !== true) {
+        return ["Build finished, but the running revision hash does not match the server's recorded successful deployment."];
+    }
+
+    if (deployment.id !== acceptedDeploymentId) {
+        return ['Build finished, but this deployment was not recorded as the latest successful deployment.'];
+    }
+
+    const revisionLines = formatDeploymentRevision(deployment);
+    const noRevisionReported = revisionLines[0] === 'No source revision was reported.';
+    const lines = [
+        noRevisionReported
+            ? 'Deployment confirmed, but no source revision was reported for it.'
+            : 'Deployment revision confirmed.',
+    ];
     if (sourceMetadataRejected) {
         const safeReason = sanitizeDisplayText(sourceMetadataRejected, 100) ?? 'invalid_metadata';
         lines.push(`Optional source metadata was rejected by the server (${safeReason}).`);
     }
-    lines.push(...formatDeploymentRevision(deployment));
+    lines.push(...(noRevisionReported ? revisionLines.slice(1) : revisionLines));
     return lines;
+}
+
+/**
+ * Provenance collection is optional, best effort — a failure here must never
+ * fail the deploy. Wraps collectSourceMetadata() (or an injected collector,
+ * for testing) in a try/catch and degrades to null on throw.
+ */
+export function safeCollectSourceMetadata(
+    sourceDir: string,
+    options: { gitMetadata?: boolean },
+    collector: (sourceDir: string) => SourceMetadata | null = collectSourceMetadata,
+): SourceMetadata | null {
+    if (!shouldCollectGitMetadata(options)) {
+        return null;
+    }
+
+    try {
+        return collector(sourceDir);
+    } catch {
+        return null;
+    }
 }
 
 /**
@@ -511,9 +590,7 @@ export async function deploy(projectName: string, sourcePath?: string, options: 
 
     // Provenance is optional, best effort, and collected before archiving so
     // the deploy artifact itself can never make the source look dirty.
-    const sourceMetadata = shouldCollectGitMetadata(options)
-        ? collectSourceMetadata(sourceDir)
-        : null;
+    const sourceMetadata = safeCollectSourceMetadata(sourceDir, options);
     if (sourceMetadata) {
         console.log(chalk.gray(`Revision to upload (client-reported): ${formatRevisionSummary(sourceMetadata)}`));
     }
@@ -627,7 +704,10 @@ export async function deploy(projectName: string, sourcePath?: string, options: 
                         console.log(chalk.green(`\n✓ Deployed to ${projectSlug}${envLabel}!`));
 
                         try {
-                            const confirmedProject = await fetchDeploymentConfirmation(config, projectSlug);
+                            const confirmedProject = await confirmDeploymentWithRetry(
+                                acceptedDeployment.deploymentId,
+                                () => fetchDeploymentConfirmation(config, projectSlug),
+                            );
                             for (const line of formatDeploymentConfirmation(
                                 confirmedProject,
                                 acceptedDeployment.deploymentId,

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -1,7 +1,6 @@
 import fs from 'fs';
 import path from 'path';
 import { randomUUID } from 'crypto';
-import archiver from 'archiver';
 import axios from 'axios';
 import chalk from 'chalk';
 import yaml from 'js-yaml';
@@ -12,6 +11,7 @@ import type { Config } from '../utils/config';
 import { planDeployFiles } from '../utils/deploy-ignore';
 import { buildProjectSlug } from '../utils/slug';
 import { hasSolidActionsSkills } from '../utils/skills';
+import { createTarArchive } from '../utils/tar-archive';
 import {
     buildDeployForm,
     collectSourceMetadata,
@@ -553,8 +553,8 @@ export async function deploy(projectName: string, sourcePath?: string, options: 
         console.log(chalk.yellow(`⚠ Skipped ${plan.summary.symlinksSkipped.length} symlink(s) (not followed): ${plan.summary.symlinksSkipped.join(', ')}`));
     }
 
+    const archive = await createTarArchive({ gzip: true, gzipOptions: { level: 9 } });
     const output = fs.createWriteStream(archivePath);
-    const archive = archiver('tar', { gzip: true, gzipOptions: { level: 9 } });
 
     output.on('close', async () => {
         console.log(chalk.gray(`Archived ${archive.pointer()} total bytes`));

--- a/src/commands/project-view.ts
+++ b/src/commands/project-view.ts
@@ -1,0 +1,173 @@
+import axios from 'axios';
+import chalk from 'chalk';
+import { getApiHeaders, requireConfigWithWorkspace } from '../utils/api';
+import type { Config } from '../utils/config';
+import { buildProjectSlug } from '../utils/slug';
+import {
+    formatRevisionSummary,
+    sanitizeDisplayText,
+    type MetadataSource,
+} from '../utils/source-provenance';
+
+export interface DeploymentDetail {
+    id: string;
+    status: string;
+    source_hash: string;
+    metadata_source: MetadataSource | null;
+    commit_sha: string | null;
+    short_sha: string | null;
+    branch: string | null;
+    tag: string | null;
+    commit_subject: string | null;
+    commit_author_date: string | null;
+    remote_url: string | null;
+    dirty: boolean | null;
+    completed_at: string | null;
+}
+
+export interface ProjectDeploymentDetail {
+    slug?: string;
+    name?: string;
+    status?: string;
+    deployed_hash?: string | null;
+    deployment_matches_deployed_hash?: boolean;
+    latest_successful_deployment?: DeploymentDetail | null;
+}
+
+export interface ProjectViewOptions {
+    env?: string;
+}
+
+export function projectSlugForView(project: string, environment?: string): string {
+    if (environment === undefined) {
+        return project;
+    }
+
+    if (!['production', 'staging', 'dev'].includes(environment)) {
+        throw new Error('Environment must be production, staging, or dev.');
+    }
+
+    return environment === 'production'
+        ? project
+        : buildProjectSlug(project, environment);
+}
+
+function metadataSourceLabel(source: unknown): string | null {
+    const labels: Record<string, string> = {
+        git: 'Git',
+        github_actions: 'GitHub Actions',
+        gitlab_ci: 'GitLab CI',
+        circleci: 'CircleCI',
+        bitbucket_pipelines: 'Bitbucket Pipelines',
+    };
+    const safe = sanitizeDisplayText(source, 32);
+    return safe ? labels[safe] ?? safe : null;
+}
+
+export function formatDeploymentRevision(deployment: DeploymentDetail): string[] {
+    const sha = sanitizeDisplayText(deployment.short_sha, 16)
+        ?? sanitizeDisplayText(deployment.commit_sha, 64);
+    if (!sha) {
+        const archiveHash = sanitizeDisplayText(deployment.source_hash, 64);
+        return [
+            'No source revision was reported.',
+            ...(archiveHash ? [`Archive: ${archiveHash}`] : []),
+        ];
+    }
+
+    const lines = [
+        `Revision (Client-reported): ${formatRevisionSummary(deployment)}`,
+    ];
+    const source = metadataSourceLabel(deployment.metadata_source);
+    if (source) {
+        lines.push(`Source: ${source}`);
+    }
+
+    const branch = sanitizeDisplayText(deployment.branch, 255);
+    const tag = sanitizeDisplayText(deployment.tag, 255);
+    if (branch) {
+        lines.push(`Branch: ${branch}`);
+    }
+    if (tag) {
+        lines.push(`Tag: ${tag}`);
+    }
+
+    const subject = sanitizeDisplayText(deployment.commit_subject, 500);
+    const authorDate = sanitizeDisplayText(deployment.commit_author_date, 40);
+    const remote = sanitizeDisplayText(deployment.remote_url, 2048);
+    if (subject) {
+        lines.push(`Subject: ${subject}`);
+    }
+    if (authorDate) {
+        lines.push(`Author date: ${authorDate}`);
+    }
+    if (remote) {
+        lines.push(`Remote: ${remote}`);
+    }
+
+    return lines;
+}
+
+export function formatProjectView(project: ProjectDeploymentDetail): string[] {
+    const slug = sanitizeDisplayText(project.slug ?? project.name, 255) ?? 'unknown';
+    const status = sanitizeDisplayText(project.status, 64) ?? 'unknown';
+    const lines = [`Project: ${slug}`, `Status: ${status}`];
+    const deployment = project.latest_successful_deployment ?? null;
+
+    if (!project.deployed_hash && !deployment) {
+        lines.push('No deployment provenance recorded (deployed before tracking).');
+        return lines;
+    }
+
+    if (project.deployment_matches_deployed_hash !== true || !deployment) {
+        lines.push('Revision unknown for the running build.');
+        return lines;
+    }
+
+    lines.push(...formatDeploymentRevision(deployment));
+    return lines;
+}
+
+export async function projectViewWithConfig(
+    project: string,
+    options: ProjectViewOptions,
+    config: Config,
+    writeLine: (line: string) => void = console.log,
+): Promise<void> {
+    let slug: string;
+    try {
+        slug = projectSlugForView(project, options.env);
+    } catch (error: any) {
+        console.error(chalk.red(error.message));
+        process.exit(1);
+        return;
+    }
+
+    try {
+        const response = await axios.get(
+            `${config.host}/api/v1/projects/${encodeURIComponent(slug)}?include=deployment`,
+            { headers: getApiHeaders(config) },
+        );
+        for (const line of formatProjectView(response.data)) {
+            writeLine(line);
+        }
+    } catch (error: any) {
+        if (error.response?.status === 401) {
+            console.error(chalk.red('Authentication failed. Run "solidactions login --global" to re-configure.'));
+        } else if (error.response?.status === 404) {
+            const message = sanitizeDisplayText(error.response.data?.message, 500)
+                ?? `Project "${slug}" not found.`;
+            console.error(chalk.red(message));
+        } else if (error.response) {
+            console.error(chalk.red(`Failed to view project: ${error.response.status}`));
+        } else {
+            console.error(chalk.red('Connection failed:'), error.message);
+        }
+        process.exit(1);
+    }
+}
+
+export async function projectView(project: string, options: ProjectViewOptions): Promise<void> {
+    const config = await requireConfigWithWorkspace();
+    await projectViewWithConfig(project, options, config);
+}

--- a/src/commands/project-view.ts
+++ b/src/commands/project-view.ts
@@ -6,6 +6,7 @@ import { buildProjectSlug } from '../utils/slug';
 import {
     formatRevisionSummary,
     sanitizeDisplayText,
+    sanitizeRemoteUrl,
     type MetadataSource,
 } from '../utils/source-provenance';
 
@@ -94,7 +95,11 @@ export function formatDeploymentRevision(deployment: DeploymentDetail): string[]
 
     const subject = sanitizeDisplayText(deployment.commit_subject, 500);
     const authorDate = sanitizeDisplayText(deployment.commit_author_date, 40);
-    const remote = sanitizeDisplayText(deployment.remote_url, 2048);
+    // Defense in depth: sanitizeRemoteUrl already strips credentials at
+    // collection time (source-provenance.ts), but a legacy or unnormalized
+    // server response could still carry them, so re-sanitize at this display
+    // boundary too — remote_url must never reach the terminal with a token.
+    const remote = sanitizeRemoteUrl(sanitizeDisplayText(deployment.remote_url, 2048) ?? undefined);
     if (subject) {
         lines.push(`Subject: ${subject}`);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { init } from './commands/init';
 import { pull } from './commands/pull';
 import { projectList } from './commands/project-list';
 import { projectCreate } from './commands/project-create';
+import { projectView } from './commands/project-view';
 import { logsBuild } from './commands/project-logs';
 import { run } from './commands/run-start';
 import { runs } from './commands/run-list';
@@ -180,6 +181,20 @@ program
 // =============================================================================
 
 const project = program.command('project').description('Manage projects');
+
+project
+    .command('view')
+    .description('View project status and the client-reported deployed revision')
+    .argument('<project>', 'Exact project slug (or project family/name when --env is explicit)')
+    .option('-e, --env <environment>', 'Resolve an explicit environment (production/staging/dev)')
+    .addHelpText('after', `
+Without --env, <project> is used as an exact slug. With --env production it is
+used unchanged; staging/dev use the same "-<env>" suffix rule as deploy.
+Unlike historical commands such as \`run start\`, project view has no implicit
+dev environment default.`)
+    .action(async (projectName, options) => {
+        await projectView(projectName, options);
+    });
 
 project
     .command('create')

--- a/src/index.ts
+++ b/src/index.ts
@@ -217,7 +217,7 @@ project
     .option('--force-rebuild', 'Force a fresh build, bypassing all build caches (alias for --no-cache)')
     .option(
         '--no-git-metadata',
-        'Do not transmit Git provenance (branch, commit subject, and remote hostname); also available as SOLIDACTIONS_NO_GIT_METADATA=1',
+        'Do not transmit Git provenance (branch, commit subject, and sanitized remote repository URL; credentials are stripped); also available as SOLIDACTIONS_NO_GIT_METADATA=1',
     )
     .action((projectName, path, options) => {
         // Commander's negation convention maps --no-cache to options.cache === false

--- a/src/index.ts
+++ b/src/index.ts
@@ -200,6 +200,10 @@ project
     .option('--config-only', 'Sync YAML env declarations without building/deploying')
     .option('--no-cache', 'Force a fresh build, bypassing all build caches')
     .option('--force-rebuild', 'Force a fresh build, bypassing all build caches (alias for --no-cache)')
+    .option(
+        '--no-git-metadata',
+        'Do not transmit Git provenance (branch, commit subject, and remote hostname); also available as SOLIDACTIONS_NO_GIT_METADATA=1',
+    )
     .action((projectName, path, options) => {
         // Commander's negation convention maps --no-cache to options.cache === false
         // (NOT options.noCache). Normalize both flags to a single boolean.

--- a/src/utils/archiver-loader.cjs
+++ b/src/utils/archiver-loader.cjs
@@ -1,0 +1,1 @@
+module.exports = () => import('archiver');

--- a/src/utils/source-provenance.ts
+++ b/src/utils/source-provenance.ts
@@ -138,7 +138,7 @@ function localGitMetadata(sourceDir: string): SourceMetadata | null {
         commit_sha: commitSha,
         short_sha: shortSha,
         branch: displayValue(git(sourceDir, ['symbolic-ref', '--short', '-q', 'HEAD']) ?? undefined, 255),
-        tag: displayValue(git(sourceDir, ['describe', '--tags', '--abbrev=0', 'HEAD']) ?? undefined, 255),
+        tag: displayValue(git(sourceDir, ['describe', '--tags', '--exact-match', 'HEAD']) ?? undefined, 255),
         commit_subject: displayValue(git(sourceDir, ['show', '-s', '--format=%s', 'HEAD']) ?? undefined, 500),
         commit_author_date: authorDateValue(git(sourceDir, ['show', '-s', '--format=%aI', 'HEAD']) ?? undefined),
         remote_url: sanitizeRemoteUrl(git(sourceDir, ['config', '--get', 'remote.origin.url']) ?? undefined),

--- a/src/utils/source-provenance.ts
+++ b/src/utils/source-provenance.ts
@@ -84,21 +84,31 @@ function authorDateValue(value: string | undefined): string | null {
     return sanitized && STRICT_ISO_PATTERN.test(sanitized) ? sanitized : null;
 }
 
+const SCP_STYLE_PATTERN = /^[^@\s/]+@([^\s/:]+):(.+)$/;
+
 export function sanitizeRemoteUrl(value: string | undefined): string | null {
     const sanitized = displayValue(value, 2048);
     if (!sanitized) {
         return null;
     }
 
-    if (/^https?:\/\//i.test(sanitized)) {
+    if (/^[a-z][a-z0-9+.-]*:\/\//i.test(sanitized)) {
         try {
             const remote = new URL(sanitized);
             remote.username = '';
             remote.password = '';
+            remote.search = '';
+            remote.hash = '';
             return remote.toString();
         } catch {
             return null;
         }
+    }
+
+    const scpMatch = SCP_STYLE_PATTERN.exec(sanitized);
+    if (scpMatch) {
+        const [, host, path] = scpMatch;
+        return `${host}:${path}`;
     }
 
     return sanitized;

--- a/src/utils/source-provenance.ts
+++ b/src/utils/source-provenance.ts
@@ -85,11 +85,21 @@ function authorDateValue(value: string | undefined): string | null {
 }
 
 const SCP_STYLE_PATTERN = /^[^@\s/]+@([^\s/:]+):(.+)$/;
+// Git remote helper syntax: `<helper>::<address>`, e.g. `hg::https://host/repo`.
+// https://git-scm.com/docs/gitremote-helpers
+const HELPER_PREFIX_PATTERN = /^([a-zA-Z0-9-]+::)(.*)$/;
 
 export function sanitizeRemoteUrl(value: string | undefined): string | null {
     const sanitized = displayValue(value, 2048);
     if (!sanitized) {
         return null;
+    }
+
+    const helperMatch = HELPER_PREFIX_PATTERN.exec(sanitized);
+    if (helperMatch) {
+        const [, prefix, remainder] = helperMatch;
+        const sanitizedRemainder = sanitizeRemoteUrl(remainder);
+        return sanitizedRemainder === null ? null : `${prefix}${sanitizedRemainder}`;
     }
 
     if (/^[a-z][a-z0-9+.-]*:\/\//i.test(sanitized)) {
@@ -103,6 +113,14 @@ export function sanitizeRemoteUrl(value: string | undefined): string | null {
         } catch {
             return null;
         }
+    }
+
+    if (/^\/\//.test(sanitized)) {
+        // Protocol-relative: //[user[:pass]@]host[:port]/path[?query][#fragment]
+        return sanitized
+            .split('#')[0]
+            .split('?')[0]
+            .replace(/^\/\/[^/@]*@/, '//');
     }
 
     const scpMatch = SCP_STYLE_PATTERN.exec(sanitized);

--- a/src/utils/source-provenance.ts
+++ b/src/utils/source-provenance.ts
@@ -44,6 +44,36 @@ function displayValue(value: string | undefined, maxLength: number): string | nu
     return sanitized === '' ? null : sanitized;
 }
 
+export function sanitizeDisplayText(value: unknown, maxLength = 2048): string | null {
+    return typeof value === 'string' ? displayValue(value, maxLength) : null;
+}
+
+function dirtyLabel(dirty: boolean | null): string {
+    if (dirty === true) {
+        return 'DIRTY';
+    }
+    if (dirty === false) {
+        return 'clean';
+    }
+    return 'dirty state unknown';
+}
+
+export function formatRevisionSummary(metadata: {
+    commit_sha: string | null;
+    short_sha: string | null;
+    dirty: boolean | null;
+}): string {
+    const sha = sanitizeDisplayText(metadata.short_sha, 16)
+        ?? sanitizeDisplayText(metadata.commit_sha, 64);
+    if (!sha) {
+        return 'No source revision was reported.';
+    }
+
+    return `${sha} (${dirtyLabel(
+        typeof metadata.dirty === 'boolean' ? metadata.dirty : null,
+    )})`;
+}
+
 function shaValue(value: string | undefined): string | null {
     const sanitized = displayValue(value, 64);
     return sanitized && SHA_PATTERN.test(sanitized) ? sanitized : null;

--- a/src/utils/source-provenance.ts
+++ b/src/utils/source-provenance.ts
@@ -1,0 +1,260 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { spawnSync } from 'child_process';
+import FormData from 'form-data';
+
+export type MetadataSource =
+    | 'git'
+    | 'github_actions'
+    | 'gitlab_ci'
+    | 'circleci'
+    | 'bitbucket_pipelines';
+
+export interface SourceMetadata {
+    metadata_source: MetadataSource;
+    commit_sha: string;
+    short_sha: string | null;
+    branch: string | null;
+    tag: string | null;
+    commit_subject: string | null;
+    commit_author_date: string | null;
+    remote_url: string | null;
+    dirty: boolean | null;
+}
+
+export interface DeployAcceptance {
+    deploymentId: string | null;
+    sourceMetadata: SourceMetadata | null;
+    sourceMetadataRejected: string | null;
+}
+
+type Environment = Record<string, string | undefined>;
+
+const DISPLAY_FORMATTING = /[\x00-\x1f\x7f\u061c\u200b-\u200f\u202a-\u202e\u2060\u2066-\u2069\ufeff]/g;
+const SHA_PATTERN = /^[0-9a-f]{7,64}$/i;
+const STRICT_ISO_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
+
+function displayValue(value: string | undefined, maxLength: number): string | null {
+    if (!value) {
+        return null;
+    }
+
+    const sanitized = value.replace(DISPLAY_FORMATTING, '').trim().slice(0, maxLength);
+    return sanitized === '' ? null : sanitized;
+}
+
+function shaValue(value: string | undefined): string | null {
+    const sanitized = displayValue(value, 64);
+    return sanitized && SHA_PATTERN.test(sanitized) ? sanitized : null;
+}
+
+function authorDateValue(value: string | undefined): string | null {
+    const sanitized = displayValue(value, 40);
+    return sanitized && STRICT_ISO_PATTERN.test(sanitized) ? sanitized : null;
+}
+
+export function sanitizeRemoteUrl(value: string | undefined): string | null {
+    const sanitized = displayValue(value, 2048);
+    if (!sanitized) {
+        return null;
+    }
+
+    if (/^https?:\/\//i.test(sanitized)) {
+        try {
+            const remote = new URL(sanitized);
+            remote.username = '';
+            remote.password = '';
+            return remote.toString();
+        } catch {
+            return null;
+        }
+    }
+
+    return sanitized;
+}
+
+function git(sourceDir: string, args: string[]): string | null {
+    const result = spawnSync('git', ['-C', sourceDir, ...args], {
+        encoding: 'utf8',
+        timeout: 2_000,
+        maxBuffer: 1024 * 1024,
+        windowsHide: true,
+        stdio: ['ignore', 'pipe', 'ignore'],
+    });
+
+    if (result.status !== 0 || result.error) {
+        return null;
+    }
+
+    return result.stdout.trim();
+}
+
+function localGitMetadata(sourceDir: string): SourceMetadata | null {
+    if (git(sourceDir, ['rev-parse', '--is-inside-work-tree']) !== 'true') {
+        return null;
+    }
+
+    const commitSha = shaValue(git(sourceDir, ['rev-parse', 'HEAD']) ?? undefined);
+    if (!commitSha) {
+        return null;
+    }
+
+    const status = git(sourceDir, ['status', '--porcelain=v1', '--untracked-files=all', '--', '.']);
+    const shortSha = shaValue(git(sourceDir, ['rev-parse', '--short=12', 'HEAD']) ?? undefined);
+
+    return {
+        metadata_source: 'git',
+        commit_sha: commitSha,
+        short_sha: shortSha,
+        branch: displayValue(git(sourceDir, ['symbolic-ref', '--short', '-q', 'HEAD']) ?? undefined, 255),
+        tag: displayValue(git(sourceDir, ['describe', '--tags', '--abbrev=0', 'HEAD']) ?? undefined, 255),
+        commit_subject: displayValue(git(sourceDir, ['show', '-s', '--format=%s', 'HEAD']) ?? undefined, 500),
+        commit_author_date: authorDateValue(git(sourceDir, ['show', '-s', '--format=%aI', 'HEAD']) ?? undefined),
+        remote_url: sanitizeRemoteUrl(git(sourceDir, ['config', '--get', 'remote.origin.url']) ?? undefined),
+        dirty: status === null ? null : status !== '',
+    };
+}
+
+function baseCiMetadata(source: MetadataSource, sha: string): SourceMetadata {
+    return {
+        metadata_source: source,
+        commit_sha: sha,
+        short_sha: sha.slice(0, 12),
+        branch: null,
+        tag: null,
+        commit_subject: null,
+        commit_author_date: null,
+        remote_url: null,
+        dirty: null,
+    };
+}
+
+function githubMetadata(environment: Environment): SourceMetadata | null {
+    const sha = shaValue(environment.GITHUB_SHA);
+    if (!sha) {
+        return null;
+    }
+
+    const metadata = baseCiMetadata('github_actions', sha);
+    metadata.branch = displayValue(
+        environment.GITHUB_HEAD_REF
+            || (environment.GITHUB_REF_TYPE === 'branch' ? environment.GITHUB_REF_NAME : undefined),
+        255,
+    );
+    metadata.tag = displayValue(
+        environment.GITHUB_REF_TYPE === 'tag' ? environment.GITHUB_REF_NAME : undefined,
+        255,
+    );
+    const server = displayValue(environment.GITHUB_SERVER_URL, 1024);
+    const repository = displayValue(environment.GITHUB_REPOSITORY, 1024);
+    metadata.remote_url = sanitizeRemoteUrl(server && repository ? `${server.replace(/\/$/, '')}/${repository}` : undefined);
+    return metadata;
+}
+
+function gitlabMetadata(environment: Environment): SourceMetadata | null {
+    const sha = shaValue(environment.CI_COMMIT_SHA);
+    if (!sha) {
+        return null;
+    }
+
+    return {
+        ...baseCiMetadata('gitlab_ci', sha),
+        branch: displayValue(environment.CI_COMMIT_REF_NAME, 255),
+        tag: displayValue(environment.CI_COMMIT_TAG, 255),
+        commit_subject: displayValue(environment.CI_COMMIT_TITLE, 500),
+        commit_author_date: authorDateValue(environment.CI_COMMIT_TIMESTAMP),
+        remote_url: sanitizeRemoteUrl(environment.CI_REPOSITORY_URL),
+    };
+}
+
+function circleMetadata(environment: Environment): SourceMetadata | null {
+    const sha = shaValue(environment.CIRCLE_SHA1);
+    if (!sha) {
+        return null;
+    }
+
+    return {
+        ...baseCiMetadata('circleci', sha),
+        branch: displayValue(environment.CIRCLE_BRANCH, 255),
+        tag: displayValue(environment.CIRCLE_TAG, 255),
+        remote_url: sanitizeRemoteUrl(environment.CIRCLE_REPOSITORY_URL),
+    };
+}
+
+function bitbucketMetadata(environment: Environment): SourceMetadata | null {
+    const sha = shaValue(environment.BITBUCKET_COMMIT);
+    if (!sha) {
+        return null;
+    }
+
+    return {
+        ...baseCiMetadata('bitbucket_pipelines', sha),
+        branch: displayValue(environment.BITBUCKET_BRANCH, 255),
+        tag: displayValue(environment.BITBUCKET_TAG, 255),
+        remote_url: sanitizeRemoteUrl(
+            environment.BITBUCKET_GIT_HTTP_ORIGIN || environment.BITBUCKET_GIT_SSH_ORIGIN,
+        ),
+    };
+}
+
+export function collectSourceMetadata(
+    sourceDir: string,
+    environment: Environment = process.env,
+): SourceMetadata | null {
+    return localGitMetadata(path.resolve(sourceDir))
+        ?? githubMetadata(environment)
+        ?? gitlabMetadata(environment)
+        ?? circleMetadata(environment)
+        ?? bitbucketMetadata(environment);
+}
+
+export function shouldCollectGitMetadata(
+    options: { gitMetadata?: boolean },
+    environment: Environment = process.env,
+): boolean {
+    return options.gitMetadata !== false && environment.SOLIDACTIONS_NO_GIT_METADATA !== '1';
+}
+
+function appendSourceMetadata(form: FormData, metadata: SourceMetadata | null): void {
+    if (metadata) {
+        form.append('source_metadata', JSON.stringify(metadata));
+    }
+}
+
+export function buildDeployForm(archivePath: string, metadata: SourceMetadata | null): FormData {
+    const form = new FormData();
+    form.append('source', fs.createReadStream(archivePath));
+    appendSourceMetadata(form, metadata);
+    return form;
+}
+
+export function createDeployArchiveLocation(): {
+    directory: string;
+    archivePath: string;
+    cleanup: () => void;
+} {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'solidactions-deploy-'));
+    return {
+        directory,
+        archivePath: path.join(directory, 'source.tar.gz'),
+        cleanup: () => fs.rmSync(directory, { recursive: true, force: true }),
+    };
+}
+
+function nullableString(value: unknown): string | null {
+    return typeof value === 'string' && value !== '' ? value : null;
+}
+
+export function parseDeployAcceptance(data: unknown): DeployAcceptance {
+    const body = data && typeof data === 'object' ? data as Record<string, unknown> : {};
+    const sourceMetadata = body.source_metadata && typeof body.source_metadata === 'object'
+        ? body.source_metadata as SourceMetadata
+        : null;
+
+    return {
+        deploymentId: nullableString(body.deployment_id),
+        sourceMetadata,
+        sourceMetadataRejected: nullableString(body.source_metadata_rejected),
+    };
+}

--- a/src/utils/tar-archive.ts
+++ b/src/utils/tar-archive.ts
@@ -1,0 +1,14 @@
+import type { Archiver, TarOptions } from 'archiver';
+
+type ArchiverModule = typeof import('archiver');
+
+// Kept in an untransformed CommonJS bridge because TypeScript rewrites
+// import() to require() for this project, and require() cannot load archiver
+// v8's ESM-only entry point on Node 18.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const importArchiver = require('./archiver-loader.cjs') as () => Promise<ArchiverModule>;
+
+export async function createTarArchive(options: TarOptions): Promise<Archiver> {
+    const { TarArchive } = await importArchiver();
+    return new TarArchive(options);
+}

--- a/tests/deploy-confirmation-retry.test.ts
+++ b/tests/deploy-confirmation-retry.test.ts
@@ -1,0 +1,103 @@
+/**
+ * App issue #972: rebuild provenance can lag server-side, so the single
+ * confirmation GET fired the instant status flips to "deployed" can catch
+ * the server before latest_successful_deployment / deployment_matches_deployed_hash
+ * have caught up, wrongly printing the mismatch message for a healthy deploy.
+ * confirmDeploymentWithRetry is the extracted, independently testable retry
+ * wrapper around fetchDeploymentConfirmation — injected fetcher/wait keep
+ * this deterministic and fast (no real network, no real timers).
+ */
+import { describe, expect, it } from 'vitest';
+import { confirmDeploymentWithRetry, isConfirmationMatch } from '../src/commands/deploy';
+import type { ProjectDeploymentDetail } from '../src/commands/project-view';
+
+function project(overrides: Partial<ProjectDeploymentDetail> = {}): ProjectDeploymentDetail {
+    return {
+        slug: 'billing',
+        status: 'deployed',
+        deployment_matches_deployed_hash: true,
+        latest_successful_deployment: {
+            id: 'accepted-deployment',
+            status: 'succeeded',
+            source_hash: 'archive-md5',
+            metadata_source: 'git',
+            commit_sha: 'abcdef1234567890',
+            short_sha: 'abcdef123456',
+            branch: 'main',
+            tag: null,
+            commit_subject: 'ship',
+            commit_author_date: '2026-07-27T10:00:00-05:00',
+            remote_url: null,
+            dirty: false,
+            completed_at: '2026-07-27T15:00:00Z',
+        },
+        ...overrides,
+    };
+}
+
+const mismatched = project({ deployment_matches_deployed_hash: false });
+const matched = project();
+
+describe('isConfirmationMatch', () => {
+    it('is true when the hash matches and the deployment ID matches', () => {
+        expect(isConfirmationMatch(matched, 'accepted-deployment')).toBe(true);
+    });
+
+    it('is false on a deployed-hash mismatch', () => {
+        expect(isConfirmationMatch(mismatched, 'accepted-deployment')).toBe(false);
+    });
+
+    it('is false when no matching deployment row exists', () => {
+        expect(isConfirmationMatch(project({ latest_successful_deployment: null }), 'accepted-deployment')).toBe(false);
+    });
+
+    it('is false on a deployment-ID mismatch', () => {
+        expect(isConfirmationMatch(matched, 'different-deployment')).toBe(false);
+    });
+
+    it('is true (nothing to retry against) for a legacy null accepted ID', () => {
+        expect(isConfirmationMatch(mismatched, null)).toBe(true);
+    });
+});
+
+describe('confirmDeploymentWithRetry', () => {
+    it('does not retry when the first fetch already matches', async () => {
+        let calls = 0;
+        const result = await confirmDeploymentWithRetry(
+            'accepted-deployment',
+            async () => { calls++; return matched; },
+            { wait: async () => {} },
+        );
+
+        expect(calls).toBe(1);
+        expect(result).toBe(matched);
+    });
+
+    it('retries a mismatch and returns the eventually-matching result', async () => {
+        let calls = 0;
+        const waited: number[] = [];
+        const result = await confirmDeploymentWithRetry(
+            'accepted-deployment',
+            async () => { calls++; return calls < 3 ? mismatched : matched; },
+            { wait: async (ms: number) => { waited.push(ms); } },
+        );
+
+        expect(calls).toBe(3);
+        expect(result).toBe(matched);
+        expect(waited).toHaveLength(2);
+        expect(waited.every((ms) => ms > 0)).toBe(true);
+    });
+
+    it('gives up after a bounded number of attempts (2-3) and returns the last mismatch', async () => {
+        let calls = 0;
+        const result = await confirmDeploymentWithRetry(
+            'accepted-deployment',
+            async () => { calls++; return mismatched; },
+            { wait: async () => {} },
+        );
+
+        expect(calls).toBeGreaterThanOrEqual(2);
+        expect(calls).toBeLessThanOrEqual(3);
+        expect(result).toBe(mismatched);
+    });
+});

--- a/tests/deploy-confirmation.test.ts
+++ b/tests/deploy-confirmation.test.ts
@@ -96,8 +96,30 @@ describe('deploy polling and final confirmation', () => {
             null,
         ).join('\n');
 
-        expect(lines).toContain('this deployment was not the recorded successful deployment');
+        expect(lines).toContain('this deployment was not recorded as the latest successful deployment');
         expect(lines).not.toContain('abcdef123456');
+    });
+
+    it('reports a deployed-hash mismatch with a message distinct from a deployment-ID mismatch', () => {
+        const body = structuredClone(responseBody) as any;
+        body.deployment_matches_deployed_hash = false;
+
+        const lines = formatDeploymentConfirmation(body, 'accepted-deployment', null).join('\n');
+
+        expect(lines).toContain('running revision hash does not match');
+        expect(lines).not.toContain('this deployment was not recorded as the latest successful deployment');
+        expect(lines).not.toContain('abcdef123456');
+    });
+
+    it('reports no matching deployment row distinctly when the server has none recorded yet', () => {
+        const body = structuredClone(responseBody) as any;
+        body.latest_successful_deployment = null;
+
+        const lines = formatDeploymentConfirmation(body, 'accepted-deployment', null).join('\n');
+
+        expect(lines).toContain('has no successful deployment recorded yet');
+        expect(lines).not.toContain('running revision hash does not match');
+        expect(lines).not.toContain('this deployment was not recorded as the latest successful deployment');
     });
 
     it('renders metadata rejection safely after a confirmed build', () => {
@@ -112,9 +134,21 @@ describe('deploy polling and final confirmation', () => {
             'invalid_metadata',
         ).join('\n');
 
-        expect(lines).toContain('Deployment revision confirmed');
         expect(lines).toContain('source metadata was rejected');
         expect(lines).toContain('invalid_metadata');
+        expect(lines).toContain('no source revision was reported');
+    });
+
+    it('does not contradict itself when a matching deployment has no reported SHA', () => {
+        const body = structuredClone(responseBody) as any;
+        body.latest_successful_deployment.commit_sha = null;
+        body.latest_successful_deployment.short_sha = null;
+
+        const lines = formatDeploymentConfirmation(body, 'accepted-deployment', null);
+
+        // Must not both claim the revision is confirmed AND that none was reported.
+        expect(lines).not.toContain('Deployment revision confirmed.');
+        expect(lines.join('\n')).not.toContain('No source revision was reported.');
     });
 
     it('uses a legacy-safe message when the 202 response has no deployment ID', () => {

--- a/tests/deploy-confirmation.test.ts
+++ b/tests/deploy-confirmation.test.ts
@@ -1,0 +1,148 @@
+import * as http from 'http';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import {
+    fetchDeploymentConfirmation,
+    formatDeploymentConfirmation,
+    projectStatusUrl,
+} from '../src/commands/deploy';
+import { formatRevisionSummary } from '../src/utils/source-provenance';
+import type { Config } from '../src/utils/config';
+
+let server: http.Server;
+let port: number;
+let requests: string[] = [];
+let responseBody: Record<string, unknown>;
+
+beforeAll(async () => {
+    server = http.createServer((req, res) => {
+        requests.push(req.url ?? '');
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(responseBody));
+    });
+    await new Promise<void>((resolve) => {
+        server.listen(0, '127.0.0.1', () => {
+            port = (server.address() as { port: number }).port;
+            resolve();
+        });
+    });
+});
+
+afterAll(() => new Promise<void>((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve());
+}));
+
+beforeEach(() => {
+    requests = [];
+    responseBody = {
+        slug: 'billing',
+        status: 'deployed',
+        deployment_matches_deployed_hash: true,
+        latest_successful_deployment: {
+            id: 'accepted-deployment',
+            status: 'succeeded',
+            source_hash: 'archive-md5',
+            metadata_source: 'git',
+            commit_sha: 'abcdef1234567890',
+            short_sha: 'abcdef123456',
+            branch: 'main',
+            tag: null,
+            commit_subject: 'ship',
+            commit_author_date: '2026-07-27T10:00:00-05:00',
+            remote_url: null,
+            dirty: false,
+            completed_at: '2026-07-27T15:00:00Z',
+        },
+    };
+});
+
+function config(): Config {
+    return {
+        host: `http://127.0.0.1:${port}`,
+        apiKey: 'test-key',
+        workspaceId: 'workspace-1',
+    };
+}
+
+describe('deploy polling and final confirmation', () => {
+    it('keeps the one-second status URL plain', () => {
+        expect(projectStatusUrl('https://example.test', 'billing')).toBe(
+            'https://example.test/api/v1/projects/billing',
+        );
+    });
+
+    it('makes exactly one final deployment-detail request', async () => {
+        const result = await fetchDeploymentConfirmation(config(), 'billing');
+
+        expect(requests).toEqual(['/api/v1/projects/billing?include=deployment']);
+        expect(result.latest_successful_deployment?.id).toBe('accepted-deployment');
+    });
+
+    it('confirms only when the accepted ID is the matching latest successful deployment', () => {
+        const lines = formatDeploymentConfirmation(
+            responseBody as any,
+            'accepted-deployment',
+            null,
+        ).join('\n');
+
+        expect(lines).toContain('Deployment revision confirmed');
+        expect(lines).toContain('abcdef123456');
+        expect(lines).toContain('clean');
+    });
+
+    it('reports a deployment-ID mismatch without displaying the other deployment revision', () => {
+        const lines = formatDeploymentConfirmation(
+            responseBody as any,
+            'different-deployment',
+            null,
+        ).join('\n');
+
+        expect(lines).toContain('this deployment was not the recorded successful deployment');
+        expect(lines).not.toContain('abcdef123456');
+    });
+
+    it('renders metadata rejection safely after a confirmed build', () => {
+        const body = structuredClone(responseBody) as any;
+        body.latest_successful_deployment.commit_sha = null;
+        body.latest_successful_deployment.short_sha = null;
+        body.latest_successful_deployment.metadata_source = null;
+
+        const lines = formatDeploymentConfirmation(
+            body,
+            'accepted-deployment',
+            'invalid_metadata',
+        ).join('\n');
+
+        expect(lines).toContain('Deployment revision confirmed');
+        expect(lines).toContain('source metadata was rejected');
+        expect(lines).toContain('invalid_metadata');
+    });
+
+    it('uses a legacy-safe message when the 202 response has no deployment ID', () => {
+        const lines = formatDeploymentConfirmation(responseBody as any, null, null).join('\n');
+
+        expect(lines).toContain('legacy server response');
+        expect(lines).not.toContain('abcdef123456');
+    });
+});
+
+describe('compact pre-upload revision summary', () => {
+    const metadata = {
+        metadata_source: 'git' as const,
+        commit_sha: 'abcdef1234567890',
+        short_sha: 'abcdef123456',
+        branch: 'main',
+        tag: null,
+        commit_subject: 'ship',
+        commit_author_date: '2026-07-27T10:00:00-05:00',
+        remote_url: null,
+        dirty: false,
+    };
+
+    it('prints clean, dirty, and unknown state beside every SHA', () => {
+        expect(formatRevisionSummary(metadata)).toContain('abcdef123456 (clean)');
+        expect(formatRevisionSummary({ ...metadata, dirty: true })).toContain('abcdef123456 (DIRTY)');
+        expect(formatRevisionSummary({ ...metadata, dirty: null })).toContain(
+            'abcdef123456 (dirty state unknown)',
+        );
+    });
+});

--- a/tests/deploy-confirmation.test.ts
+++ b/tests/deploy-confirmation.test.ts
@@ -89,6 +89,17 @@ describe('deploy polling and final confirmation', () => {
         expect(lines).toContain('clean');
     });
 
+    it('sanitizes credentials out of remote_url in the post-deploy confirmation, even from an unnormalized server payload', () => {
+        const body = structuredClone(responseBody) as any;
+        body.latest_successful_deployment.remote_url = 'https://user:secret@host.example/repo';
+
+        const lines = formatDeploymentConfirmation(body, 'accepted-deployment', null).join('\n');
+
+        expect(lines).toContain('Remote: https://host.example/repo');
+        expect(lines).not.toContain('secret');
+        expect(lines).not.toContain('user:secret@');
+    });
+
     it('reports a deployment-ID mismatch without displaying the other deployment revision', () => {
         const lines = formatDeploymentConfirmation(
             responseBody as any,

--- a/tests/deploy-live-wiring.test.ts
+++ b/tests/deploy-live-wiring.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Pins the real deploy() wiring for source provenance. The existing suite
+ * (see deploy-plan-limit.test.ts's header) deliberately tests only deploy()'s
+ * extracted pure helpers, not deploy() itself — so nothing previously failed
+ * if the `source_metadata` argument were dropped from the live multipart
+ * POST, or if the real shouldCollectGitMetadata() gate (now inside
+ * safeCollectSourceMetadata) were bypassed. This drives the real deploy()
+ * function end-to-end against an in-process HTTP server and inspects the
+ * raw bytes of the live upload request.
+ */
+import * as http from 'http';
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { deploy } from '../src/commands/deploy';
+
+function git(cwd: string, ...args: string[]): string {
+    return execFileSync('git', ['-C', cwd, ...args], { encoding: 'utf8' }).trim();
+}
+
+function makeSourceDir(): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sa-deploy-wiring-'));
+    fs.writeFileSync(
+        path.join(dir, 'solidactions.yaml'),
+        'workflows:\n  - name: noop\n    command: "true"\n',
+    );
+    fs.writeFileSync(
+        path.join(dir, 'package.json'),
+        JSON.stringify({ name: 'fixture', dependencies: { '@solidactions/sdk': '^0.7.3' } }),
+    );
+    git(dir, 'init', '-b', 'main');
+    git(dir, 'config', 'user.name', 'Deploy Wiring Test');
+    git(dir, 'config', 'user.email', 'deploy-wiring@example.test');
+    git(dir, 'add', '.');
+    git(dir, 'commit', '-m', 'Initial commit');
+    return dir;
+}
+
+const PROJECT_NAME = 'wiring-project';
+
+let server: http.Server;
+let port: number;
+let deployRequests: Array<{ body: string }> = [];
+
+function confirmationBody(): unknown {
+    return {
+        slug: PROJECT_NAME,
+        status: 'deployed',
+        deployment_matches_deployed_hash: true,
+        latest_successful_deployment: {
+            id: 'dep-1',
+            status: 'succeeded',
+            source_hash: 'archive-hash',
+            metadata_source: 'git',
+            commit_sha: 'a'.repeat(40),
+            short_sha: 'a'.repeat(12),
+            branch: 'main',
+            tag: null,
+            commit_subject: 'Initial commit',
+            commit_author_date: '2026-07-27T10:00:00-05:00',
+            remote_url: null,
+            dirty: false,
+            completed_at: '2026-07-27T15:00:00Z',
+        },
+    };
+}
+
+beforeAll(async () => {
+    server = http.createServer((req, res) => {
+        const chunks: Buffer[] = [];
+        req.on('data', (c: Buffer) => chunks.push(c));
+        req.on('end', () => {
+            const body = Buffer.concat(chunks).toString('utf8');
+            const url = req.url ?? '';
+
+            if (req.method === 'POST' && url.endsWith('/deploy')) {
+                deployRequests.push({ body });
+                res.writeHead(200, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ deployment_id: 'dep-1' }));
+                return;
+            }
+            if (req.method === 'GET' && url.includes('include=deployment')) {
+                res.writeHead(200, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify(confirmationBody()));
+                return;
+            }
+            if (req.method === 'GET' && /^\/api\/v1\/projects\/[^/?]+$/.test(url)) {
+                // Shared by the pre-deploy existence check and every poll tick —
+                // only the poll reads `status`; the existence check reads `slug`.
+                res.writeHead(200, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ slug: PROJECT_NAME, status: 'deployed' }));
+                return;
+            }
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({}));
+        });
+    });
+    await new Promise<void>((resolve) => {
+        server.listen(0, '127.0.0.1', () => {
+            port = (server.address() as { port: number }).port;
+            resolve();
+        });
+    });
+});
+
+afterAll(() => new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+}));
+
+let originalExit: typeof process.exit;
+let sourceDirs: string[] = [];
+
+beforeEach(() => {
+    deployRequests = [];
+    sourceDirs = [];
+    process.env.SOLIDACTIONS_HOST = `http://127.0.0.1:${port}`;
+    process.env.SOLIDACTIONS_API_KEY = 'test-key';
+    process.env.SOLIDACTIONS_WORKSPACE_ID = 'workspace-1';
+    originalExit = process.exit;
+});
+
+afterEach(() => {
+    process.exit = originalExit;
+    delete process.env.SOLIDACTIONS_HOST;
+    delete process.env.SOLIDACTIONS_API_KEY;
+    delete process.env.SOLIDACTIONS_WORKSPACE_ID;
+    for (const dir of sourceDirs.splice(0)) {
+        fs.rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+/**
+ * deploy()'s own returned promise resolves once archive.finalize() settles —
+ * well before the upload/poll/confirm chain runs inside the archive write
+ * stream's 'close' event handler (fire-and-forget past that point, per
+ * deploy-plan-limit.test.ts's header comment). So completion must be
+ * observed via the eventual process.exit() call, not via awaiting deploy().
+ */
+async function runDeploy(options: { gitMetadata?: boolean } = {}): Promise<void> {
+    const dir = makeSourceDir();
+    sourceDirs.push(dir);
+
+    await new Promise<void>((resolve) => {
+        (process as any).exit = (_code?: number) => { resolve(); };
+        void deploy(PROJECT_NAME, dir, { env: 'production', ...options });
+    });
+}
+
+describe('deploy() live wiring — source provenance', () => {
+    it('sends real source_metadata, built from the real collector, in the live deploy POST', async () => {
+        await runDeploy();
+
+        expect(deployRequests).toHaveLength(1);
+        const body = deployRequests[0].body;
+        expect(body).toContain('name="source_metadata"');
+        expect(body).toContain('"metadata_source":"git"');
+        expect(body).toContain(git(sourceDirs[0], 'rev-parse', 'HEAD'));
+    }, 10_000);
+
+    it('honors the real shouldCollectGitMetadata() opt-out in the live deploy POST', async () => {
+        await runDeploy({ gitMetadata: false });
+
+        expect(deployRequests).toHaveLength(1);
+        expect(deployRequests[0].body).not.toContain('name="source_metadata"');
+    }, 10_000);
+});

--- a/tests/deploy-live-wiring.test.ts
+++ b/tests/deploy-live-wiring.test.ts
@@ -1,12 +1,20 @@
 /**
- * Pins the real deploy() wiring for source provenance. The existing suite
- * (see deploy-plan-limit.test.ts's header) deliberately tests only deploy()'s
- * extracted pure helpers, not deploy() itself — so nothing previously failed
- * if the `source_metadata` argument were dropped from the live multipart
- * POST, or if the real shouldCollectGitMetadata() gate (now inside
- * safeCollectSourceMetadata) were bypassed. This drives the real deploy()
- * function end-to-end against an in-process HTTP server and inspects the
- * raw bytes of the live upload request.
+ * Pins the real deploy() wiring — the existing suite (see
+ * deploy-plan-limit.test.ts's header) deliberately tests only deploy()'s
+ * extracted pure helpers, not deploy() itself, so nothing previously failed
+ * if a call site quietly reverted to the unguarded primitive it wraps. This
+ * drives the real deploy() function end-to-end against an in-process HTTP
+ * server and inspects both the raw live upload request and the printed
+ * confirmation output. Covers two call sites (round 3 review):
+ *   - deploy.ts ~593: must go through safeCollectSourceMetadata(), not a
+ *     direct collectSourceMetadata() call — pinned below by the opt-out
+ *     test, which fails if the guard is bypassed (a direct call ignores
+ *     `gitMetadata: false` and always attaches source_metadata).
+ *   - deploy.ts ~707: must go through confirmDeploymentWithRetry(), not a
+ *     single direct fetchDeploymentConfirmation() call — pinned below by
+ *     forcing one transient mismatch from the mock server and asserting the
+ *     deploy still ends up printing the confirmed message (a single fetch
+ *     would only ever see the first, mismatched response).
  */
 import * as http from 'http';
 import { execFileSync } from 'child_process';
@@ -43,6 +51,8 @@ const PROJECT_NAME = 'wiring-project';
 let server: http.Server;
 let port: number;
 let deployRequests: Array<{ body: string }> = [];
+let confirmationCallCount = 0;
+let mismatchesBeforeMatch = 0;
 
 function confirmationBody(): unknown {
     return {
@@ -82,8 +92,12 @@ beforeAll(async () => {
                 return;
             }
             if (req.method === 'GET' && url.includes('include=deployment')) {
+                confirmationCallCount++;
+                const body = confirmationCallCount <= mismatchesBeforeMatch
+                    ? { ...confirmationBody() as object, deployment_matches_deployed_hash: false }
+                    : confirmationBody();
                 res.writeHead(200, { 'Content-Type': 'application/json' });
-                res.end(JSON.stringify(confirmationBody()));
+                res.end(JSON.stringify(body));
                 return;
             }
             if (req.method === 'GET' && /^\/api\/v1\/projects\/[^/?]+$/.test(url)) {
@@ -115,6 +129,8 @@ let sourceDirs: string[] = [];
 beforeEach(() => {
     deployRequests = [];
     sourceDirs = [];
+    confirmationCallCount = 0;
+    mismatchesBeforeMatch = 0;
     process.env.SOLIDACTIONS_HOST = `http://127.0.0.1:${port}`;
     process.env.SOLIDACTIONS_API_KEY = 'test-key';
     process.env.SOLIDACTIONS_WORKSPACE_ID = 'workspace-1';
@@ -164,5 +180,25 @@ describe('deploy() live wiring — source provenance', () => {
 
         expect(deployRequests).toHaveLength(1);
         expect(deployRequests[0].body).not.toContain('name="source_metadata"');
+    }, 10_000);
+});
+
+describe('deploy() live wiring — confirmation retry', () => {
+    it('retries the live confirmation fetch through a transient mismatch and still prints confirmed (app #972 lag)', async () => {
+        mismatchesBeforeMatch = 1; // first confirmation GET mismatches; second (real retry) matches
+
+        const logs: string[] = [];
+        const originalLog = console.log;
+        console.log = (...args: unknown[]) => { logs.push(args.map(String).join(' ')); };
+        try {
+            await runDeploy();
+        } finally {
+            console.log = originalLog;
+        }
+
+        // A single direct fetch (no retry) would only ever see the first,
+        // mismatched response and never reach the confirmed message.
+        expect(confirmationCallCount).toBeGreaterThanOrEqual(2);
+        expect(logs.join('\n')).toContain('Deployment revision confirmed.');
     }, 10_000);
 });

--- a/tests/deploy-metadata-safety.test.ts
+++ b/tests/deploy-metadata-safety.test.ts
@@ -1,0 +1,47 @@
+/**
+ * collectSourceMetadata() collection is documented as "optional, best effort"
+ * (see the comment above its call site in deploy()), but had no exception
+ * boundary. safeCollectSourceMetadata is the extracted, independently
+ * testable wrapper — following this suite's convention of testing deploy()'s
+ * pure helpers rather than deploy() itself (see deploy-plan-limit.test.ts).
+ */
+import { describe, expect, it } from 'vitest';
+import { safeCollectSourceMetadata } from '../src/commands/deploy';
+import type { SourceMetadata } from '../src/utils/source-provenance';
+
+const metadata: SourceMetadata = {
+    metadata_source: 'git',
+    commit_sha: '0123456789abcdef0123456789abcdef01234567',
+    short_sha: '0123456789ab',
+    branch: 'main',
+    tag: null,
+    commit_subject: 'Subject',
+    commit_author_date: '2026-07-27T10:11:12-05:00',
+    remote_url: null,
+    dirty: false,
+};
+
+describe('safeCollectSourceMetadata', () => {
+    it('degrades to null instead of throwing when the collector throws', () => {
+        const throwingCollector = (): SourceMetadata | null => {
+            throw new Error('git binary not found');
+        };
+
+        expect(safeCollectSourceMetadata('/any/source', {}, throwingCollector)).toBeNull();
+    });
+
+    it('returns the collector result when it succeeds', () => {
+        expect(safeCollectSourceMetadata('/any/source', {}, () => metadata)).toEqual(metadata);
+    });
+
+    it('does not call the collector when the privacy opt-out is set', () => {
+        let called = false;
+        const collector = (): SourceMetadata | null => {
+            called = true;
+            return metadata;
+        };
+
+        expect(safeCollectSourceMetadata('/any/source', { gitMetadata: false }, collector)).toBeNull();
+        expect(called).toBe(false);
+    });
+});

--- a/tests/flag-consistency.test.ts
+++ b/tests/flag-consistency.test.ts
@@ -194,6 +194,14 @@ describe('flag consistency (F-C4)', () => {
         expect(result.stdout).toMatch(/--wait/);
     });
 
+    it('project deploy: --no-git-metadata help accurately describes remote repository provenance', async () => {
+        const result = await runCliHelp(['project', 'deploy', '--help']);
+
+        expect(result.stdout).toMatch(/sanitized remote repository (?:URL|identity)/i);
+        expect(result.stdout).toMatch(/credentials (?:are )?stripped/i);
+        expect(result.stdout).not.toMatch(/remote hostname\)/i);
+    });
+
     it('run start: --wait (long form) waits for completion and reports success', async () => {
         const home = tmpHomeWithConfig();
         const result = await runCli(['run', 'start', 'my-project', 'my-workflow', '--wait'], home);

--- a/tests/package-metadata.test.ts
+++ b/tests/package-metadata.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Pins two package.json fields per PR #90's fix round:
+ * - engines.node floor: archiver@8 resolves readdir-glob -> minimatch ->
+ *   brace-expansion@5.0.8, which declares `"node": "20 || >=22"` — a
+ *   PRODUCTION dependency path (verified via `npm ls brace-expansion --omit=dev`).
+ *   Node 18 is EOL; the floor must be >=20.
+ * - version: publish.yml rewrites this from the release tag before packing
+ *   (since 3e1c966), so the in-repo field is vestigial. It must not be
+ *   "corrected" ad hoc to track the live published version.
+ */
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+function readPackageJson(): Record<string, unknown> {
+    const raw = fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8');
+    return JSON.parse(raw);
+}
+
+describe('package.json metadata', () => {
+    it('requires Node >=20 (brace-expansion@5.0.8, a production dependency, needs it)', () => {
+        const pkg = readPackageJson();
+        expect((pkg.engines as Record<string, string>).node).toBe('>=20.0.0');
+    });
+
+    it('leaves the vestigial version field untouched by this PR (publish.yml rewrites it from the release tag)', () => {
+        const pkg = readPackageJson();
+        expect(pkg.version).toBe('1.33.0');
+    });
+});

--- a/tests/project-view.test.ts
+++ b/tests/project-view.test.ts
@@ -116,6 +116,16 @@ describe('project view request and rendering', () => {
         expect(output).not.toMatch(/[\u001b\u202e\u200b\u0000]/);
     });
 
+    it('sanitizes credentials out of remote_url even if an unnormalized server response carries them', () => {
+        const body = structuredClone(responseBody) as any;
+        body.latest_successful_deployment.remote_url = 'https://user:secret@host.example/repo';
+
+        const output = formatProjectView(body).join('\n');
+        expect(output).toContain('Remote: https://host.example/repo');
+        expect(output).not.toContain('secret');
+        expect(output).not.toContain('user:secret@');
+    });
+
     it('labels CI dirty state as unknown', () => {
         const body = structuredClone(responseBody) as any;
         body.latest_successful_deployment.metadata_source = 'github_actions';

--- a/tests/project-view.test.ts
+++ b/tests/project-view.test.ts
@@ -1,0 +1,175 @@
+import * as http from 'http';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import {
+    formatProjectView,
+    projectSlugForView,
+    projectViewWithConfig,
+    type ProjectDeploymentDetail,
+} from '../src/commands/project-view';
+import type { Config } from '../src/utils/config';
+
+let server: http.Server;
+let port: number;
+let requests: string[] = [];
+let responseBody: Record<string, unknown>;
+
+beforeAll(async () => {
+    server = http.createServer((req, res) => {
+        requests.push(req.url ?? '');
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(responseBody));
+    });
+    await new Promise<void>((resolve) => {
+        server.listen(0, '127.0.0.1', () => {
+            port = (server.address() as { port: number }).port;
+            resolve();
+        });
+    });
+});
+
+afterAll(() => new Promise<void>((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve());
+}));
+
+beforeEach(() => {
+    requests = [];
+    responseBody = {
+        slug: 'billing-dev',
+        status: 'deployed',
+        deployed_hash: 'archive-md5',
+        deployment_matches_deployed_hash: true,
+        latest_successful_deployment: {
+            id: 'deployment-1',
+            status: 'succeeded',
+            source_hash: 'archive-md5',
+            metadata_source: 'git',
+            commit_sha: 'abcdef1234567890',
+            short_sha: 'abcdef123456',
+            branch: 'feature/payments',
+            tag: 'v2.0.0',
+            commit_subject: 'Ship payments',
+            commit_author_date: '2026-07-27T10:00:00-05:00',
+            remote_url: 'git@example.test:team/repo.git',
+            dirty: false,
+            completed_at: '2026-07-27T15:00:00Z',
+        },
+    };
+});
+
+function config(): Config {
+    return {
+        host: `http://127.0.0.1:${port}`,
+        apiKey: 'test-key',
+        workspaceId: 'workspace-1',
+    };
+}
+
+describe('project slug resolution for view', () => {
+    it('treats the positional value as an exact slug when --env is absent', () => {
+        expect(projectSlugForView('Already-Exact_slug', undefined)).toBe('Already-Exact_slug');
+    });
+
+    it('uses the supplied production slug unchanged', () => {
+        expect(projectSlugForView('billing-api', 'production')).toBe('billing-api');
+    });
+
+    it('derives staging and dev slugs with the deploy slug rule', () => {
+        expect(projectSlugForView('Billing API', 'staging')).toBe('billing-api-staging');
+        expect(projectSlugForView('Billing API', 'dev')).toBe('billing-api-dev');
+    });
+
+    it('rejects unsupported explicit environments', () => {
+        expect(() => projectSlugForView('billing', 'qa')).toThrow(/production.*staging.*dev/i);
+    });
+});
+
+describe('project view request and rendering', () => {
+    it('requests the exact slug with the bounded deployment include', async () => {
+        const lines: string[] = [];
+        await projectViewWithConfig('billing-dev', {}, config(), (line) => lines.push(line));
+
+        expect(requests).toEqual(['/api/v1/projects/billing-dev?include=deployment']);
+        expect(lines.join('\n')).toContain('Status: deployed');
+        expect(lines.join('\n')).toContain('abcdef123456');
+        expect(lines.join('\n')).toContain('clean');
+        expect(lines.join('\n')).toContain('Client-reported');
+    });
+
+    it('renders dirty as a prominent warning and preserves ordinary Unicode', () => {
+        const body = structuredClone(responseBody) as any;
+        body.latest_successful_deployment.dirty = true;
+        body.latest_successful_deployment.commit_subject = 'Ship café 東京';
+
+        const output = formatProjectView(body).join('\n');
+        expect(output).toContain('DIRTY');
+        expect(output).toContain('Ship café 東京');
+    });
+
+    it('strips controls, bidi overrides, and zero-width characters at rendering', () => {
+        const body = structuredClone(responseBody) as any;
+        body.latest_successful_deployment.branch = 'fea\u001bture/\u202egnimoc\u200b';
+        body.latest_successful_deployment.commit_subject = 'safe\u0000 subject';
+
+        const output = formatProjectView(body).join('\n');
+        expect(output).toContain('feature/gnimoc');
+        expect(output).toContain('safe subject');
+        expect(output).not.toMatch(/[\u001b\u202e\u200b\u0000]/);
+    });
+
+    it('labels CI dirty state as unknown', () => {
+        const body = structuredClone(responseBody) as any;
+        body.latest_successful_deployment.metadata_source = 'github_actions';
+        body.latest_successful_deployment.dirty = null;
+
+        expect(formatProjectView(body).join('\n')).toContain('dirty state unknown');
+    });
+
+    it('does not invent a revision when the successful deployment has no metadata', () => {
+        const body = {
+            slug: 'no-revision',
+            status: 'deployed',
+            deployed_hash: 'archive-md5',
+            deployment_matches_deployed_hash: true,
+            latest_successful_deployment: {
+                id: 'deployment-no-revision',
+                status: 'succeeded',
+                source_hash: 'archive-md5',
+                metadata_source: null,
+                commit_sha: null,
+                short_sha: null,
+                branch: null,
+                tag: null,
+                commit_subject: null,
+                commit_author_date: null,
+                remote_url: null,
+                dirty: null,
+                completed_at: '2026-07-27T15:00:00Z',
+            },
+        } satisfies ProjectDeploymentDetail;
+
+        expect(formatProjectView(body).join('\n')).toContain('No source revision was reported');
+    });
+
+    it('does not show an older revision when the deployed hash does not match', () => {
+        const body = structuredClone(responseBody) as any;
+        body.deployment_matches_deployed_hash = false;
+
+        const output = formatProjectView(body).join('\n');
+        expect(output).toContain('Revision unknown for the running build');
+        expect(output).not.toContain('abcdef123456');
+    });
+
+    it('uses the neutral legacy message when provenance predates tracking', () => {
+        const body = {
+            slug: 'legacy',
+            status: 'deployed',
+            deployed_hash: null,
+            deployment_matches_deployed_hash: false,
+            latest_successful_deployment: null,
+        };
+
+        expect(formatProjectView(body).join('\n')).toContain(
+            'No deployment provenance recorded (deployed before tracking)',
+        );
+    });
+});

--- a/tests/pull.test.ts
+++ b/tests/pull.test.ts
@@ -20,15 +20,15 @@
 import * as fs from 'fs';
 import * as http from 'http';
 import * as path from 'path';
-import archiver from 'archiver';
 import { describe, expect, it, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
 import { pull } from '../src/commands/pull';
+import { createTarArchive } from '../src/utils/tar-archive';
 import { makeTmpEnv, writeGlobal } from './helpers';
 
 /** Build a gzip tar buffer mirroring deploy.ts's upload shape. */
-function buildFixtureArchive(): Promise<Buffer> {
+async function buildFixtureArchive(): Promise<Buffer> {
+    const archive = await createTarArchive({ gzip: true, gzipOptions: { level: 9 } });
     return new Promise((resolve, reject) => {
-        const archive = archiver('tar', { gzip: true, gzipOptions: { level: 9 } });
         const chunks: Buffer[] = [];
         archive.on('data', (chunk) => chunks.push(chunk));
         archive.on('error', reject);

--- a/tests/source-provenance.test.ts
+++ b/tests/source-provenance.test.ts
@@ -90,6 +90,34 @@ describe('sanitizeRemoteUrl', () => {
             'example.test:acme/repo.git',
         );
     });
+
+    it('strips credentials behind a git remote-helper prefix', () => {
+        expect(sanitizeRemoteUrl('hg::https://token:secret@host.example/repo')).toBe(
+            'hg::https://host.example/repo',
+        );
+    });
+
+    it('drops a secret query string behind a git remote-helper prefix', () => {
+        expect(sanitizeRemoteUrl('hg::https://host.example/repo?access_token=secret')).toBe(
+            'hg::https://host.example/repo',
+        );
+    });
+
+    it('passes an unrecognized remainder behind a helper prefix through unchanged', () => {
+        expect(sanitizeRemoteUrl('fossil::/local/path')).toBe('fossil::/local/path');
+    });
+
+    it('strips credentials from a protocol-relative remote', () => {
+        expect(sanitizeRemoteUrl('//token:secret@host.example/repo')).toBe(
+            '//host.example/repo',
+        );
+    });
+
+    it('drops query and fragment from a protocol-relative remote', () => {
+        expect(sanitizeRemoteUrl('//host.example/repo?access_token=secret#frag')).toBe(
+            '//host.example/repo',
+        );
+    });
 });
 
 describe('collectSourceMetadata — local Git', () => {

--- a/tests/source-provenance.test.ts
+++ b/tests/source-provenance.test.ts
@@ -1,0 +1,337 @@
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import FormData from 'form-data';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+    buildDeployForm,
+    collectSourceMetadata,
+    createDeployArchiveLocation,
+    parseDeployAcceptance,
+    shouldCollectGitMetadata,
+} from '../src/utils/source-provenance';
+
+const roots: string[] = [];
+
+function tempDir(prefix: string): string {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+    roots.push(root);
+    return root;
+}
+
+function git(cwd: string, ...args: string[]): string {
+    return execFileSync('git', ['-C', cwd, ...args], { encoding: 'utf8' }).trim();
+}
+
+async function multipartBody(form: FormData): Promise<string> {
+    const chunks: Buffer[] = [];
+    await new Promise<void>((resolve, reject) => {
+        form.on('data', (chunk: Buffer | string) => {
+            chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+        });
+        form.on('end', resolve);
+        form.on('error', reject);
+        form.resume();
+    });
+    return Buffer.concat(chunks).toString('utf8');
+}
+
+function repository(): string {
+    const root = tempDir('sa-provenance-git-');
+    git(root, 'init', '-b', 'main');
+    git(root, 'config', 'user.name', 'Provenance Test');
+    git(root, 'config', 'user.email', 'provenance@example.test');
+    fs.writeFileSync(path.join(root, 'tracked.txt'), 'clean\n');
+    git(root, 'add', 'tracked.txt');
+    git(root, 'commit', '-m', 'Initial subject');
+    git(root, 'remote', 'add', 'origin', 'https://deploy-user:secret@example.test/acme/private.git');
+    return root;
+}
+
+afterEach(() => {
+    for (const root of roots.splice(0)) {
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+});
+
+describe('collectSourceMetadata — local Git', () => {
+    it('collects a clean branch, SHA, subject, author date, and credential-free remote', () => {
+        const root = repository();
+        const metadata = collectSourceMetadata(root, {});
+
+        expect(metadata).toMatchObject({
+            metadata_source: 'git',
+            commit_sha: git(root, 'rev-parse', 'HEAD'),
+            short_sha: git(root, 'rev-parse', '--short=12', 'HEAD'),
+            branch: 'main',
+            commit_subject: 'Initial subject',
+            dirty: false,
+            remote_url: 'https://example.test/acme/private.git',
+        });
+        expect(metadata?.commit_author_date).toMatch(/^\d{4}-\d{2}-\d{2}T.*[+-]\d{2}:\d{2}$/);
+    });
+
+    it('includes tracked and untracked changes in the deployed subtree only', () => {
+        const root = repository();
+        const deployed = path.join(root, 'packages', 'deployed');
+        const sibling = path.join(root, 'packages', 'sibling');
+        fs.mkdirSync(deployed, { recursive: true });
+        fs.mkdirSync(sibling, { recursive: true });
+        fs.writeFileSync(path.join(deployed, 'workflow.ts'), 'export {};\n');
+        fs.writeFileSync(path.join(sibling, 'outside.ts'), 'export {};\n');
+        git(root, 'add', '.');
+        git(root, 'commit', '-m', 'Add monorepo packages');
+
+        fs.writeFileSync(path.join(sibling, 'outside.ts'), 'changed outside\n');
+        expect(collectSourceMetadata(deployed, {})?.dirty).toBe(false);
+
+        fs.writeFileSync(path.join(deployed, 'workflow.ts'), 'changed in deploy\n');
+        expect(collectSourceMetadata(deployed, {})?.dirty).toBe(true);
+        git(root, 'checkout', '--', 'packages/deployed/workflow.ts');
+        expect(collectSourceMetadata(deployed, {})?.dirty).toBe(false);
+
+        fs.writeFileSync(path.join(deployed, 'untracked.txt'), 'included in deploy\n');
+        expect(collectSourceMetadata(deployed, {})?.dirty).toBe(true);
+    });
+
+    it('discovers Git from a subdirectory and a linked worktree', () => {
+        const root = repository();
+        const nested = path.join(root, 'nested', 'project');
+        fs.mkdirSync(nested, { recursive: true });
+        fs.writeFileSync(path.join(nested, 'workflow.ts'), 'export {};\n');
+        git(root, 'add', '.');
+        git(root, 'commit', '-m', 'Add nested project');
+        expect(collectSourceMetadata(nested, {})?.commit_sha).toBe(git(root, 'rev-parse', 'HEAD'));
+
+        const worktree = tempDir('sa-provenance-worktree-');
+        fs.rmSync(worktree, { recursive: true, force: true });
+        git(root, 'worktree', 'add', '-b', 'deploy-worktree', worktree);
+        expect(collectSourceMetadata(worktree, {})).toMatchObject({
+            branch: 'deploy-worktree',
+            dirty: false,
+        });
+    });
+
+    it('reports nearest tag and no invented branch for detached HEAD', () => {
+        const root = repository();
+        git(root, 'tag', 'v1.2.3');
+        git(root, 'checkout', '--detach', 'HEAD');
+
+        expect(collectSourceMetadata(root, {})).toMatchObject({
+            branch: null,
+            tag: 'v1.2.3',
+            dirty: false,
+        });
+    });
+
+    it('strips terminal controls, bidi, and zero-width formatting from display strings', () => {
+        const root = repository();
+        git(root, 'remote', 'set-url', 'origin', 'git@example.test:acme/repo\u202E.git');
+        fs.writeFileSync(path.join(root, 'subject.txt'), 'next\n');
+        git(root, 'add', '.');
+        git(root, 'commit', '-m', 'Safe\u200B subject');
+
+        const metadata = collectSourceMetadata(root, {});
+
+        expect(metadata?.commit_subject).toBe('Safe subject');
+        expect(metadata?.remote_url).toBe('git@example.test:acme/repo.git');
+    });
+
+    it('returns no metadata for a non-repository directory', () => {
+        expect(collectSourceMetadata(tempDir('sa-provenance-plain-'), {})).toBeNull();
+    });
+
+    it('keeps a local Git identity when an optional command fails instead of mixing in CI data', () => {
+        const root = repository();
+        git(root, 'remote', 'remove', 'origin');
+
+        expect(collectSourceMetadata(root, {
+            GITHUB_SHA: '0123456789abcdef0123456789abcdef01234567',
+            GITHUB_REF_NAME: 'unrelated-ci-branch',
+            GITHUB_REF_TYPE: 'branch',
+        })).toMatchObject({
+            metadata_source: 'git',
+            branch: 'main',
+            remote_url: null,
+        });
+    });
+});
+
+describe('collectSourceMetadata — CI fallback', () => {
+    const sha = '0123456789abcdef0123456789abcdef01234567';
+
+    it('uses GitHub Actions first and distinguishes pull-request branches and tags', () => {
+        const pr = collectSourceMetadata(tempDir('sa-ci-gh-'), {
+            GITHUB_SHA: sha,
+            GITHUB_HEAD_REF: 'feature/provenance',
+            GITHUB_REF_NAME: '123/merge',
+            GITHUB_REF_TYPE: 'branch',
+            GITHUB_SERVER_URL: 'https://github.example.test',
+            GITHUB_REPOSITORY: 'acme/private',
+        });
+        expect(pr).toMatchObject({
+            metadata_source: 'github_actions',
+            commit_sha: sha,
+            short_sha: sha.slice(0, 12),
+            branch: 'feature/provenance',
+            dirty: null,
+            remote_url: 'https://github.example.test/acme/private',
+        });
+
+        const tag = collectSourceMetadata(tempDir('sa-ci-gh-tag-'), {
+            GITHUB_SHA: sha,
+            GITHUB_REF_NAME: 'v2.0.0',
+            GITHUB_REF_TYPE: 'tag',
+        });
+        expect(tag).toMatchObject({ branch: null, tag: 'v2.0.0' });
+    });
+
+    it('supports GitLab, CircleCI, and Bitbucket variables', () => {
+        expect(collectSourceMetadata(tempDir('sa-ci-gl-'), {
+            CI_COMMIT_SHA: sha,
+            CI_COMMIT_REF_NAME: 'release',
+            CI_COMMIT_TAG: 'v2',
+            CI_COMMIT_TITLE: 'Release\u202E title',
+            CI_COMMIT_TIMESTAMP: '2026-07-27T10:11:12-05:00',
+            CI_REPOSITORY_URL: 'https://oauth2:token@gitlab.example.test/acme/private.git',
+        })).toMatchObject({
+            metadata_source: 'gitlab_ci',
+            branch: 'release',
+            tag: 'v2',
+            commit_subject: 'Release title',
+            remote_url: 'https://gitlab.example.test/acme/private.git',
+            dirty: null,
+        });
+
+        expect(collectSourceMetadata(tempDir('sa-ci-circle-'), {
+            CIRCLE_SHA1: sha,
+            CIRCLE_BRANCH: 'main',
+            CIRCLE_TAG: 'nightly',
+            CIRCLE_REPOSITORY_URL: 'git@example.test:acme/repo.git',
+        })).toMatchObject({
+            metadata_source: 'circleci',
+            branch: 'main',
+            tag: 'nightly',
+            dirty: null,
+        });
+
+        expect(collectSourceMetadata(tempDir('sa-ci-bb-'), {
+            BITBUCKET_COMMIT: sha,
+            BITBUCKET_BRANCH: 'main',
+            BITBUCKET_TAG: 'stable',
+            BITBUCKET_GIT_HTTP_ORIGIN: 'https://x-token-auth:token@bitbucket.example.test/acme/private.git',
+        })).toMatchObject({
+            metadata_source: 'bitbucket_pipelines',
+            branch: 'main',
+            tag: 'stable',
+            remote_url: 'https://bitbucket.example.test/acme/private.git',
+            dirty: null,
+        });
+    });
+
+    it('uses documented CI precedence and ignores incomplete SHA sources', () => {
+        const gitlabSha = 'abcdef0123456789abcdef0123456789abcdef01';
+        expect(collectSourceMetadata(tempDir('sa-ci-precedence-'), {
+            GITHUB_SHA: 'not-a-sha',
+            CI_COMMIT_SHA: gitlabSha,
+            CIRCLE_SHA1: sha,
+        })?.metadata_source).toBe('gitlab_ci');
+    });
+
+    it('omits a malformed optional CI author date so it cannot reject valid SHA metadata', () => {
+        expect(collectSourceMetadata(tempDir('sa-ci-bad-date-'), {
+            CI_COMMIT_SHA: sha,
+            CI_COMMIT_TIMESTAMP: 'not-an-iso-date',
+        })).toMatchObject({
+            metadata_source: 'gitlab_ci',
+            commit_author_date: null,
+        });
+    });
+});
+
+describe('deploy provenance transport', () => {
+    const metadata = {
+        metadata_source: 'git' as const,
+        commit_sha: '0123456789abcdef0123456789abcdef01234567',
+        short_sha: '0123456789ab',
+        branch: 'main',
+        tag: null,
+        commit_subject: 'Subject',
+        commit_author_date: '2026-07-27T10:11:12-05:00',
+        remote_url: 'https://example.test/acme/repo.git',
+        dirty: false,
+    };
+
+    it('builds the live deploy multipart with the archive and one normalized source_metadata field', async () => {
+        const archive = path.join(tempDir('sa-deploy-form-'), 'source.tar.gz');
+        fs.writeFileSync(archive, 'valid archive bytes');
+        const body = await multipartBody(buildDeployForm(archive, metadata));
+
+        expect(body).toContain('name="source"');
+        expect(body).toContain('valid archive bytes');
+        expect(body).toContain('name="source_metadata"');
+        expect(body).toContain(JSON.stringify(metadata));
+    });
+
+    it('keeps a non-repository source upload valid without adding a metadata field', async () => {
+        const root = tempDir('sa-nonrepo-deploy-');
+        const archive = path.join(root, 'source.tar.gz');
+        fs.writeFileSync(archive, 'valid archive bytes');
+        const body = await multipartBody(buildDeployForm(archive, collectSourceMetadata(root, {})));
+
+        expect(body).toContain('name="source"');
+        expect(body).not.toContain('name="source_metadata"');
+    });
+
+    it('builds a source-only multipart when either privacy opt-out omits collected metadata', async () => {
+        const archive = path.join(tempDir('sa-private-deploy-'), 'source.tar.gz');
+        fs.writeFileSync(archive, 'valid archive bytes');
+
+        for (const enabled of [
+            shouldCollectGitMetadata({ gitMetadata: false }, {}),
+            shouldCollectGitMetadata({}, { SOLIDACTIONS_NO_GIT_METADATA: '1' }),
+        ]) {
+            const body = await multipartBody(buildDeployForm(archive, enabled ? metadata : null));
+            expect(body).toContain('name="source"');
+            expect(body).not.toContain('name="source_metadata"');
+        }
+    });
+
+    it('omits metadata for either privacy opt-out', () => {
+        expect(shouldCollectGitMetadata({ gitMetadata: false }, {})).toBe(false);
+        expect(shouldCollectGitMetadata({}, { SOLIDACTIONS_NO_GIT_METADATA: '1' })).toBe(false);
+        expect(shouldCollectGitMetadata({}, {})).toBe(true);
+    });
+
+    it('creates the archive outside the source tree and removes its whole temp directory', () => {
+        const source = tempDir('sa-provenance-source-');
+        const location = createDeployArchiveLocation();
+        roots.push(location.directory);
+
+        expect(path.relative(source, location.archivePath)).toMatch(/^\.\./);
+        expect(location.archivePath).not.toContain('.steps-deploy.tar.gz');
+        fs.writeFileSync(location.archivePath, 'archive');
+        location.cleanup();
+        expect(fs.existsSync(location.directory)).toBe(false);
+        expect(fs.readdirSync(source)).toEqual([]);
+    });
+
+    it('captures the accepted deployment identity, normalized metadata, and safe rejection code', () => {
+        expect(parseDeployAcceptance({
+            deployment_id: 'deployment-123',
+            source_metadata: metadata,
+            source_metadata_rejected: 'invalid_commit_sha',
+        })).toEqual({
+            deploymentId: 'deployment-123',
+            sourceMetadata: metadata,
+            sourceMetadataRejected: 'invalid_commit_sha',
+        });
+
+        expect(parseDeployAcceptance({ message: 'queued' })).toEqual({
+            deploymentId: null,
+            sourceMetadata: null,
+            sourceMetadataRejected: null,
+        });
+    });
+});

--- a/tests/source-provenance.test.ts
+++ b/tests/source-provenance.test.ts
@@ -9,6 +9,7 @@ import {
     collectSourceMetadata,
     createDeployArchiveLocation,
     parseDeployAcceptance,
+    sanitizeRemoteUrl,
     shouldCollectGitMetadata,
 } from '../src/utils/source-provenance';
 
@@ -53,6 +54,42 @@ afterEach(() => {
     for (const root of roots.splice(0)) {
         fs.rmSync(root, { recursive: true, force: true });
     }
+});
+
+describe('sanitizeRemoteUrl', () => {
+    it('strips credentials from a ssh:// remote', () => {
+        expect(sanitizeRemoteUrl('ssh://token:secret@host.example/acme/repo.git')).toBe(
+            'ssh://host.example/acme/repo.git',
+        );
+    });
+
+    it('strips a credential-bearing user from an SCP-style remote', () => {
+        expect(sanitizeRemoteUrl('token@host.example:acme/repo.git')).toBe(
+            'host.example:acme/repo.git',
+        );
+    });
+
+    it('drops a secret carried in the query string of an https remote', () => {
+        expect(sanitizeRemoteUrl('https://host.example/acme/repo.git?access_token=secret')).toBe(
+            'https://host.example/acme/repo.git',
+        );
+    });
+
+    it('drops a fragment from a remote URL', () => {
+        expect(sanitizeRemoteUrl('https://host.example/acme/repo.git#readme')).toBe(
+            'https://host.example/acme/repo.git',
+        );
+    });
+
+    it('keeps a bracketed IPv6 canonical https remote valid', () => {
+        expect(sanitizeRemoteUrl('https://[::1]:443/repo')).toBe('https://[::1]/repo');
+    });
+
+    it('passes a benign SCP-style remote through with the host intact', () => {
+        expect(sanitizeRemoteUrl('git@example.test:acme/repo.git')).toBe(
+            'example.test:acme/repo.git',
+        );
+    });
 });
 
 describe('collectSourceMetadata — local Git', () => {
@@ -151,7 +188,7 @@ describe('collectSourceMetadata — local Git', () => {
         const metadata = collectSourceMetadata(root, {});
 
         expect(metadata?.commit_subject).toBe('Safe subject');
-        expect(metadata?.remote_url).toBe('git@example.test:acme/repo.git');
+        expect(metadata?.remote_url).toBe('example.test:acme/repo.git');
     });
 
     it('returns no metadata for a non-repository directory', () => {

--- a/tests/source-provenance.test.ts
+++ b/tests/source-provenance.test.ts
@@ -113,7 +113,7 @@ describe('collectSourceMetadata — local Git', () => {
         });
     });
 
-    it('reports nearest tag and no invented branch for detached HEAD', () => {
+    it('reports a tag pointing exactly at HEAD and no invented branch for detached HEAD', () => {
         const root = repository();
         git(root, 'tag', 'v1.2.3');
         git(root, 'checkout', '--detach', 'HEAD');
@@ -121,6 +121,20 @@ describe('collectSourceMetadata — local Git', () => {
         expect(collectSourceMetadata(root, {})).toMatchObject({
             branch: null,
             tag: 'v1.2.3',
+            dirty: false,
+        });
+    });
+
+    it('does not report a tag that points only at an ancestor of HEAD', () => {
+        const root = repository();
+        git(root, 'tag', 'v1.2.3');
+        fs.writeFileSync(path.join(root, 'later.txt'), 'later clean commit\n');
+        git(root, 'add', 'later.txt');
+        git(root, 'commit', '-m', 'Later untagged commit');
+
+        expect(collectSourceMetadata(root, {})).toMatchObject({
+            commit_sha: git(root, 'rev-parse', 'HEAD'),
+            tag: null,
             dirty: false,
         });
     });

--- a/tests/source-provenance.test.ts
+++ b/tests/source-provenance.test.ts
@@ -69,7 +69,9 @@ describe('collectSourceMetadata — local Git', () => {
             dirty: false,
             remote_url: 'https://example.test/acme/private.git',
         });
-        expect(metadata?.commit_author_date).toMatch(/^\d{4}-\d{2}-\d{2}T.*[+-]\d{2}:\d{2}$/);
+        expect(metadata?.commit_author_date).toMatch(
+            /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/,
+        );
     });
 
     it('includes tracked and untracked changes in the deployed subtree only', () => {


### PR DESCRIPTION
## Summary

- collect real local Git or supported CI provenance for project deploy, including subtree dirtiness and exact-HEAD tags
- sanitize display metadata and credential-bearing remotes; support --no-git-metadata and SOLIDACTIONS_NO_GIT_METADATA
- upload provenance with the temporary source archive and capture the accepted deployment identity
- confirm the server-recorded deployed revision after builds and add project view
- distinguish clean, DIRTY, unknown, absent, mismatch, and deployment-ID mismatch states
- document the new behavior and bump the CLI to 1.34.0

Companion to SolidActions/solidactions-app#966 for SolidActions/solidactions-app#956. The app/runner PR must land before this CLI version is released.

## Verification

- full Vitest: 805 passed
- focused provenance/help review: 31 passed
- TypeScript build and release check green
- live isolated-stack clean/dirty/CI/non-repo/cache/rebuild/project-view smoke
- context-free Claude TUI cleanroom round 2: Approved

Cleanroom round 1 found ancestor-tag misattribution and understated privacy help; commit 5b59632 added red regressions and fixed both before the approved second round.