### PR TITLE
Add OAuth connection mapping commands (#992)

### DIFF
--- a/src/commands/connection-list.ts
+++ b/src/commands/connection-list.ts
@@ -1,0 +1,71 @@
+import axios from 'axios';
+import chalk from 'chalk';
+import { getApiHeaders, requireConfigWithWorkspace } from '../utils/api';
+import { renderTable, sanitizeCell, truncateCell } from '../utils/table';
+
+interface OAuthConnection {
+    name: string;
+    provider: string;
+    status: string;
+    error_message: string | null;
+    last_used_at: string | null;
+}
+
+const ERROR_SNIPPET_WIDTH = 40;
+
+function connectionStatus(connection: OAuthConnection): string {
+    const status = connection.status || '?';
+    const error = connection.error_message?.trim();
+
+    if (!error) {
+        return status;
+    }
+
+    return `${status} — ${truncateCell(sanitizeCell(error), ERROR_SNIPPET_WIDTH)}`;
+}
+
+export async function connectionList(): Promise<void> {
+    const config = await requireConfigWithWorkspace();
+
+    try {
+        const response = await axios.get(`${config.host}/api/v1/connections`, {
+            headers: getApiHeaders(config),
+        });
+        const connections: OAuthConnection[] = response.data.data || [];
+
+        if (connections.length === 0) {
+            console.log(chalk.gray('No connections found.'));
+            return;
+        }
+
+        console.log(chalk.blue('Connections:\n'));
+
+        const rows = connections.map((connection) => [
+            connection.name || '?',
+            connection.provider || '?',
+            connectionStatus(connection),
+            connection.last_used_at || '-',
+        ]);
+        const lines = renderTable(['NAME', 'PROVIDER', 'STATUS', 'LAST USED'], rows, {
+            minWidths: [24, 14, 20],
+        });
+
+        console.log(chalk.gray(lines[0]));
+        console.log(chalk.gray(lines[1]));
+        for (const line of lines.slice(2)) {
+            console.log(line);
+        }
+
+        console.log('');
+        console.log(chalk.gray(`${connections.length} connection(s)`));
+    } catch (error: any) {
+        if (error.response?.status === 401) {
+            console.error(chalk.red('Authentication failed. Run "solidactions login --global" to re-configure.'));
+        } else if (error.response) {
+            console.error(chalk.red(`Failed: ${error.response.status}`), error.response.data);
+        } else {
+            console.error(chalk.red('Connection failed:'), error.message);
+        }
+        process.exit(1);
+    }
+}

--- a/src/commands/env-reset.ts
+++ b/src/commands/env-reset.ts
@@ -49,7 +49,7 @@ export async function envReset(projectName: string, key: string, options: EnvRes
             {},
             { headers: getApiHeaders(config, 'application/json') }
         );
-        const restored = resetResponse.data;
+        const restored = resetResponse.data.mapping;
 
         console.log(chalk.green(
             `Variable "${key}" reset to ${describeRestoredSource(restored)} ` +

--- a/src/commands/env-reset.ts
+++ b/src/commands/env-reset.ts
@@ -1,0 +1,76 @@
+import axios from 'axios';
+import chalk from 'chalk';
+import { describeProjectEnvironments, getApiHeaders, requireConfigWithWorkspace } from '../utils/api';
+
+interface EnvResetOptions {
+    env?: string;
+}
+
+function describeRestoredSource(mapping: any): string {
+    const sourceType = mapping.source_type || mapping.source || 'unknown';
+
+    if (sourceType === 'oauth_connection') {
+        const connection = mapping.oauth_connection_name || mapping.oauth_connection_id;
+        return connection ? `oauth_connection "${connection}"` : 'oauth_connection';
+    }
+
+    if (sourceType === 'global_variable') {
+        const globalKey = mapping.global_variable_key;
+        return globalKey ? `global_variable "${globalKey}"` : 'global_variable';
+    }
+
+    return sourceType;
+}
+
+export async function envReset(projectName: string, key: string, options: EnvResetOptions = {}): Promise<void> {
+    const config = await requireConfigWithWorkspace();
+    const environment = options.env || 'dev';
+    const projectSlug = environment === 'production'
+        ? projectName
+        : `${projectName}-${environment}`;
+
+    try {
+        const listResponse = await axios.get(
+            `${config.host}/api/v1/projects/${projectSlug}/variable-mappings`,
+            { headers: getApiHeaders(config) }
+        );
+        const mappings = listResponse.data || [];
+        const mapping = mappings.find((candidate: any) => candidate.env_name === key);
+
+        if (!mapping) {
+            console.error(chalk.red(
+                `Variable "${key}" has no variable mapping in project "${projectName}" (${environment}).`
+            ));
+            process.exit(1);
+        }
+
+        const resetResponse = await axios.post(
+            `${config.host}/api/v1/projects/${projectSlug}/variable-mappings/${mapping.id}/reset`,
+            {},
+            { headers: getApiHeaders(config, 'application/json') }
+        );
+        const restored = resetResponse.data;
+
+        console.log(chalk.green(
+            `Variable "${key}" reset to ${describeRestoredSource(restored)} ` +
+            `in project "${projectName}" (${environment}).`
+        ));
+    } catch (error: any) {
+        if (error.response) {
+            if (error.response.status === 401) {
+                console.error(chalk.red('Authentication failed. Run "solidactions login --global" to re-configure.'));
+            } else if (error.response.status === 404) {
+                const envsList = await describeProjectEnvironments(config, projectName);
+                console.error(chalk.red(
+                    `Project "${projectName}" has no ${environment} environment` +
+                    `${envsList ? ` (exists in: ${envsList})` : ''}.`
+                ));
+            } else {
+                console.error(chalk.red(`Failed: ${error.response.status}`), error.response.data);
+            }
+        } else {
+            console.error(chalk.red('Connection failed:'), error.message);
+        }
+        process.exit(1);
+    }
+}

--- a/src/commands/env-set.ts
+++ b/src/commands/env-set.ts
@@ -20,6 +20,7 @@ export const GLOBAL_ENV_SCOPE_NOTE = [
 interface EnvSetOptions {
     secret?: boolean;
     env?: string;
+    oauthConnection?: string;
     yes?: boolean;
     stagingValue?: string;
     devValue?: string;
@@ -31,7 +32,15 @@ interface EnvSetOptions {
 
 export async function envSet(keyOrProject: string, valueOrKey?: string, valueIfProject?: string, options: EnvSetOptions = {}): Promise<void> {
     // Detect mode based on arguments
-    const isProjectMode = valueIfProject !== undefined;
+    const isOauthConnectionMode = options.oauthConnection !== undefined;
+    const isProjectMode = valueIfProject !== undefined || isOauthConnectionMode;
+
+    if (isOauthConnectionMode && (valueIfProject !== undefined || options.global)) {
+        process.stderr.write(chalk.red(
+            'env set: --oauth-connection binds a project key; give <project> <KEY> and no value\n'
+        ));
+        process.exit(1);
+    }
 
     // Jordan Wall #4 (Sweep C, → 1.23.0): a 2-positional-arg call used to fall
     // through to GLOBAL scope silently, so a typo'd `env set KEY VALUE` (meant
@@ -86,6 +95,25 @@ export async function envSet(keyOrProject: string, valueOrKey?: string, valueIfP
         const isSecret = options.secret || /secret|key|token|password|credential/i.test(key);
 
         try {
+            if (isOauthConnectionMode) {
+                await axios.post(
+                    `${config.host}/api/v1/projects/${projectSlug}/variable-mappings`,
+                    {
+                        project_key: key,
+                        oauth_connection_name: options.oauthConnection,
+                    },
+                    {
+                        headers: getApiHeaders(config, 'application/json'),
+                    }
+                );
+
+                console.log(chalk.green(
+                    `Variable "${key}" bound to OAuth connection "${options.oauthConnection}" ` +
+                    `in project "${projectName}" (${environment}).`
+                ));
+                return;
+            }
+
             // Check if variable already has a value
             if (!options.yes) {
                 const mappingsResponse = await axios.get(

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ import { oauthActionSearch } from './commands/oauth-action-search';
 import { oauthActionList } from './commands/oauth-action-list';
 import { oauthActionView } from './commands/oauth-action-view';
 import { oauthActionPlatforms } from './commands/oauth-action-platforms';
+import { connectionList } from './commands/connection-list';
 import { workspacesList, workspaceSet } from './commands/workspaces';
 import { skillPush } from './commands/skill-push';
 import { skillPublish } from './commands/skill-publish';
@@ -571,6 +572,19 @@ oauthActionCmd
     .option('--json', 'Emit raw JSON for AI/script consumption')
     .action((options) => {
         oauthActionPlatforms(options);
+    });
+
+// =============================================================================
+// connection <subcommand>
+// =============================================================================
+
+const connection = program.command('connection').description('Manage OAuth connections');
+
+connection
+    .command('list')
+    .description('List OAuth connections in the active workspace')
+    .action(() => {
+        connectionList();
     });
 
 // =============================================================================

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import { envDelete } from './commands/env-delete';
 import { envMap } from './commands/env-map';
 import { envPull } from './commands/env-pull';
 import { envPush } from './commands/env-push';
+import { envReset } from './commands/env-reset';
 import { envSet } from './commands/env-set';
 import { scheduleSet } from './commands/schedule-set';
 import { scheduleList } from './commands/schedule-list';
@@ -350,6 +351,16 @@ env
     .option('-y, --yes', 'Skip confirmation prompt')
     .action((keyOrProject, key, options) => {
         envDelete(keyOrProject, key, options);
+    });
+
+env
+    .command('reset')
+    .description('Reset a project variable mapping to its YAML-declared source')
+    .argument('<project>', 'Project name')
+    .argument('<KEY>', 'Variable key')
+    .option('-e, --env <environment>', 'Environment to reset in', 'dev')
+    .action(async (projectName, key, options) => {
+        await envReset(projectName, key, options);
     });
 
 env

--- a/src/index.ts
+++ b/src/index.ts
@@ -319,6 +319,7 @@ env
     .argument('[value]', 'Variable value (when first arg is project)')
     .option('-s, --secret', 'Mark as encrypted secret')
     .option('-e, --env <environment>', 'Target environment (production/staging/dev)', 'dev')
+    .option('--oauth-connection <name>', 'Bind the project key to an OAuth connection')
     .option('--global', 'Set a global variable (no project) — required for the 2-arg form')
     .option('--staging-value <value>', 'Staging environment value (global only)')
     .option('--dev-value <value>', 'Dev environment value (global only)')

--- a/src/index.ts
+++ b/src/index.ts
@@ -358,6 +358,7 @@ env
     .description('Reset a project variable mapping to its YAML-declared source')
     .argument('<project>', 'Project name')
     .argument('<KEY>', 'Variable key')
+    .allowExcessArguments(false)
     .option('-e, --env <environment>', 'Environment to reset in', 'dev')
     .action(async (projectName, key, options) => {
         await envReset(projectName, key, options);

--- a/tests/connection-list.test.ts
+++ b/tests/connection-list.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Contract tests for `solidactions connection list`.
+ *
+ * Test-double policy: the command talks to a real in-process HTTP server and
+ * reads a real temporary CLI config. No mock/spy/stub libraries.
+ */
+import * as childProcess from 'child_process';
+import * as fs from 'fs';
+import * as http from 'http';
+import * as os from 'os';
+import * as path from 'path';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { writeGlobal } from './helpers';
+
+const CLI_BINARY = path.resolve(__dirname, '../dist/index.js');
+
+let server: http.Server;
+let port: number;
+let responseBody: object = { data: [] };
+let capturedRequest: {
+    method: string | undefined;
+    url: string | undefined;
+    headers: http.IncomingHttpHeaders;
+} | null = null;
+
+beforeAll(async () => {
+    server = http.createServer((request, response) => {
+        capturedRequest = {
+            method: request.method,
+            url: request.url,
+            headers: request.headers,
+        };
+        response.writeHead(200, { 'Content-Type': 'application/json' });
+        response.end(JSON.stringify(responseBody));
+    });
+
+    await new Promise<void>((resolve) => {
+        server.listen(0, '127.0.0.1', () => {
+            port = (server.address() as { port: number }).port;
+            resolve();
+        });
+    });
+});
+
+afterAll(() => {
+    return new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+    });
+});
+
+describe('connectionList', () => {
+    let root: string;
+    let home: string;
+    let cwd: string;
+
+    beforeEach(() => {
+        root = fs.mkdtempSync(path.join(os.tmpdir(), 'sa-cli-connection-list-'));
+        home = path.join(root, 'home');
+        cwd = path.join(root, 'work');
+        fs.mkdirSync(home, { recursive: true });
+        fs.mkdirSync(cwd, { recursive: true });
+        writeGlobal(home, {
+            host: `http://127.0.0.1:${port}`,
+            apiKey: 'test-key',
+            workspaceId: 'workspace-1',
+        });
+        capturedRequest = null;
+        responseBody = { data: [] };
+    });
+
+    afterEach(() => {
+        fs.rmSync(root, { recursive: true, force: true });
+    });
+
+    it('GETs the workspace connections endpoint and renders the connection summary table', async () => {
+        responseBody = {
+            data: [
+                {
+                    id: 'connection-1',
+                    name: 'Primary Gmail',
+                    provider: 'gmail',
+                    broker: 'pica',
+                    status: 'connected',
+                    error_message: null,
+                    last_used_at: '2026-07-30T15:04:05.000000Z',
+                    created_at: '2026-07-29T10:00:00.000000Z',
+                    connection_key: 'must-not-print',
+                },
+                {
+                    id: 'connection-2',
+                    name: 'Team Slack',
+                    provider: 'slack',
+                    broker: 'pica',
+                    status: 'error',
+                    error_message: 'Refresh token expired\nReconnect this account before trying again.',
+                    last_used_at: null,
+                    created_at: '2026-07-29T11:00:00.000000Z',
+                    cached_access_token: 'must-not-print-either',
+                },
+            ],
+        };
+
+        const result = await runCli(['connection', 'list'], home, cwd);
+
+        expect(result.status).toBe(0);
+        expect(result.stderr).toBe('');
+        expect(capturedRequest).toMatchObject({
+            method: 'GET',
+            url: '/api/v1/connections',
+        });
+        expect(capturedRequest?.headers.authorization).toBe('Bearer test-key');
+        expect(capturedRequest?.headers['x-workspace-id']).toBe('workspace-1');
+
+        const rendered = result.stdout;
+        expect(rendered).toContain('NAME');
+        expect(rendered).toContain('PROVIDER');
+        expect(rendered).toContain('STATUS');
+        expect(rendered).toContain('LAST USED');
+        expect(rendered).toContain('Primary Gmail');
+        expect(rendered).toContain('gmail');
+        expect(rendered).toContain('connected');
+        expect(rendered).toContain('2026-07-30T15:04:05.000000Z');
+        expect(rendered).toContain('Team Slack');
+        expect(rendered).toContain('error — Refresh token expired\\nReconnect');
+        expect(rendered).toContain('…');
+        expect(rendered).not.toContain('trying again.');
+        expect(rendered).not.toContain('must-not-print');
+    });
+
+    it('reports an empty workspace without rendering a table', async () => {
+        const result = await runCli(['connection', 'list'], home, cwd);
+
+        expect(result.status).toBe(0);
+        expect(result.stderr).toBe('');
+        expect(result.stdout.trim()).toBe('No connections found.');
+    });
+});
+
+describe('connection command registration', () => {
+    it('registers singular `connection list` in the real built CLI', () => {
+        expect(fs.existsSync(CLI_BINARY)).toBe(true);
+
+        const topLevel = childProcess.spawnSync(process.execPath, [CLI_BINARY, '--help'], {
+            encoding: 'utf8',
+            timeout: 15_000,
+        });
+        expect(topLevel.status).toBe(0);
+        expect(topLevel.stdout).toMatch(/^\s+connection\s+\S/m);
+
+        const list = childProcess.spawnSync(process.execPath, [CLI_BINARY, 'connection', 'list', '--help'], {
+            encoding: 'utf8',
+            timeout: 15_000,
+        });
+        expect(list.status).toBe(0);
+        expect(list.stdout).toContain('Usage: solidactions connection list [options]');
+    });
+});
+
+interface CliResult {
+    stdout: string;
+    stderr: string;
+    status: number | null;
+}
+
+function runCli(args: string[], home: string, cwd: string): Promise<CliResult> {
+    return new Promise((resolve, reject) => {
+        const childEnv: NodeJS.ProcessEnv = { ...process.env, HOME: home };
+        delete childEnv.SOLIDACTIONS_HOST;
+        delete childEnv.SOLIDACTIONS_API_KEY;
+        delete childEnv.SOLIDACTIONS_WORKSPACE_ID;
+
+        const child = childProcess.spawn(process.execPath, [CLI_BINARY, ...args], {
+            cwd,
+            env: childEnv,
+        });
+        let stdout = '';
+        let stderr = '';
+
+        child.stdout.on('data', (chunk) => {
+            stdout += chunk;
+        });
+        child.stderr.on('data', (chunk) => {
+            stderr += chunk;
+        });
+
+        const timer = setTimeout(() => {
+            child.kill();
+            reject(new Error(`CLI timed out. stdout: ${stdout} stderr: ${stderr}`));
+        }, 15_000);
+
+        child.on('close', (status) => {
+            clearTimeout(timer);
+            resolve({ stdout, stderr, status });
+        });
+        child.on('error', (error) => {
+            clearTimeout(timer);
+            reject(error);
+        });
+    });
+}

--- a/tests/env-reset.test.ts
+++ b/tests/env-reset.test.ts
@@ -54,12 +54,15 @@ beforeAll(async () => {
             if (request.method === 'POST' && request.url?.endsWith('/variable-mappings/17/reset')) {
                 response.writeHead(200, { 'Content-Type': 'application/json' });
                 response.end(JSON.stringify({
-                    id: 17,
-                    env_name: 'GMAIL_TOKEN',
-                    source_type: 'oauth_connection',
-                    source: 'oauth_connection',
-                    oauth_connection_id: 'connection-1',
-                    oauth_connection_name: 'Primary Gmail',
+                    message: 'Variable mapping reset successfully.',
+                    mapping: {
+                        id: 17,
+                        env_name: 'GMAIL_TOKEN',
+                        source_type: 'oauth_connection',
+                        source: 'oauth_connection',
+                        oauth_connection_id: 'connection-1',
+                        oauth_connection_name: 'Primary Gmail',
+                    },
                 }));
                 return;
             }

--- a/tests/env-reset.test.ts
+++ b/tests/env-reset.test.ts
@@ -175,6 +175,22 @@ describe('env reset', () => {
         });
     });
 
+    it('rejects excess positional arguments before making an API request', async () => {
+        const result = await runCli([
+            'env',
+            'reset',
+            'mail-worker',
+            'GMAIL_TOKEN',
+            'extra',
+        ], home, cwd);
+
+        expect(result.status).toBe(1);
+        expect(result.stdout).toBe('');
+        expect(result.stderr).toContain('too many arguments');
+        expect(result.stderr).toContain("Expected 2 arguments but got 3");
+        expect(requests).toHaveLength(0);
+    });
+
     it('is registered with project, key, and environment help', async () => {
         const result = await runCli(['env', 'reset', '--help'], home, cwd);
 

--- a/tests/env-reset.test.ts
+++ b/tests/env-reset.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Contract tests for `env reset`.
+ *
+ * Test-double policy: the real compiled CLI talks to a real in-process HTTP
+ * server and reads a real temporary CLI config. No mock/spy/stub libraries.
+ */
+import * as childProcess from 'child_process';
+import * as fs from 'fs';
+import * as http from 'http';
+import * as os from 'os';
+import * as path from 'path';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { writeGlobal } from './helpers';
+
+const CLI_BINARY = path.resolve(__dirname, '../dist/index.js');
+
+interface CapturedRequest {
+    method: string | undefined;
+    url: string | undefined;
+    headers: http.IncomingHttpHeaders;
+    body: unknown;
+}
+
+let server: http.Server;
+let port: number;
+let requests: CapturedRequest[] = [];
+
+beforeAll(async () => {
+    server = http.createServer((request, response) => {
+        let rawBody = '';
+        request.on('data', (chunk) => {
+            rawBody += chunk;
+        });
+        request.on('end', () => {
+            requests.push({
+                method: request.method,
+                url: request.url,
+                headers: request.headers,
+                body: rawBody ? JSON.parse(rawBody) : null,
+            });
+
+            if (request.method === 'GET' && request.url?.endsWith('/variable-mappings')) {
+                response.writeHead(200, { 'Content-Type': 'application/json' });
+                response.end(JSON.stringify([
+                    {
+                        id: 17,
+                        env_name: 'GMAIL_TOKEN',
+                        source_type: 'local',
+                    },
+                ]));
+                return;
+            }
+
+            if (request.method === 'POST' && request.url?.endsWith('/variable-mappings/17/reset')) {
+                response.writeHead(200, { 'Content-Type': 'application/json' });
+                response.end(JSON.stringify({
+                    id: 17,
+                    env_name: 'GMAIL_TOKEN',
+                    source_type: 'oauth_connection',
+                    source: 'oauth_connection',
+                    oauth_connection_id: 'connection-1',
+                    oauth_connection_name: 'Primary Gmail',
+                }));
+                return;
+            }
+
+            response.writeHead(404, { 'Content-Type': 'application/json' });
+            response.end(JSON.stringify({ message: `Unhandled ${request.method} ${request.url}` }));
+        });
+    });
+
+    await new Promise<void>((resolve) => {
+        server.listen(0, '127.0.0.1', () => {
+            port = (server.address() as { port: number }).port;
+            resolve();
+        });
+    });
+});
+
+afterAll(() => {
+    return new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+    });
+});
+
+describe('env reset', () => {
+    let root: string;
+    let home: string;
+    let cwd: string;
+
+    beforeEach(() => {
+        root = fs.mkdtempSync(path.join(os.tmpdir(), 'sa-cli-env-reset-'));
+        home = path.join(root, 'home');
+        cwd = path.join(root, 'work');
+        fs.mkdirSync(home, { recursive: true });
+        fs.mkdirSync(cwd, { recursive: true });
+        writeGlobal(home, {
+            host: `http://127.0.0.1:${port}`,
+            apiKey: 'test-key',
+            workspaceId: 'workspace-1',
+        });
+        requests = [];
+    });
+
+    afterEach(() => {
+        fs.rmSync(root, { recursive: true, force: true });
+    });
+
+    it('defaults to dev and performs the exact lookup-then-reset contract', async () => {
+        const result = await runCli(['env', 'reset', 'mail-worker', 'GMAIL_TOKEN'], home, cwd);
+
+        expect(result.status).toBe(0);
+        expect(result.stderr).toBe('');
+        expect(requests).toEqual([
+            expect.objectContaining({
+                method: 'GET',
+                url: '/api/v1/projects/mail-worker-dev/variable-mappings',
+                body: null,
+            }),
+            expect.objectContaining({
+                method: 'POST',
+                url: '/api/v1/projects/mail-worker-dev/variable-mappings/17/reset',
+                body: {},
+            }),
+        ]);
+        expect(requests[0].headers.authorization).toBe('Bearer test-key');
+        expect(requests[0].headers['x-workspace-id']).toBe('workspace-1');
+        expect(result.stdout).toContain('GMAIL_TOKEN');
+        expect(result.stdout).toContain('oauth_connection');
+        expect(result.stdout).toContain('Primary Gmail');
+    });
+
+    it('uses the shared environment slug convention', async () => {
+        const staging = await runCli([
+            'env',
+            'reset',
+            'mail-worker',
+            'GMAIL_TOKEN',
+            '--env',
+            'staging',
+        ], home, cwd);
+        const production = await runCli([
+            'env',
+            'reset',
+            'mail-worker',
+            'GMAIL_TOKEN',
+            '--env',
+            'production',
+        ], home, cwd);
+
+        expect(staging.status).toBe(0);
+        expect(production.status).toBe(0);
+        expect(requests.map((request) => request.url)).toEqual([
+            '/api/v1/projects/mail-worker-staging/variable-mappings',
+            '/api/v1/projects/mail-worker-staging/variable-mappings/17/reset',
+            '/api/v1/projects/mail-worker/variable-mappings',
+            '/api/v1/projects/mail-worker/variable-mappings/17/reset',
+        ]);
+    });
+
+    it('errors clearly and does not POST when the key has no mapping', async () => {
+        const result = await runCli(['env', 'reset', 'mail-worker', 'MISSING_KEY'], home, cwd);
+
+        expect(result.status).toBe(1);
+        expect(result.stdout).toBe('');
+        expect(result.stderr).toContain('MISSING_KEY');
+        expect(result.stderr).toContain('no variable mapping');
+        expect(requests).toHaveLength(1);
+        expect(requests[0]).toMatchObject({
+            method: 'GET',
+            url: '/api/v1/projects/mail-worker-dev/variable-mappings',
+        });
+    });
+
+    it('is registered with project, key, and environment help', async () => {
+        const result = await runCli(['env', 'reset', '--help'], home, cwd);
+
+        expect(result.status).toBe(0);
+        expect(result.stderr).toBe('');
+        expect(result.stdout).toContain('Usage: solidactions env reset [options] <project> <KEY>');
+        expect(result.stdout).toContain('-e, --env <environment>');
+        expect(requests).toHaveLength(0);
+    });
+});
+
+interface CliResult {
+    stdout: string;
+    stderr: string;
+    status: number | null;
+}
+
+function runCli(args: string[], home: string, cwd: string): Promise<CliResult> {
+    return new Promise((resolve, reject) => {
+        const childEnv: NodeJS.ProcessEnv = { ...process.env, HOME: home };
+        delete childEnv.SOLIDACTIONS_HOST;
+        delete childEnv.SOLIDACTIONS_API_KEY;
+        delete childEnv.SOLIDACTIONS_WORKSPACE_ID;
+
+        const child = childProcess.spawn(process.execPath, [CLI_BINARY, ...args], {
+            cwd,
+            env: childEnv,
+        });
+        let stdout = '';
+        let stderr = '';
+
+        child.stdout.on('data', (chunk) => {
+            stdout += chunk;
+        });
+        child.stderr.on('data', (chunk) => {
+            stderr += chunk;
+        });
+
+        const timer = setTimeout(() => {
+            child.kill();
+            reject(new Error(`CLI timed out. stdout: ${stdout} stderr: ${stderr}`));
+        }, 15_000);
+
+        child.on('close', (status) => {
+            clearTimeout(timer);
+            resolve({ stdout, stderr, status });
+        });
+        child.on('error', (error) => {
+            clearTimeout(timer);
+            reject(error);
+        });
+    });
+}

--- a/tests/env-set-oauth-connection.test.ts
+++ b/tests/env-set-oauth-connection.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Contract tests for `env set --oauth-connection`.
+ *
+ * Test-double policy: the real compiled CLI talks to a real in-process HTTP
+ * server and reads a real temporary CLI config. No mock/spy/stub libraries.
+ */
+import * as childProcess from 'child_process';
+import * as fs from 'fs';
+import * as http from 'http';
+import * as os from 'os';
+import * as path from 'path';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { writeGlobal } from './helpers';
+
+const CLI_BINARY = path.resolve(__dirname, '../dist/index.js');
+const OAUTH_MODE_ERROR = '--oauth-connection binds a project key; give <project> <KEY> and no value';
+
+interface CapturedRequest {
+    method: string | undefined;
+    url: string | undefined;
+    headers: http.IncomingHttpHeaders;
+    body: unknown;
+}
+
+let server: http.Server;
+let port: number;
+let requests: CapturedRequest[] = [];
+
+beforeAll(async () => {
+    server = http.createServer((request, response) => {
+        let rawBody = '';
+        request.on('data', (chunk) => {
+            rawBody += chunk;
+        });
+        request.on('end', () => {
+            requests.push({
+                method: request.method,
+                url: request.url,
+                headers: request.headers,
+                body: rawBody ? JSON.parse(rawBody) : null,
+            });
+
+            response.writeHead(200, { 'Content-Type': 'application/json' });
+            response.end(JSON.stringify({
+                env_name: 'GMAIL_TOKEN',
+                source_type: 'oauth_connection',
+                oauth_connection_name: 'Primary Gmail',
+            }));
+        });
+    });
+
+    await new Promise<void>((resolve) => {
+        server.listen(0, '127.0.0.1', () => {
+            port = (server.address() as { port: number }).port;
+            resolve();
+        });
+    });
+});
+
+afterAll(() => {
+    return new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+    });
+});
+
+describe('env set --oauth-connection', () => {
+    let root: string;
+    let home: string;
+    let cwd: string;
+
+    beforeEach(() => {
+        root = fs.mkdtempSync(path.join(os.tmpdir(), 'sa-cli-env-oauth-'));
+        home = path.join(root, 'home');
+        cwd = path.join(root, 'work');
+        fs.mkdirSync(home, { recursive: true });
+        fs.mkdirSync(cwd, { recursive: true });
+        writeGlobal(home, {
+            host: `http://127.0.0.1:${port}`,
+            apiKey: 'test-key',
+            workspaceId: 'workspace-1',
+        });
+        requests = [];
+    });
+
+    afterEach(() => {
+        fs.rmSync(root, { recursive: true, force: true });
+    });
+
+    it('binds a project key by connection name through the single mapping endpoint', async () => {
+        const result = await runCli([
+            'env',
+            'set',
+            'mail-worker',
+            'GMAIL_TOKEN',
+            '--oauth-connection',
+            'Primary Gmail',
+        ], home, cwd);
+
+        expect(result.status).toBe(0);
+        expect(result.stderr).toBe('');
+        expect(requests).toHaveLength(1);
+        expect(requests[0]).toMatchObject({
+            method: 'POST',
+            url: '/api/v1/projects/mail-worker-dev/variable-mappings',
+            body: {
+                project_key: 'GMAIL_TOKEN',
+                oauth_connection_name: 'Primary Gmail',
+            },
+        });
+        expect(requests[0].headers.authorization).toBe('Bearer test-key');
+        expect(requests[0].headers['x-workspace-id']).toBe('workspace-1');
+        expect(result.stdout).toContain('GMAIL_TOKEN');
+        expect(result.stdout).toContain('Primary Gmail');
+    });
+
+    it('uses the shared environment suffix convention', async () => {
+        const staging = await runCli([
+            'env',
+            'set',
+            'mail-worker',
+            'GMAIL_TOKEN',
+            '--oauth-connection',
+            'Primary Gmail',
+            '--env',
+            'staging',
+        ], home, cwd);
+        const production = await runCli([
+            'env',
+            'set',
+            'mail-worker',
+            'GMAIL_TOKEN',
+            '--oauth-connection',
+            'Primary Gmail',
+            '--env',
+            'production',
+        ], home, cwd);
+
+        expect(staging.status).toBe(0);
+        expect(production.status).toBe(0);
+        expect(requests.map((request) => request.url)).toEqual([
+            '/api/v1/projects/mail-worker-staging/variable-mappings',
+            '/api/v1/projects/mail-worker/variable-mappings',
+        ]);
+    });
+
+    it('rejects a literal value before config or network work', async () => {
+        fs.rmSync(path.join(home, '.solidactions'), { recursive: true, force: true });
+
+        const result = await runCli([
+            'env',
+            'set',
+            'mail-worker',
+            'GMAIL_TOKEN',
+            'literal-value',
+            '--oauth-connection',
+            'Primary Gmail',
+        ], home, cwd);
+
+        expect(result.status).toBe(1);
+        expect(result.stderr).toContain(OAUTH_MODE_ERROR);
+        expect(result.stderr).not.toContain('Not logged in');
+        expect(requests).toHaveLength(0);
+    });
+
+    it('rejects --global before config or network work', async () => {
+        fs.rmSync(path.join(home, '.solidactions'), { recursive: true, force: true });
+
+        const result = await runCli([
+            'env',
+            'set',
+            'GMAIL_TOKEN',
+            'unused',
+            '--global',
+            '--oauth-connection',
+            'Primary Gmail',
+        ], home, cwd);
+
+        expect(result.status).toBe(1);
+        expect(result.stderr).toContain(OAUTH_MODE_ERROR);
+        expect(result.stderr).not.toContain('Not logged in');
+        expect(requests).toHaveLength(0);
+    });
+
+    it('applies the existing project env-key validation', async () => {
+        const result = await runCli([
+            'env',
+            'set',
+            'mail-worker',
+            'not-valid!',
+            '--oauth-connection',
+            'Primary Gmail',
+        ], home, cwd);
+
+        expect(result.status).toBe(1);
+        expect(result.stderr).toContain('Invalid variable name "not-valid!"');
+        expect(requests).toHaveLength(0);
+    });
+});
+
+interface CliResult {
+    stdout: string;
+    stderr: string;
+    status: number | null;
+}
+
+function runCli(args: string[], home: string, cwd: string): Promise<CliResult> {
+    return new Promise((resolve, reject) => {
+        const childEnv: NodeJS.ProcessEnv = { ...process.env, HOME: home };
+        delete childEnv.SOLIDACTIONS_HOST;
+        delete childEnv.SOLIDACTIONS_API_KEY;
+        delete childEnv.SOLIDACTIONS_WORKSPACE_ID;
+
+        const child = childProcess.spawn(process.execPath, [CLI_BINARY, ...args], {
+            cwd,
+            env: childEnv,
+        });
+        let stdout = '';
+        let stderr = '';
+
+        child.stdout.on('data', (chunk) => {
+            stdout += chunk;
+        });
+        child.stderr.on('data', (chunk) => {
+            stderr += chunk;
+        });
+
+        const timer = setTimeout(() => {
+            child.kill();
+            reject(new Error(`CLI timed out. stdout: ${stdout} stderr: ${stderr}`));
+        }, 15_000);
+
+        child.on('close', (status) => {
+            clearTimeout(timer);
+            resolve({ stdout, stderr, status });
+        });
+        child.on('error', (error) => {
+            clearTimeout(timer);
+            reject(error);
+        });
+    });
+}


### PR DESCRIPTION
Implements the CLI half of SolidActions/solidactions-app#992.

Depends on SolidActions/solidactions-app#1006. The app PR must merge and deploy before this CLI is tagged; this PR does not tag or release anything. #992 should close only after both halves land.

Fixes #93.

## What changed

- adds singular `solidactions connection list` with status/error and last-used output
- adds `solidactions env set <project> <KEY> --oauth-connection <name>` through the single mapping endpoint and shared environment slug convention
- adds `solidactions env reset <project> <KEY> [-e ...]`, printing the restored source and clearly rejecting missing mappings
- preserves existing literal/global `env set` behavior

## Verification

- `npm run check:release`: build, 90 test files / 849 tests, packed CLI scaffold/build, generated-project audit
- real app+CLI smoke: connection list → bind → masked list → resolved pull → reset; YAML default restored
- context-free interactive Claude TUI in tmux: PASS; discovered all commands via help and completed the cold workflow

No version bump, tag, deployment, or release is included. SolidActions/solidactions-cli#94 remains separately filed for pre-existing pulled-file permissions.