### PR TITLE
Harden hosted and headless CLI onboarding

### DIFF
--- a/src/commands/device-login.ts
+++ b/src/commands/device-login.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import chalk from 'chalk';
+import '../utils/api';
 import { Config } from '../utils/config';
 import { fetchWorkspaces, WorkspaceLookupRecord, WorkspaceScope } from '../utils/workspace-lookup';
 import {

--- a/src/commands/device-login.ts
+++ b/src/commands/device-login.ts
@@ -2,7 +2,12 @@ import axios from 'axios';
 import chalk from 'chalk';
 import { Config } from '../utils/config';
 import { fetchWorkspaces, WorkspaceLookupRecord, WorkspaceScope } from '../utils/workspace-lookup';
-import { completeLogin, resolveLoginHost } from './login';
+import {
+    completeLogin,
+    persistPreflightedLoginCredential,
+    preflightDeviceLoginWrite,
+    resolveLoginHost,
+} from './login';
 
 // Public device-flow client id — not a secret; matches the server-seeded
 // oauth_clients row (config('services.cli.oauth_client_id') on the app side).
@@ -97,6 +102,7 @@ export async function deviceLogin(
 ): Promise<void> {
     const resolved = resolveLoginHost(options);
     const host = resolved.host;
+    const preflight = await preflightDeviceLoginWrite(options);
 
     console.log(chalk.blue('Requesting device authorization...'));
     const code = await requestDeviceCode(host);
@@ -121,22 +127,24 @@ export async function deviceLogin(
     }
 
     const config: Config = { host, apiKey: token.access_token };
+    await persistPreflightedLoginCredential(config, preflight, options);
 
-    // Same tail as login(): fetch workspaces, then resolve + write + report
-    // exactly as login() does via the shared completeLogin() helper.
     let workspaces: WorkspaceLookupRecord[];
     let scope: WorkspaceScope | null;
     try {
         ({ workspaces, scope } = await fetchWorkspaces(config));
     } catch (e: any) {
         if (e.response?.status === 401) {
-            console.error(chalk.red(`Invalid API key for ${host}.`));
+            console.error(chalk.red(`Authentication was saved to ${preflight.targetPath}, but the server rejected it during workspace discovery.`));
         } else {
-            console.error(chalk.red(`Could not reach ${host}: ${e.message}`));
+            console.error(chalk.red(
+                `Authentication was saved to ${preflight.targetPath}, but workspace discovery failed: ${e.message}`,
+            ));
         }
+        console.error(chalk.yellow('Run `solidactions workspace set <name>` when workspace access is available.'));
         process.exit(1);
         return;
     }
 
-    await completeLogin(config, workspaces, options, scope);
+    await completeLogin(config, workspaces, options, scope, preflight);
 }

--- a/src/commands/env-set.ts
+++ b/src/commands/env-set.ts
@@ -141,7 +141,10 @@ export async function envSet(keyOrProject: string, valueOrKey?: string, valueIfP
                     console.error(chalk.red('Authentication failed. Run "solidactions login --global" to re-configure.'));
                 } else if (error.response.status === 404) {
                     const envsList = await describeProjectEnvironments(config, projectName);
-                    console.error(chalk.red(`Project "${projectName}" has no ${environment} environment${envsList ? ` (exists in: ${envsList})` : ''}.`));
+                    console.error(chalk.red(
+                        `Project "${projectName}" has no ${environment} environment${envsList ? ` (exists in: ${envsList})` : ''}.`
+                        + `\nRun 'solidactions project deploy ${projectName} -e ${environment} --create' first.`,
+                    ));
                 } else if (error.response.status === 422) {
                     console.error(chalk.red(formatValidationError(error.response.data)));
                 } else {

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import path from 'path';
 import readline from 'readline';
 import chalk from 'chalk';
 import prompts from 'prompts';
@@ -11,7 +12,14 @@ import {
     findLocalConfigPath,
     getGlobalConfigPath,
 } from '../utils/config';
-import { decideWriteTarget, pathForTarget, ensureGitignoreCovers, confirmOverwrite } from '../utils/config-write-target';
+import {
+    decideWriteTarget,
+    pathForTarget,
+    ensureGitignoreCovers,
+    confirmOverwrite,
+    WriteTarget,
+    WritePromptDependencies,
+} from '../utils/config-write-target';
 import { fetchWorkspaces, matchWorkspace, WorkspaceLookupRecord, WorkspaceScope } from '../utils/workspace-lookup';
 
 export type { Config };
@@ -127,6 +135,145 @@ const LOGIN_REFUSAL_MESSAGE =
     'at ~/.solidactions/config.json (a backup is kept if one exists), or --local to write ' +
     './.solidactions/config.json for just this directory.';
 
+export const DEVICE_LOGIN_REFUSAL_MESSAGE =
+    'No TTY detected. Re-run with the config destination made explicit: '
+    + 'solidactions login --device --global --workspace <name>';
+
+export interface LoginWritePreflight {
+    target: WriteTarget;
+    targetPath: string;
+    backupPath: string | null;
+    backupCreated: boolean;
+    credentialPersisted: boolean;
+}
+
+export interface LoginWritePreflightDependencies {
+    isTTY?: boolean;
+    destinationQuestion?: WritePromptDependencies['question'];
+    overwriteQuestion?: WritePromptDependencies['question'];
+}
+
+function nearestExistingPath(startPath: string): string {
+    let candidate = startPath;
+    while (!fs.existsSync(candidate)) {
+        const parent = path.dirname(candidate);
+        if (parent === candidate) break;
+        candidate = parent;
+    }
+    return candidate;
+}
+
+function failWritePreflight(targetPath: string, reason: string): never {
+    console.error(chalk.red(
+        `Cannot save configuration to ${targetPath}: ${reason}. `
+        + 'Choose a writable destination with --local or --global and retry.',
+    ));
+    process.exit(1);
+}
+
+function assertDirectoryWritable(directoryPath: string, targetPath: string): void {
+    let stat: fs.Stats;
+    try {
+        stat = fs.statSync(directoryPath);
+    } catch (error: any) {
+        failWritePreflight(targetPath, `could not inspect ${directoryPath} (${error.message})`);
+    }
+    if (!stat.isDirectory()) {
+        failWritePreflight(targetPath, `${directoryPath} is not a directory`);
+    }
+
+    // accessSync is authoritative for the current identity. The mode check
+    // also catches deliberately read-only fixtures when tests run as root.
+    if ((stat.mode & 0o222) === 0 || (stat.mode & 0o111) === 0) {
+        failWritePreflight(targetPath, `${directoryPath} is not writable/searchable`);
+    }
+    try {
+        fs.accessSync(directoryPath, fs.constants.W_OK | fs.constants.X_OK);
+    } catch {
+        failWritePreflight(targetPath, `${directoryPath} is not writable/searchable`);
+    }
+}
+
+/**
+ * Resolve and validate the device-login destination before requesting a
+ * browser approval. The returned path is reused after authorization.
+ */
+export async function preflightDeviceLoginWrite(
+    options: { local?: boolean; global?: boolean },
+    dependencies: LoginWritePreflightDependencies = {},
+): Promise<LoginWritePreflight> {
+    const target = await decideWriteTarget(options, undefined, DEVICE_LOGIN_REFUSAL_MESSAGE, {
+        isTTY: dependencies.isTTY,
+        question: dependencies.destinationQuestion,
+    });
+    const targetPath = pathForTarget(target);
+
+    if (fs.existsSync(targetPath)) {
+        let stat: fs.Stats;
+        try {
+            stat = fs.statSync(targetPath);
+        } catch (error: any) {
+            failWritePreflight(targetPath, error.message);
+        }
+        if (!stat.isFile()) {
+            failWritePreflight(targetPath, 'the config path is not a regular file');
+        }
+        try {
+            fs.accessSync(targetPath, fs.constants.R_OK);
+        } catch {
+            failWritePreflight(targetPath, 'the existing config is not readable for backup');
+        }
+    }
+
+    const existingParent = nearestExistingPath(path.dirname(targetPath));
+    assertDirectoryWritable(existingParent, targetPath);
+
+    let backupPath: string | null = null;
+    if (fs.existsSync(targetPath)) {
+        backupPath = backupPathFor(targetPath);
+        const proceed = await confirmOverwrite(targetPath, backupPath, {
+            isTTY: dependencies.isTTY,
+            question: dependencies.overwriteQuestion,
+        });
+        if (!proceed) {
+            console.log(chalk.yellow('Aborted. No changes were made and no device code was requested.'));
+            process.exit(0);
+        }
+    }
+
+    return {
+        target,
+        targetPath,
+        backupPath,
+        backupCreated: false,
+        credentialPersisted: false,
+    };
+}
+
+/**
+ * Persist the approved base credential before workspace discovery. Existing
+ * device-login configs are backed up exactly once.
+ */
+export async function persistPreflightedLoginCredential(
+    config: Config,
+    preflight: LoginWritePreflight,
+    options: { gitignore?: boolean },
+): Promise<void> {
+    if (preflight.backupPath && !preflight.backupCreated) {
+        fs.copyFileSync(preflight.targetPath, preflight.backupPath);
+        preflight.backupCreated = true;
+        console.log(chalk.gray(`Backup saved to ${preflight.backupPath}`));
+    }
+
+    writeConfigFile(preflight.targetPath, config);
+    preflight.credentialPersisted = true;
+
+    if (preflight.target === 'local') {
+        const targetRoot = path.dirname(path.dirname(preflight.targetPath));
+        await ensureGitignoreCovers(targetRoot, !!options.gitignore);
+    }
+}
+
 export function loginHostLines(resolved: { host: string; isDefault: boolean }): string[] {
     if (resolved.isDefault) {
         return [
@@ -139,10 +286,16 @@ export function loginHostLines(resolved: { host: string; isDefault: boolean }): 
 
 /**
  * Prompt the user to pick a workspace from an already-fetched list. Auto-
- * selects when there's exactly one. Returns undefined if none exist.
+ * selects when there's exactly one. Invalid answers re-prompt; EOF or a
+ * closed input returns undefined without selecting anything.
  */
-async function selectWorkspaceInteractively(
+interface WorkspaceSelectionDependencies {
+    question?: () => Promise<string | undefined>;
+}
+
+export async function selectWorkspaceInteractively(
     workspaces: WorkspaceLookupRecord[],
+    dependencies: WorkspaceSelectionDependencies = {},
 ): Promise<WorkspaceLookupRecord | undefined> {
     if (workspaces.length === 0) {
         console.log(chalk.yellow('No workspaces found. Create one at your SolidActions dashboard, then run `solidactions workspace set <name>`.'));
@@ -159,30 +312,57 @@ async function selectWorkspaceInteractively(
     });
     console.log('');
 
-    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-    const answer = await new Promise<string>((resolve) => {
-        rl.question(chalk.blue('Enter number: '), resolve);
+    const rl = dependencies.question
+        ? null
+        : readline.createInterface({ input: process.stdin, output: process.stdout });
+    const question = dependencies.question ?? (async () => {
+        if (!rl || (rl as any).closed) return undefined;
+        return new Promise<string | undefined>((resolve) => {
+            let answered = false;
+            const onClose = () => {
+                if (!answered) resolve(undefined);
+            };
+            rl.once('close', onClose);
+            rl.question(chalk.blue('Enter number: '), (answer) => {
+                answered = true;
+                rl.removeListener('close', onClose);
+                resolve(answer);
+            });
+        });
     });
-    rl.close();
 
-    const index = parseInt(answer, 10) - 1;
-    if (isNaN(index) || index < 0 || index >= workspaces.length) {
-        console.error(chalk.red('Invalid selection.'));
-        process.exit(1);
+    try {
+        while (true) {
+            const answer = await question();
+            if (answer === undefined) {
+                console.log(chalk.yellow(
+                    'Workspace selection cancelled. Run `solidactions workspace list`, then '
+                    + '`solidactions workspace set <name>` when ready.',
+                ));
+                return undefined;
+            }
+            const index = parseInt(answer, 10) - 1;
+            if (!isNaN(index) && index >= 0 && index < workspaces.length) {
+                return workspaces[index];
+            }
+            console.error(chalk.red('Invalid selection. Enter one of the numbers shown.'));
+        }
+    } finally {
+        rl?.close();
     }
-    return workspaces[index];
 }
 
 /**
- * Shared tail of `login`, reused verbatim by `deviceLogin`: resolve the
- * workspace against an already-fetched list, determine the write target,
- * back up + write the config file once, and print the success output.
+ * Shared tail of API-key and device login: resolve the workspace against an
+ * already-fetched list, persist the final config, and print success output.
+ * Device login passes its already-written, preflighted destination.
  */
 export async function completeLogin(
     config: Config,
     workspaces: WorkspaceLookupRecord[],
     options: { workspace?: string; local?: boolean; global?: boolean; gitignore?: boolean },
     scope: WorkspaceScope | null = null,
+    preflight: LoginWritePreflight | null = null,
 ): Promise<void> {
     // Device-flow tokens carry a scope (mode + workspace_ids) that later
     // gates `workspace set`; absent for user-scoped Sanctum PATs.
@@ -191,16 +371,37 @@ export async function completeLogin(
         config.scopedWorkspaceIds = scope.workspace_ids;
     }
 
-    // 2. Resolve the workspace (still before writing).
+    // Resolve the workspace. Device login has already persisted its base
+    // credential; API-key login still resolves before its first write.
     if (options.workspace) {
         const match = matchWorkspace(options.workspace, workspaces);
         if (!match) {
-            console.error(chalk.red(`Workspace "${options.workspace}" not found. Run \`solidactions workspace list\` to list available workspaces.`));
+            if (preflight?.credentialPersisted) {
+                writeConfigFile(preflight.targetPath, config);
+                console.error(chalk.yellow(
+                    `Workspace "${options.workspace}" was not found. Authentication was saved to ${preflight.targetPath}.`,
+                ));
+                console.error(chalk.yellow(
+                    'Run `solidactions workspace list`, then `solidactions workspace set <name>` to finish setup.',
+                ));
+            } else {
+                console.error(chalk.red(`Workspace "${options.workspace}" not found. Run \`solidactions workspace list\` to list available workspaces.`));
+            }
             process.exit(1);
             return;
         }
         config.workspace = match.slug ?? match.name;
         config.workspaceId = match.id;
+    } else if (workspaces.length === 1) {
+        const selected = workspaces[0];
+        console.log(chalk.gray(`Auto-selected workspace: ${selected.name}`));
+        config.workspace = selected.slug ?? selected.name;
+        config.workspaceId = selected.id;
+    } else if (workspaces.length === 0) {
+        console.log(chalk.yellow(
+            'No workspaces found. Create one at your SolidActions dashboard, then '
+            + 'run `solidactions workspace set <name>`.',
+        ));
     } else if (process.stdin.isTTY) {
         const selected = await selectWorkspaceInteractively(workspaces);
         if (selected) {
@@ -208,35 +409,44 @@ export async function completeLogin(
             config.workspaceId = selected.id;
         }
     } else {
-        console.log(chalk.yellow('No workspace set — run `solidactions workspace set <name>` later.'));
+        console.log(chalk.yellow(
+            'Multiple workspaces are available, so no workspace was selected. '
+            + 'Run `solidactions workspace list`, then `solidactions workspace set <name>`.',
+        ));
     }
 
-    // 3. Determine target location, back up if needed, and write ONCE.
-    const target = await decideWriteTarget({ local: options.local, global: options.global }, undefined, LOGIN_REFUSAL_MESSAGE);
-    const targetPath = pathForTarget(target);
+    let savedTargetPath: string;
+    if (preflight) {
+        savedTargetPath = preflight.targetPath;
+        writeConfigFile(preflight.targetPath, config);
+    } else {
+        const target = await decideWriteTarget({ local: options.local, global: options.global }, undefined, LOGIN_REFUSAL_MESSAGE);
+        const targetPath = pathForTarget(target);
+        savedTargetPath = targetPath;
 
-    const existingRaw = fs.existsSync(targetPath) ? fs.readFileSync(targetPath, 'utf-8') : null;
-    const wouldChange = existingRaw !== null && existingRaw.trim() !== JSON.stringify(config, null, 2).trim();
+        const existingRaw = fs.existsSync(targetPath) ? fs.readFileSync(targetPath, 'utf-8') : null;
+        const wouldChange = existingRaw !== null && existingRaw.trim() !== JSON.stringify(config, null, 2).trim();
 
-    if (wouldChange) {
-        const backupPath = backupPathFor(targetPath);
-        const proceed = await confirmOverwrite(targetPath, backupPath);
-        if (!proceed) {
-            console.log(chalk.yellow('Aborted. No changes were made.'));
-            process.exit(0);
+        if (wouldChange) {
+            const backupPath = backupPathFor(targetPath);
+            const proceed = await confirmOverwrite(targetPath, backupPath);
+            if (!proceed) {
+                console.log(chalk.yellow('Aborted. No changes were made.'));
+                process.exit(0);
+            }
+            fs.copyFileSync(targetPath, backupPath);
+            console.log(chalk.gray(`Backup saved to ${backupPath}`));
         }
-        fs.copyFileSync(targetPath, backupPath);
-        console.log(chalk.gray(`Backup saved to ${backupPath}`));
-    }
 
-    writeConfigFile(targetPath, config);
+        writeConfigFile(targetPath, config);
 
-    if (target === 'local') {
-        await ensureGitignoreCovers(process.cwd(), !!options.gitignore);
+        if (target === 'local') {
+            await ensureGitignoreCovers(process.cwd(), !!options.gitignore);
+        }
     }
 
     console.log(chalk.green('Logged in successfully!'));
-    console.log(chalk.gray(`Configuration saved to ${targetPath}`));
+    console.log(chalk.gray(`Configuration saved to ${savedTargetPath}`));
     console.log('');
     console.log(chalk.blue('Next step — scaffold a new project (includes AI tooling):'));
     console.log(chalk.gray('  solidactions init <project-name>      Creates ./<project-name>/ with scaffold + AI skills'));

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,7 +117,7 @@ program
     .option('--device', 'Authenticate via browser using OAuth device authorization')
     .option('--dev', 'Use local development server (http://localhost:8000)')
     .option('--host <url>', 'Custom API host URL')
-    .option('--workspace <name-or-id>', 'Set workspace by name, slug, or ID (skips interactive prompt). Non-interactive logins without this flag leave the workspace unset.')
+    .option('--workspace <name-or-id>', 'Set workspace by name, slug, or ID. A sole workspace is auto-selected; use --workspace to choose among multiple workspaces.')
     .option('--local', 'Save config to ./.solidactions/config.json in the current folder')
     .option('--global', 'Save config to ~/.solidactions/config.json (default if prompted)')
     .option('--gitignore', 'With --local, add .solidactions/ to .gitignore without prompting')

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -9,6 +9,99 @@ import { resolveWorkspaceInput } from './workspace-lookup';
 // like "Project files not found ..." don't false-match.
 const NOT_FOUND_IN_WORKSPACE = /Project '.+' not found in your active workspace/;
 
+export const SANDBOX_EGRESS_MESSAGE =
+    'Sandbox network egress appears to be blocking app.solidactions.com. '
+    + "Allow-list app.solidactions.com in your provider's network settings, "
+    + 'start a new agent session if required, then retry. '
+    + 'See https://www.solidactions.com/docs/troubleshooting/#sandbox-egress';
+
+const SANDBOX_EGRESS_PHRASES = [
+    /\bhost (?:is )?not permitted\b/i,
+    /\bnetwork access denied\b/i,
+    /\bnetwork egress\b[\s\S]*?\b(?:blocked|disabled)\b/i,
+    /\bdestination\b[\s\S]*?\bnot allowed\b/i,
+];
+
+function responseServerHeader(headers: any): string {
+    if (!headers) {
+        return '';
+    }
+
+    if (typeof headers.get === 'function') {
+        const value = headers.get('server') ?? headers.get('Server');
+        return value == null ? '' : String(value).trim();
+    }
+
+    for (const [name, value] of Object.entries(headers)) {
+        if (name.toLowerCase() === 'server') {
+            return value == null ? '' : String(value).trim();
+        }
+    }
+
+    return '';
+}
+
+function flattenProxyResponseText(data: unknown): string {
+    if (typeof data === 'string') {
+        return data;
+    }
+    if (data instanceof Error) {
+        return data.message;
+    }
+    if (!data || typeof data !== 'object' || Array.isArray(data)) {
+        return '';
+    }
+
+    return ['error', 'message']
+        .map((field) => flattenProxyResponseText((data as Record<string, unknown>)[field]))
+        .filter(Boolean)
+        .join('\n');
+}
+
+/**
+ * Diagnose a provider proxy's observed Cloud-host 403 without rewriting
+ * SolidActions authorization errors or failures against custom hosts.
+ */
+export function augmentSandboxEgressMessage(error: any): any {
+    const response = error?.response;
+    if (response?.status !== 403 || responseServerHeader(response.headers)) {
+        return error;
+    }
+
+    const data = response.data;
+    const responseCode = data && typeof data === 'object' && !Array.isArray(data)
+        ? (data as Record<string, unknown>).code
+        : null;
+    if (responseCode != null && String(responseCode).trim() !== '') {
+        return error;
+    }
+
+    const requestConfig = error.config ?? response.config;
+    let hostname = '';
+    try {
+        hostname = new URL(requestConfig?.url, requestConfig?.baseURL).hostname;
+    } catch {
+        return error;
+    }
+    if (hostname !== 'app.solidactions.com') {
+        return error;
+    }
+
+    const proxyText = flattenProxyResponseText(data).trim();
+    if (!proxyText || !SANDBOX_EGRESS_PHRASES.some((phrase) => phrase.test(proxyText))) {
+        return error;
+    }
+
+    error.message = SANDBOX_EGRESS_MESSAGE;
+    response.data = {
+        ...(data && typeof data === 'object' && !Array.isArray(data) ? data : {}),
+        message: `${SANDBOX_EGRESS_MESSAGE}\n\nProvider response: ${proxyText}`,
+        providerResponse: data,
+    };
+
+    return error;
+}
+
 /**
  * Inspect an axios error and, if its response message matches the new
  * workspace-not-found 404 from solidactions-app PR #128, append a
@@ -47,7 +140,13 @@ export function augmentWorkspaceForbiddenMessage(error: any): any {
 
 axios.interceptors.response.use(
     (response) => response,
-    (error) => Promise.reject(augmentWorkspaceForbiddenMessage(augmentNotFoundMessage(error))),
+    (error) => Promise.reject(
+        augmentWorkspaceForbiddenMessage(
+            augmentNotFoundMessage(
+                augmentSandboxEgressMessage(error),
+            ),
+        ),
+    ),
 );
 
 export function getApiHeaders(config: Config, contentType?: string): Record<string, string> {

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -152,7 +152,7 @@ export async function ensureWorkspaceSelected(config: Config): Promise<Config> {
     const resolved = resolveConfig();
     const workspaceSource = resolved?.sources.workspaceId ?? null;
 
-    let workspaces: Array<{ id: string; name: string; org_name: string; role: string }>;
+    let workspaces: Array<{ id: string; name: string; slug?: string; org_name: string; role: string }>;
     try {
         const response = await axios.get(`${config.host}/api/v1/workspaces`, {
             headers: {
@@ -168,6 +168,7 @@ export async function ensureWorkspaceSelected(config: Config): Promise<Config> {
                     workspaces.push({
                         id: ws.id,
                         name: ws.name,
+                        slug: ws.slug,
                         org_name: ws.tenant_name || orgName,
                         role: ws.role,
                     });
@@ -202,6 +203,14 @@ export async function ensureWorkspaceSelected(config: Config): Promise<Config> {
         selected = workspaces[0];
         console.log(chalk.gray(`Auto-selected workspace: ${selected.name}`));
     } else {
+        if (!process.stdin.isTTY) {
+            console.error(chalk.red(
+                'Multiple workspaces are available and no workspace is set for this config. '
+                + 'Run `solidactions workspace set <name-or-id> --local` (or --global).',
+            ));
+            process.exit(1);
+        }
+
         console.log(chalk.blue('\nSelect your default workspace (change anytime with `solidactions workspace set`):\n'));
         workspaces.forEach((ws, i) => {
             console.log(`  ${chalk.white(`${i + 1}.`)} ${ws.name} ${chalk.gray(`(${ws.org_name}, ${ws.role})`)}`);
@@ -222,6 +231,7 @@ export async function ensureWorkspaceSelected(config: Config): Promise<Config> {
         selected = workspaces[index];
     }
 
+    config.workspace = selected.slug ?? selected.name;
     config.workspaceId = selected.id;
 
     if (workspaceSource !== 'env') {
@@ -244,13 +254,6 @@ export async function requireConfigWithWorkspace(): Promise<Config> {
         const ws = await resolveWorkspaceInput(config, config.workspace!);
         config = { ...config, workspace: ws.slug ?? ws.name, workspaceId: ws.id };
         return config;
-    }
-
-    if (!config.workspaceId && !process.stdin.isTTY) {
-        console.error(chalk.red(
-            'No workspace set for this config. Run `solidactions workspace set <name-or-id> --local` (or --global).',
-        ));
-        process.exit(1);
     }
 
     return ensureWorkspaceSelected(config);

--- a/src/utils/config-write-target.ts
+++ b/src/utils/config-write-target.ts
@@ -6,6 +6,31 @@ import { getGlobalConfigPath, getLocalConfigPath } from './config';
 
 export type WriteTarget = 'local' | 'global';
 
+export interface WritePromptDependencies {
+    isTTY?: boolean;
+    question?: (label: string) => Promise<string | undefined>;
+}
+
+async function askReadlineQuestion(
+    rl: readline.Interface,
+    label: string,
+): Promise<string | undefined> {
+    if ((rl as any).closed) return undefined;
+
+    return new Promise<string | undefined>((resolve) => {
+        let answered = false;
+        const onClose = () => {
+            if (!answered) resolve(undefined);
+        };
+        rl.once('close', onClose);
+        rl.question(label, (answer) => {
+            answered = true;
+            rl.removeListener('close', onClose);
+            resolve(answer);
+        });
+    });
+}
+
 /**
  * Decide whether a write should target the local or global config file,
  * mirroring the contract used by `login`:
@@ -18,6 +43,7 @@ export async function decideWriteTarget(
     options: { local?: boolean; global?: boolean },
     promptLabel = 'Save config locally (./.solidactions) or globally (~/.solidactions)? [global] ',
     refusalMessage = 'Refusing to write config non-interactively. Pass --local or --global.',
+    dependencies: WritePromptDependencies = {},
 ): Promise<WriteTarget> {
     if (options.local && options.global) {
         console.error(chalk.red('Error: --local and --global are mutually exclusive.'));
@@ -26,18 +52,28 @@ export async function decideWriteTarget(
     if (options.local) return 'local';
     if (options.global) return 'global';
 
-    if (process.stdin.isTTY) {
-        const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    const isTTY = dependencies.isTTY ?? process.stdin.isTTY === true;
+    if (isTTY) {
+        const rl = dependencies.question
+            ? null
+            : readline.createInterface({ input: process.stdin, output: process.stdout });
         try {
             while (true) {
-                const answer = await new Promise<string>((resolve) => rl.question(chalk.blue(promptLabel), resolve));
+                const label = chalk.blue(promptLabel);
+                const answer = dependencies.question
+                    ? await dependencies.question(label)
+                    : await askReadlineQuestion(rl!, label);
+                if (answer === undefined) {
+                    console.error(chalk.red('Input closed before a config destination was selected. No changes were made.'));
+                    process.exit(1);
+                }
                 const normalized = answer.trim().toLowerCase();
                 if (normalized === '' || normalized === 'global' || normalized === 'g') return 'global';
                 if (normalized === 'local' || normalized === 'l') return 'local';
                 console.log(chalk.yellow("Please answer 'local' or 'global' (or press Enter for global)."));
             }
         } finally {
-            rl.close();
+            rl?.close();
         }
     }
     console.error(chalk.red(refusalMessage));
@@ -55,20 +91,34 @@ export function pathForTarget(target: WriteTarget): string {
  * automatically so they never wedge; an interactive TTY additionally asks a
  * y/N confirm (default N).
  */
-export async function confirmOverwrite(existingPath: string, backupPath: string): Promise<boolean> {
+export async function confirmOverwrite(
+    existingPath: string,
+    backupPath: string,
+    dependencies: WritePromptDependencies = {},
+): Promise<boolean> {
     const notice = `Existing config at ${existingPath} will be overwritten (backup will be saved to ${backupPath}).`;
 
-    if (!process.stdin.isTTY) {
+    const isTTY = dependencies.isTTY ?? process.stdin.isTTY === true;
+    if (!isTTY) {
         console.log(chalk.yellow(notice));
         return true;
     }
 
-    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    const rl = dependencies.question
+        ? null
+        : readline.createInterface({ input: process.stdin, output: process.stdout });
     try {
-        const answer = await new Promise<string>((resolve) => rl.question(chalk.yellow(`${notice} Continue? [y/N] `), resolve));
+        const label = chalk.yellow(`${notice} Continue? [y/N] `);
+        const answer = dependencies.question
+            ? await dependencies.question(label)
+            : await askReadlineQuestion(rl!, label);
+        if (answer === undefined) {
+            console.log(chalk.yellow('Overwrite confirmation input closed; treating it as a decline.'));
+            return false;
+        }
         return answer.trim().toLowerCase().startsWith('y');
     } finally {
-        rl.close();
+        rl?.close();
     }
 }
 

--- a/tests/api-egress-error.test.ts
+++ b/tests/api-egress-error.test.ts
@@ -1,0 +1,94 @@
+import { AxiosHeaders } from 'axios';
+import { describe, expect, it } from 'vitest';
+import {
+    augmentSandboxEgressMessage,
+    augmentWorkspaceForbiddenMessage,
+    SANDBOX_EGRESS_MESSAGE,
+} from '../src/utils/api';
+
+function proxyError(overrides: {
+    status?: number;
+    url?: string;
+    headers?: unknown;
+    data?: unknown;
+} = {}): any {
+    const error: any = new Error('Request failed with status code 403');
+    error.isAxiosError = true;
+    error.config = {
+        url: overrides.url ?? 'https://app.solidactions.com/oauth/device/code',
+    };
+    error.response = {
+        status: overrides.status ?? 403,
+        headers: overrides.headers ?? {},
+        data: overrides.data ?? 'host not permitted by sandbox network policy',
+    };
+    return error;
+}
+
+describe('augmentSandboxEgressMessage', () => {
+    it.each([
+        'host not permitted',
+        'HOST IS NOT PERMITTED by policy',
+        { error: 'network access denied' },
+        { message: 'Network egress to this host is blocked' },
+        { message: 'network egress has been disabled' },
+        { error: 'destination app.solidactions.com is not allowed' },
+    ])('diagnoses the narrow Cloud proxy phrase fixture %#', (data) => {
+        const originalText = typeof data === 'string'
+            ? data
+            : String((data as { error?: string; message?: string }).error
+                ?? (data as { message?: string }).message);
+        const result = augmentSandboxEgressMessage(proxyError({ data }));
+
+        expect(result.message).toBe(SANDBOX_EGRESS_MESSAGE);
+        expect(result.message).toContain('Allow-list app.solidactions.com');
+        expect(result.message).toContain(
+            'https://www.solidactions.com/docs/troubleshooting/#sandbox-egress',
+        );
+        expect(result.response.data.message).toContain(SANDBOX_EGRESS_MESSAGE);
+        expect(result.response.data.message).toContain(originalText);
+    });
+
+    it.each([
+        ['wrong status', { status: 429 }],
+        ['plain Server header', { headers: { server: 'cloudflare' } }],
+        ['mixed-case Server header', { headers: { SeRvEr: 'nginx' } }],
+        ['AxiosHeaders Server header', { headers: new AxiosHeaders({ Server: 'envoy' }) }],
+        ['SolidActions code', { data: { code: 'workspace_forbidden', message: 'host not permitted' } }],
+        ['unrelated body', { data: { message: 'Forbidden.' } }],
+        ['self-hosted URL', { url: 'https://solidactions.internal/oauth/device/code' }],
+        ['local development URL', { url: 'http://localhost:8000/oauth/device/code' }],
+    ])('does not classify %s', (_name, overrides) => {
+        const error = proxyError(overrides);
+        const originalMessage = error.message;
+        const originalData = error.response.data;
+
+        const result = augmentSandboxEgressMessage(error);
+
+        expect(result.message).toBe(originalMessage);
+        expect(result.response.data).toBe(originalData);
+    });
+
+    it.each(['ENOTFOUND', 'EAI_AGAIN', 'ECONNREFUSED'])(
+        'does not classify connection-level %s failures',
+        (code) => {
+            const error: any = new Error('Could not reach host');
+            error.code = code;
+            error.config = { url: 'https://app.solidactions.com/oauth/device/code' };
+
+            expect(augmentSandboxEgressMessage(error).message).toBe('Could not reach host');
+        },
+    );
+
+    it('keeps workspace_forbidden augmentation intact', () => {
+        const error = proxyError({
+            data: { code: 'workspace_forbidden', message: 'host not permitted' },
+        });
+
+        const result = augmentWorkspaceForbiddenMessage(augmentSandboxEgressMessage(error));
+
+        expect(result.message).toBe('Request failed with status code 403');
+        expect(result.response.data.message).toContain('limited set of workspaces');
+        expect(result.response.data.message).toContain('login --device');
+    });
+});

--- a/tests/device-login-egress-import.test.ts
+++ b/tests/device-login-egress-import.test.ts
@@ -1,0 +1,121 @@
+import axios, { AxiosError, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
+import * as childProcess from 'child_process';
+import * as fs from 'fs';
+import * as http from 'http';
+import * as os from 'os';
+import * as path from 'path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { requestDeviceCode } from '../src/commands/device-login';
+
+const CLI_BINARY = path.resolve(__dirname, '../dist/index.js');
+const EXPECTED_MESSAGE = 'Sandbox network egress appears to be blocking app.solidactions.com. '
+    + "Allow-list app.solidactions.com in your provider's network settings, "
+    + 'start a new agent session if required, then retry. '
+    + 'See https://www.solidactions.com/docs/troubleshooting/#sandbox-egress';
+
+let proxy: http.Server;
+let proxyPort: number;
+
+beforeAll(async () => {
+    proxy = http.createServer((_req, res) => {
+        res.writeHead(403, { 'Content-Type': 'text/plain' });
+        res.end('host not permitted by hosted sandbox');
+    });
+    await new Promise<void>((resolve) => {
+        proxy.listen(0, '127.0.0.1', () => {
+            proxyPort = (proxy.address() as { port: number }).port;
+            resolve();
+        });
+    });
+});
+
+afterAll(() => new Promise<void>((resolve, reject) => {
+    proxy.close((error) => error ? reject(error) : resolve());
+}));
+
+function runCli(home: string): Promise<{ stdout: string; stderr: string; status: number | null }> {
+    return new Promise((resolve, reject) => {
+        const proxyUrl = `http://127.0.0.1:${proxyPort}`;
+        const child = childProcess.spawn(process.execPath, [
+            CLI_BINARY,
+            'login',
+            '--device',
+            '--global',
+            '--host',
+            'http://app.solidactions.com',
+        ], {
+            env: {
+                ...process.env,
+                HOME: home,
+                HTTP_PROXY: proxyUrl,
+                http_proxy: proxyUrl,
+                NO_PROXY: '',
+                no_proxy: '',
+            },
+            stdio: ['ignore', 'pipe', 'pipe'],
+        });
+        let stdout = '';
+        let stderr = '';
+        child.stdout.on('data', (chunk) => { stdout += String(chunk); });
+        child.stderr.on('data', (chunk) => { stderr += String(chunk); });
+        const timer = setTimeout(() => {
+            child.kill();
+            reject(new Error(`CLI timed out. stdout: ${stdout} stderr: ${stderr}`));
+        }, 15_000);
+        child.on('error', (error) => {
+            clearTimeout(timer);
+            reject(error);
+        });
+        child.on('close', (status) => {
+            clearTimeout(timer);
+            resolve({ stdout, stderr, status });
+        });
+    });
+}
+
+describe('device-login entry registers the shared Axios error interceptor', () => {
+    it('augments a request when this test imports only the device-login entry path', async () => {
+        const originalAdapter = axios.defaults.adapter;
+        axios.defaults.adapter = async (config: InternalAxiosRequestConfig): Promise<AxiosResponse> => {
+            const response = {
+                status: 403,
+                statusText: 'Forbidden',
+                headers: {},
+                config,
+                data: 'host not permitted by hosted sandbox',
+            };
+            throw new AxiosError(
+                'Request failed with status code 403',
+                'ERR_BAD_REQUEST',
+                config,
+                null,
+                response,
+            );
+        };
+
+        try {
+            await expect(requestDeviceCode('https://app.solidactions.com'))
+                .rejects.toMatchObject({ message: EXPECTED_MESSAGE });
+        } finally {
+            axios.defaults.adapter = originalAdapter;
+        }
+    });
+
+    it('prints the diagnosis through the compiled binary top-level catch path', async () => {
+        expect(fs.existsSync(CLI_BINARY)).toBe(true);
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), 'sa-cli-egress-spawn-'));
+        const home = path.join(root, 'home');
+        fs.mkdirSync(home);
+
+        try {
+            const result = await runCli(home);
+            expect(result.status).toBe(1);
+            expect(result.stdout).toContain('Requesting device authorization');
+            expect(result.stderr.trim()).toBe(EXPECTED_MESSAGE);
+            expect(`${result.stdout}\n${result.stderr}`).not.toContain('Claude');
+            expect(`${result.stdout}\n${result.stderr}`).not.toContain('Organization settings');
+        } finally {
+            fs.rmSync(root, { recursive: true, force: true });
+        }
+    });
+});

--- a/tests/device-login-hardening.test.ts
+++ b/tests/device-login-hardening.test.ts
@@ -1,0 +1,275 @@
+import fs from 'fs';
+import http from 'http';
+import path from 'path';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { deviceLogin } from '../src/commands/device-login';
+import { preflightDeviceLoginWrite } from '../src/commands/login';
+import { makeTmpEnv, writeGlobal } from './helpers';
+
+class ProcessExitError extends Error {
+    constructor(public readonly code: number | undefined) {
+        super(`process.exit(${code})`);
+    }
+}
+
+describe('device login destination and credential hardening', () => {
+    let server: http.Server;
+    let port: number;
+    let deviceCodeRequests: number;
+    let workspaceStatus: number;
+    let workspaceBody: unknown;
+    let onTokenRequest: (() => void) | undefined;
+    let onWorkspaceRequest: (() => void) | undefined;
+    let env: ReturnType<typeof makeTmpEnv>;
+    let originalExit: typeof process.exit;
+    let originalIsTTY: boolean | undefined;
+    let originalLog: typeof console.log;
+    let originalError: typeof console.error;
+    let logLines: string[];
+    let errorLines: string[];
+
+    const host = () => `http://127.0.0.1:${port}`;
+    const globalPath = () => path.join(env.home, '.solidactions', 'config.json');
+
+    beforeAll(async () => {
+        server = http.createServer((req, res) => {
+            if (req.method === 'POST' && req.url === '/oauth/device/code') {
+                deviceCodeRequests++;
+                res.writeHead(200, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({
+                    device_code: 'device-code',
+                    user_code: 'ABCD-EFGH',
+                    verification_uri: `${host()}/device`,
+                    expires_in: 60,
+                    interval: 0.001,
+                }));
+                return;
+            }
+            if (req.method === 'POST' && req.url === '/oauth/token') {
+                onTokenRequest?.();
+                res.writeHead(200, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ access_token: 'approved-token', expires_in: 3600 }));
+                return;
+            }
+            if (req.method === 'GET' && req.url === '/api/v1/workspaces') {
+                onWorkspaceRequest?.();
+                res.writeHead(workspaceStatus, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify(workspaceBody));
+                return;
+            }
+            res.writeHead(404).end();
+        });
+        await new Promise<void>((resolve) => {
+            server.listen(0, '127.0.0.1', () => {
+                port = (server.address() as { port: number }).port;
+                resolve();
+            });
+        });
+    });
+
+    afterAll(() => new Promise<void>((resolve, reject) => {
+        server.close((error) => error ? reject(error) : resolve());
+    }));
+
+    beforeEach(() => {
+        env = makeTmpEnv();
+        deviceCodeRequests = 0;
+        workspaceStatus = 200;
+        workspaceBody = { data: [] };
+        onTokenRequest = undefined;
+        onWorkspaceRequest = undefined;
+
+        originalExit = process.exit;
+        (process as any).exit = (code?: number) => { throw new ProcessExitError(code); };
+        originalIsTTY = process.stdin.isTTY;
+        Object.defineProperty(process.stdin, 'isTTY', { value: undefined, configurable: true });
+        logLines = [];
+        errorLines = [];
+        originalLog = console.log;
+        originalError = console.error;
+        console.log = (...args: unknown[]) => { logLines.push(args.map(String).join(' ')); };
+        console.error = (...args: unknown[]) => { errorLines.push(args.map(String).join(' ')); };
+    });
+
+    afterEach(() => {
+        (process as any).exit = originalExit;
+        Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true });
+        console.log = originalLog;
+        console.error = originalError;
+        env.cleanup();
+    });
+
+    async function expectExit(action: () => Promise<void>, code = 1): Promise<void> {
+        let caught: ProcessExitError | undefined;
+        try {
+            await action();
+        } catch (error) {
+            if (error instanceof ProcessExitError) caught = error;
+            else throw error;
+        }
+        expect(caught?.code).toBe(code);
+    }
+
+    it('requires an explicit destination without a TTY before issuing a device code', async () => {
+        await expectExit(() => deviceLogin({ host: host() }));
+
+        expect(deviceCodeRequests).toBe(0);
+        expect(errorLines.join('\n')).toContain(
+            'No TTY detected. Re-run with the config destination made explicit: '
+            + 'solidactions login --device --global --workspace <name>',
+        );
+    });
+
+    it('aborts on destination-prompt EOF before a device code can be requested', async () => {
+        let wouldRequestDeviceCode = 0;
+
+        await expectExit(async () => {
+            await preflightDeviceLoginWrite({}, {
+                isTTY: true,
+                destinationQuestion: async () => undefined,
+            });
+            wouldRequestDeviceCode++;
+        });
+
+        expect(wouldRequestDeviceCode).toBe(0);
+        expect(errorLines.join('\n')).toContain('Input closed before a config destination was selected');
+    });
+
+    it('treats overwrite-confirmation EOF as decline before a device code can be requested', async () => {
+        writeGlobal(env.home, { host: 'https://old.example', apiKey: 'old-token' });
+        let wouldRequestDeviceCode = 0;
+
+        await expectExit(async () => {
+            await preflightDeviceLoginWrite({ global: true }, {
+                isTTY: true,
+                overwriteQuestion: async () => undefined,
+            });
+            wouldRequestDeviceCode++;
+        }, 0);
+
+        expect(wouldRequestDeviceCode).toBe(0);
+        expect(deviceCodeRequests).toBe(0);
+        expect(logLines.join('\n')).toContain('no device code was requested');
+    });
+
+    it('preserves normal destination and affirmative overwrite prompt answers', async () => {
+        const localPreflight = await preflightDeviceLoginWrite({}, {
+            isTTY: true,
+            destinationQuestion: async () => 'local',
+        });
+        expect(localPreflight.target).toBe('local');
+
+        writeGlobal(env.home, { host: 'https://old.example', apiKey: 'old-token' });
+        const globalPreflight = await preflightDeviceLoginWrite({ global: true }, {
+            isTTY: true,
+            overwriteQuestion: async () => 'yes',
+        });
+        expect(globalPreflight.target).toBe('global');
+        expect(globalPreflight.backupPath).toContain('config.json.bak-');
+        expect(deviceCodeRequests).toBe(0);
+    });
+
+    it('rejects mutually exclusive destinations before issuing a device code', async () => {
+        await expectExit(() => deviceLogin({ host: host(), local: true, global: true }));
+        expect(deviceCodeRequests).toBe(0);
+    });
+
+    it('rejects a .solidactions file before issuing a device code', async () => {
+        fs.writeFileSync(path.join(env.home, '.solidactions'), 'not a directory');
+
+        await expectExit(() => deviceLogin({ host: host(), global: true }));
+
+        expect(deviceCodeRequests).toBe(0);
+        expect(errorLines.join('\n')).toContain(path.join(env.home, '.solidactions'));
+    });
+
+    it('rejects a read-only destination before issuing a device code', async () => {
+        const configDir = path.dirname(globalPath());
+        fs.mkdirSync(configDir);
+        fs.chmodSync(configDir, 0o500);
+
+        await expectExit(() => deviceLogin({ host: host(), global: true }));
+
+        expect(deviceCodeRequests).toBe(0);
+        expect(errorLines.join('\n')).toContain('not writable');
+        fs.chmodSync(configDir, 0o700);
+    });
+
+    it('reuses the preflighted target and persists the token before workspace discovery', async () => {
+        const originalPath = globalPath();
+        const otherHome = path.join(path.dirname(env.home), 'other-home');
+        fs.mkdirSync(otherHome);
+        let baseConfigAtDiscovery: unknown;
+        onTokenRequest = () => {
+            process.env.HOME = otherHome;
+        };
+        onWorkspaceRequest = () => {
+            baseConfigAtDiscovery = JSON.parse(fs.readFileSync(originalPath, 'utf-8'));
+        };
+        workspaceBody = {
+            data: [{ id: 'ws-1', name: 'Only Workspace', slug: 'only-workspace' }],
+            scope: { mode: 'single', workspace_ids: ['ws-1'] },
+        };
+
+        await deviceLogin({ host: host(), global: true });
+
+        expect(baseConfigAtDiscovery).toEqual({ host: host(), apiKey: 'approved-token' });
+        expect(fs.existsSync(path.join(otherHome, '.solidactions', 'config.json'))).toBe(false);
+        expect(JSON.parse(fs.readFileSync(originalPath, 'utf-8'))).toMatchObject({
+            host: host(),
+            apiKey: 'approved-token',
+            workspace: 'only-workspace',
+            workspaceId: 'ws-1',
+            scopeMode: 'single',
+            scopedWorkspaceIds: ['ws-1'],
+        });
+        expect(logLines.join('\n')).toContain('Auto-selected workspace: Only Workspace');
+    });
+
+    it('keeps a backup and the approved credential when workspace discovery fails', async () => {
+        const existingPath = writeGlobal(env.home, { host: 'https://old.example', apiKey: 'old-token' });
+        const oldRaw = fs.readFileSync(existingPath, 'utf-8');
+        workspaceStatus = 503;
+        workspaceBody = { message: 'temporarily unavailable' };
+
+        await expectExit(() => deviceLogin({ host: host(), global: true }));
+
+        expect(JSON.parse(fs.readFileSync(existingPath, 'utf-8'))).toEqual({
+            host: host(),
+            apiKey: 'approved-token',
+        });
+        const backup = fs.readdirSync(path.dirname(existingPath))
+            .find((entry) => entry.startsWith('config.json.bak-'));
+        expect(backup).toBeDefined();
+        expect(fs.readFileSync(path.join(path.dirname(existingPath), backup!), 'utf-8')).toBe(oldRaw);
+        const output = [...logLines, ...errorLines].join('\n');
+        expect(output).toContain('Authentication was saved');
+        expect(output).toContain('solidactions workspace set <name>');
+        expect(logLines.findIndex((line) => line.includes('will be overwritten'))).toBeLessThan(
+            logLines.findIndex((line) => line.includes('Requesting device authorization')),
+        );
+    });
+
+    it('keeps the approved credential when an explicit workspace does not match', async () => {
+        workspaceBody = {
+            data: [{ id: 'ws-1', name: 'Only Workspace', slug: 'only-workspace' }],
+            scope: { mode: 'all', workspace_ids: [] },
+        };
+
+        await expectExit(() => deviceLogin({
+            host: host(),
+            global: true,
+            workspace: 'Missing Workspace',
+        }));
+
+        expect(JSON.parse(fs.readFileSync(globalPath(), 'utf-8'))).toMatchObject({
+            host: host(),
+            apiKey: 'approved-token',
+            scopeMode: 'all',
+        });
+        const output = [...logLines, ...errorLines].join('\n');
+        expect(output).toContain('Authentication was saved');
+        expect(output).toContain('solidactions workspace list');
+        expect(output).toContain('solidactions workspace set <name>');
+    });
+});

--- a/tests/env-set-deploy-first.test.ts
+++ b/tests/env-set-deploy-first.test.ts
@@ -1,0 +1,105 @@
+import * as http from 'http';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { envSet } from '../src/commands/env-set';
+import { makeTmpEnv, writeGlobal } from './helpers';
+
+class ProcessExitError extends Error {
+    constructor(public readonly code: number | undefined) {
+        super(`process.exit(${code})`);
+    }
+}
+
+let server: http.Server;
+let port: number;
+let projectRows: Array<{ name: string; slug: string; environments: string[] }> = [];
+
+beforeAll(async () => {
+    server = http.createServer((req, res) => {
+        if (req.method === 'POST' && req.url?.match(/\/api\/v1\/projects\/.+\/variable-mappings\/bulk/)) {
+            res.writeHead(404, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ message: 'Project not found.' }));
+            return;
+        }
+        if (req.method === 'GET' && req.url === '/api/v1/projects') {
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ data: projectRows }));
+            return;
+        }
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ message: `Unexpected ${req.method} ${req.url}` }));
+    });
+    await new Promise<void>((resolve) => {
+        server.listen(0, '127.0.0.1', () => {
+            port = (server.address() as { port: number }).port;
+            resolve();
+        });
+    });
+});
+
+afterAll(() => new Promise<void>((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve());
+}));
+
+beforeEach(() => {
+    projectRows = [];
+});
+
+async function failedEnvSet(
+    project: string,
+    options: { yes: true; env?: string },
+): Promise<string> {
+    const env = makeTmpEnv();
+    writeGlobal(env.home, {
+        host: `http://127.0.0.1:${port}`,
+        apiKey: 'test-key',
+        workspaceId: 'ws-1',
+    });
+    const originalExit = process.exit.bind(process);
+    const originalError = console.error;
+    const lines: string[] = [];
+    (process as any).exit = (code?: number) => { throw new ProcessExitError(code); };
+    console.error = (...args: unknown[]) => { lines.push(args.map(String).join(' ')); };
+
+    try {
+        await expect(envSet(project, 'API_KEY', 'secret', options))
+            .rejects.toMatchObject({ code: 1 });
+        return lines.join('\n');
+    } finally {
+        (process as any).exit = originalExit;
+        console.error = originalError;
+        env.cleanup();
+    }
+}
+
+describe('env set missing environment deploy-first hint', () => {
+    it('prints the exact production creation command with the actual project', async () => {
+        projectRows = [{ name: 'X', slug: 'X', environments: ['dev'] }];
+
+        const output = await failedEnvSet('X', { yes: true, env: 'production' });
+
+        expect(output).toContain('Project "X" has no production environment (exists in: dev).');
+        expect(output).toContain(
+            "Run 'solidactions project deploy X -e production --create' first.",
+        );
+    });
+
+    it('uses the default dev environment in the creation command', async () => {
+        projectRows = [{ name: 'my-project', slug: 'my-project', environments: ['production'] }];
+
+        const output = await failedEnvSet('my-project', { yes: true });
+
+        expect(output).toContain('Project "my-project" has no dev environment (exists in: production).');
+        expect(output).toContain(
+            "Run 'solidactions project deploy my-project -e dev --create' first.",
+        );
+    });
+
+    it('preserves the plain prefix and creation command when discovery returns null', async () => {
+        const output = await failedEnvSet('missing-project', { yes: true, env: 'production' });
+
+        expect(output).toContain('Project "missing-project" has no production environment.');
+        expect(output).toContain(
+            "Run 'solidactions project deploy missing-project -e production --create' first.",
+        );
+    });
+});

--- a/tests/help-device-auth-followups.test.ts
+++ b/tests/help-device-auth-followups.test.ts
@@ -47,4 +47,11 @@ describe('device-auth follow-up --help docs', () => {
         // Makes the (device) login flow unnecessary.
         expect(out).toMatch(/login --device/);
     });
+
+    it('#1002 login --help explains sole-workspace auto-selection and multiple-workspace choice', () => {
+        const out = help(['login']);
+        expect(out).toMatch(/sole\s+workspace is auto-selected/i);
+        expect(out).toMatch(/--workspace.*multiple workspaces/is);
+        expect(out).not.toMatch(/without this flag leave the workspace unset/i);
+    });
 });

--- a/tests/login-validation.test.ts
+++ b/tests/login-validation.test.ts
@@ -175,7 +175,7 @@ describe('login — validates before writing (F-C2)', () => {
         expect(out).toContain('Nonexistent Team');
     });
 
-    it('non-interactive, no --workspace: writes the config ONCE without a workspaceId and warns', async () => {
+    it('non-interactive, no --workspace: auto-selects and persists the sole workspace', async () => {
         nextStatus = 200;
         nextBody = { data: [{ id: 'ws-1', name: 'Some Workspace', slug: 'some-workspace' }] };
 
@@ -191,10 +191,29 @@ describe('login — validates before writing (F-C2)', () => {
         expect(writeCount).toBe(1);
         const globalPath = path.join(env.home, '.solidactions', 'config.json');
         const config = JSON.parse(fs.readFileSync(globalPath, 'utf-8'));
+        expect(config.workspaceId).toBe('ws-1');
+        expect(config.workspace).toBe('some-workspace');
+        const out = logLines.join(' ');
+        expect(out).toContain('Auto-selected workspace: Some Workspace');
+        expect(out).toContain('Logged in successfully!');
+    });
+
+    it('non-interactive, no --workspace: leaves multiple workspaces unset with recovery guidance', async () => {
+        nextStatus = 200;
+        nextBody = {
+            data: [
+                { id: 'ws-1', name: 'First Workspace', slug: 'first-workspace' },
+                { id: 'ws-2', name: 'Second Workspace', slug: 'second-workspace' },
+            ],
+        };
+
+        await login('good-key', { global: true, host: HOST() });
+
+        const config = JSON.parse(fs.readFileSync(path.join(env.home, '.solidactions', 'config.json'), 'utf-8'));
         expect(config.workspaceId).toBeUndefined();
         const out = logLines.join(' ');
-        expect(out).toContain('No workspace set');
-        expect(out).toContain('Logged in successfully!');
+        expect(out).toContain('solidactions workspace list');
+        expect(out).toContain('solidactions workspace set <name>');
     });
 
     it('a scoped /v1/workspaces response (device-flow token) persists scopeMode + scopedWorkspaceIds through completeLogin', async () => {

--- a/tests/require-config-sole-workspace.test.ts
+++ b/tests/require-config-sole-workspace.test.ts
@@ -1,0 +1,89 @@
+import fs from 'fs';
+import http from 'http';
+import path from 'path';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { requireConfigWithWorkspace } from '../src/utils/api';
+import { makeTmpEnv, writeGlobal } from './helpers';
+
+class ProcessExitError extends Error {
+    constructor(public readonly code: number | undefined) {
+        super(`process.exit(${code})`);
+    }
+}
+
+describe('requireConfigWithWorkspace for existing unpinned configs', () => {
+    let server: http.Server;
+    let port: number;
+    let workspaceBody: unknown;
+    let env: ReturnType<typeof makeTmpEnv>;
+    let originalExit: typeof process.exit;
+    let originalIsTTY: boolean | undefined;
+    let originalError: typeof console.error;
+    let errorLines: string[];
+
+    beforeAll(async () => {
+        server = http.createServer((_req, res) => {
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify(workspaceBody));
+        });
+        await new Promise<void>((resolve) => {
+            server.listen(0, '127.0.0.1', () => {
+                port = (server.address() as { port: number }).port;
+                resolve();
+            });
+        });
+    });
+
+    afterAll(() => new Promise<void>((resolve, reject) => {
+        server.close((error) => error ? reject(error) : resolve());
+    }));
+
+    beforeEach(() => {
+        env = makeTmpEnv();
+        originalExit = process.exit;
+        (process as any).exit = (code?: number) => { throw new ProcessExitError(code); };
+        originalIsTTY = process.stdin.isTTY;
+        Object.defineProperty(process.stdin, 'isTTY', { value: undefined, configurable: true });
+        originalError = console.error;
+        errorLines = [];
+        console.error = (...args: unknown[]) => { errorLines.push(args.map(String).join(' ')); };
+    });
+
+    afterEach(() => {
+        (process as any).exit = originalExit;
+        Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true });
+        console.error = originalError;
+        env.cleanup();
+    });
+
+    it('discovers and persists the sole workspace without a TTY', async () => {
+        const configPath = writeGlobal(env.home, {
+            host: `http://127.0.0.1:${port}`,
+            apiKey: 'existing-token',
+        });
+        workspaceBody = {
+            data: [{ id: 'ws-1', name: 'Only Workspace', slug: 'only-workspace' }],
+        };
+
+        const config = await requireConfigWithWorkspace();
+
+        expect(config.workspaceId).toBe('ws-1');
+        expect(JSON.parse(fs.readFileSync(configPath, 'utf-8')).workspaceId).toBe('ws-1');
+    });
+
+    it('refuses ambiguous multiple workspaces without a TTY and gives an explicit set command', async () => {
+        writeGlobal(env.home, {
+            host: `http://127.0.0.1:${port}`,
+            apiKey: 'existing-token',
+        });
+        workspaceBody = {
+            data: [
+                { id: 'ws-1', name: 'First Workspace' },
+                { id: 'ws-2', name: 'Second Workspace' },
+            ],
+        };
+
+        await expect(requireConfigWithWorkspace()).rejects.toMatchObject({ code: 1 });
+        expect(errorLines.join('\n')).toContain('solidactions workspace set <name-or-id>');
+    });
+});

--- a/tests/workspace-selection.test.ts
+++ b/tests/workspace-selection.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { selectWorkspaceInteractively } from '../src/commands/login';
+
+const workspaces = [
+    { id: 'ws-1', name: 'First Workspace', slug: 'first-workspace' },
+    { id: 'ws-2', name: 'Second Workspace', slug: 'second-workspace' },
+];
+
+describe('interactive login workspace selection', () => {
+    it('re-prompts after invalid input and returns a later valid selection', async () => {
+        const answers = ['not-a-number', '3', '2'];
+        const selected = await selectWorkspaceInteractively(workspaces, {
+            question: async () => answers.shift(),
+        });
+
+        expect(selected?.id).toBe('ws-2');
+    });
+
+    it('treats EOF as cancellation without selecting a workspace', async () => {
+        const selected = await selectWorkspaceInteractively(workspaces, {
+            question: async () => undefined,
+        });
+
+        expect(selected).toBeUndefined();
+    });
+});


### PR DESCRIPTION
Refs SolidActions/solidactions-app#1002

## Summary
- preflight the device-login config destination before browser authorization and persist approved credentials before workspace discovery
- auto-select a sole workspace for new and existing headless configs while preserving explicit/multiple-workspace recovery
- diagnose narrow Cloud-host sandbox egress 403s and add deploy-first `env set` remediation

## Verification
- `npm run check:release` (93 files, 876 tests, build, scaffold smoke)
- context-free Opus 5 cleanroom PASS 5/5 with genuine non-TTY compiled-binary runs

## Coordination
Public troubleshooting docs must merge and deploy before any CLI version containing the new deep link is published. This PR does not change the package version and must not be released from this issue-manager lane.