### PR TITLE
Emit command-manifest.json from the commander definitions (#1004 PR 0)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,33 +8,28 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      # contents: write — the build attaches dist/command-manifest.json to the
+      # release as the artifact the content repo pins (#1004).
+      contents: write
       id-token: write
     steps:
       - uses: actions/checkout@v6
-
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
-
       - run: npm ci
-      - run: npm run build
-
-      # `npm version` resolves increment KEYWORDS (patch/minor/major/…), so a
-      # release tagged e.g. `patch` would silently publish a bumped version
-      # instead of failing. Assert the tag is a literal semver before we hand it
-      # to `npm version`, so only an explicit version ever reaches the registry.
       - name: Assert release tag is a literal semver version
         run: |
           [[ "${GITHUB_REF_NAME}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+([-+].*)?$ ]] || {
             echo "release tag '${GITHUB_REF_NAME}' is not a semver version"; exit 1;
           }
-
-      # The release tag is the single source of truth for the published version.
-      # Deriving it here (rather than relying on a package.json bump commit) means
-      # a release whose package.json wasn't bumped can no longer collide with the
-      # registry's existing version and fail `npm publish` silently (#77). No git
-      # tag is created — this only rewrites the in-workspace package.json version.
       - run: npm version --no-git-tag-version --allow-same-version "${GITHUB_REF_NAME#v}"
-
+      # Build AFTER the version rewrite: the command manifest stamps
+      # package.json's version into cli_version, and the committed value is
+      # vestigial (the published version comes from the tag).
+      - run: npm run build
       - run: npm publish --provenance --access public
+      - name: Attach command manifest to the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${GITHUB_REF_NAME}" dist/command-manifest.json --clobber

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,21 +14,38 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v6
+
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
+
       - run: npm ci
+
+      # `npm version` resolves increment KEYWORDS (patch/minor/major/…), so a
+      # release tagged e.g. `patch` would silently publish a bumped version
+      # instead of failing. Assert the tag is a literal semver before we hand it
+      # to `npm version`, so only an explicit version ever reaches the registry.
       - name: Assert release tag is a literal semver version
         run: |
           [[ "${GITHUB_REF_NAME}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+([-+].*)?$ ]] || {
             echo "release tag '${GITHUB_REF_NAME}' is not a semver version"; exit 1;
           }
+
+      # The release tag is the single source of truth for the published version.
+      # Deriving it here (rather than relying on a package.json bump commit) means
+      # a release whose package.json wasn't bumped can no longer collide with the
+      # registry's existing version and fail `npm publish` silently (#77). No git
+      # tag is created — this only rewrites the in-workspace package.json version.
       - run: npm version --no-git-tag-version --allow-same-version "${GITHUB_REF_NAME#v}"
-      # Build AFTER the version rewrite: the command manifest stamps
-      # package.json's version into cli_version, and the committed value is
-      # vestigial (the published version comes from the tag).
+
+      # Build after the version rewrite so the explicitly-built dist/ — including
+      # the command manifest uploaded below — carries the tag-derived version
+      # without relying on the prepublishOnly hook's rebuild. It also skips the
+      # build entirely when the semver assertion above rejects the tag.
       - run: npm run build
+
       - run: npm publish --provenance --access public
+
       - name: Attach command manifest to the release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,19 @@ jobs:
       # build entirely when the semver assertion above rejects the tag.
       - run: npm run build
 
-      - run: npm publish --provenance --access public
+      # A transient failure in the upload step below (network blip, etc.) must
+      # be rerunnable — but `npm publish` rejects a version that is already on
+      # the registry, so a bare rerun would fail before ever reaching the
+      # upload. Skip the publish when the version is already there and let the
+      # rerun fall through to the upload.
+      - name: Publish to npm (skip if this version is already published)
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          if npm view "@solidactions/cli@$VERSION" version >/dev/null 2>&1; then
+            echo "@solidactions/cli@$VERSION is already published — skipping npm publish (rerun after a failed release-asset upload)"
+          else
+            npm publish --provenance --access public
+          fi
 
       - name: Attach command manifest to the release
         env:

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "deploy"
   ],
   "scripts": {
-    "build": "tsc && cp src/commands/dev-shim.mjs dist/commands/dev-shim.mjs && cp src/utils/archiver-loader.cjs dist/utils/archiver-loader.cjs",
+    "build": "tsc && cp src/commands/dev-shim.mjs dist/commands/dev-shim.mjs && cp src/utils/archiver-loader.cjs dist/utils/archiver-loader.cjs && node scripts/generate-command-manifest.mjs",
     "check:release": "npm run build && npm run test && npm run smoke:init",
     "prepublishOnly": "npm run build",
     "smoke:init": "node scripts/smoke-init.mjs",

--- a/scripts/generate-command-manifest.mjs
+++ b/scripts/generate-command-manifest.mjs
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+// #1004 PR 0: emit dist/command-manifest.json from the built command tree.
+// Runs after tsc in `npm run build`, so it loads compiled CommonJS output.
+import path from 'path';
+import fs from 'fs';
+import { fileURLToPath } from 'url';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const here = path.dirname(fileURLToPath(import.meta.url));
+const dist = path.resolve(here, '../dist');
+
+const { program } = require(path.join(dist, 'index.js'));
+const { buildCommandManifest, COMMAND_MANIFEST_FILE } = require(path.join(dist, 'utils/command-manifest.js'));
+const pkg = require(path.resolve(here, '../package.json'));
+
+const manifest = buildCommandManifest(program, pkg.version);
+const outPath = path.join(dist, COMMAND_MANIFEST_FILE);
+fs.writeFileSync(outPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+
+console.log(`command manifest: ${manifest.commands.length} commands -> ${path.relative(process.cwd(), outPath)}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,7 @@ import { setCliWorkspaceOverride } from './utils/config';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const pkg = require('../package.json');
 
-const program = new Command();
+export const program = new Command();
 
 if (process.env.SOLIDACTIONS_DEBUG === '1') {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -781,7 +781,12 @@ doc
         await docUpload(files, { folder: options.folder, title: options.title, replace: options.replace });
     });
 
-program.parseAsync().catch((err) => {
-    console.error(chalk.red(err.message ?? String(err)));
-    process.exit(1);
-});
+// Only parse argv when this file IS the process entry point (the `solidactions`
+// bin). The #1004 command-manifest generator requires this module to walk the
+// assembled command tree; that must not consume the caller's argv or exit.
+if (require.main === module) {
+    program.parseAsync().catch((err) => {
+        console.error(chalk.red(err.message ?? String(err)));
+        process.exit(1);
+    });
+}

--- a/src/utils/command-manifest.ts
+++ b/src/utils/command-manifest.ts
@@ -48,6 +48,8 @@ export interface ManifestCommand {
     /** Noun-verb path from the program root, e.g. ["crew", "env", "set"]. */
     path: string[];
     name: string;
+    /** Alternate names accepted for this command, e.g. from .alias()/.aliases(); empty if none. */
+    aliases: string[];
     description: string;
     /** Declared with { hidden: true } — parses, but is not part of the public surface. */
     hidden: boolean;
@@ -145,6 +147,7 @@ function describeCommand(command: Command, parentPath: string[]): ManifestComman
     const entry: ManifestCommand = {
         path,
         name: command.name(),
+        aliases: [...command.aliases()],
         description: command.description(),
         hidden: isHiddenCommand(command),
         arguments: command.registeredArguments.map(describeArgument),

--- a/src/utils/command-manifest.ts
+++ b/src/utils/command-manifest.ts
@@ -117,7 +117,14 @@ function describeOption(option: Option): ManifestOption {
         negated: option.negate === true,
         hidden: option.hidden === true,
     };
-    applyDefault(entry, option.defaultValue, option.defaultValueDescription);
+    // commander's Command.addOption() (lib/command.js ~:548) defaults a negated
+    // option's positive attribute to `true` when no explicit defaultValue was
+    // given (and no positive counterpart option is registered) — e.g.
+    // `--no-cache` implicitly defaults `cache` to `true`. That implicit default
+    // lives in the Command's option-processing, not on Option.defaultValue, so
+    // it's otherwise invisible here.
+    const defaultValue = option.negate === true && option.defaultValue === undefined ? true : option.defaultValue;
+    applyDefault(entry, defaultValue, option.defaultValueDescription);
     if (option.argChoices) {
         entry.choices = [...option.argChoices];
     }
@@ -157,6 +164,12 @@ function isHiddenCommand(command: Command): boolean {
  * reads (`_hasHelpOption`, `_helpFlags`, `_helpShortFlag`, `_helpLongFlag`,
  * `_helpDescription` — there is no public getter for any of them) and
  * synthesize an equivalent manifest entry by hand.
+ *
+ * commander also suppresses a help flag form when a real option on the
+ * command already owns that exact flag (`Help.visibleOptions` in
+ * lib/help.js, via `Command._findOption`/`Option.is`) — e.g.
+ * `.option('-h, --human')` steals `-h` from the synthesized help option, so
+ * only `--help` is shown. Mirror that per-form check here.
  */
 function describeHelpOption(command: Command): ManifestOption | null {
     const cmd = command as unknown as {
@@ -169,13 +182,21 @@ function describeHelpOption(command: Command): ManifestOption | null {
     if (cmd._hasHelpOption !== true) {
         return null;
     }
-    const short = cmd._helpShortFlag ?? null;
-    const long = cmd._helpLongFlag ?? null;
-    if (!short && !long) {
+    const ownsFlag = (flag: string | undefined): boolean =>
+        flag !== undefined && command.options.some((option) => option.short === flag || option.long === flag);
+    const showShort = cmd._helpShortFlag !== undefined && !ownsFlag(cmd._helpShortFlag);
+    const showLong = !ownsFlag(cmd._helpLongFlag);
+    if (!showShort && !showLong) {
         return null;
     }
+    const short = showShort ? (cmd._helpShortFlag ?? null) : null;
+    const long = showLong ? (cmd._helpLongFlag ?? null) : null;
+    const flags =
+        showShort && showLong
+            ? (cmd._helpFlags ?? [short, long].filter((flag): flag is string => flag !== null).join(', '))
+            : ((long ?? short) as string);
     return {
-        flags: cmd._helpFlags ?? [short, long].filter((flag): flag is string => flag !== null).join(', '),
+        flags,
         long,
         short,
         description: cmd._helpDescription ?? '',

--- a/src/utils/command-manifest.ts
+++ b/src/utils/command-manifest.ts
@@ -1,0 +1,168 @@
+import type { Argument, Command, Option } from 'commander';
+
+/**
+ * Machine-readable description of the CLI's command surface, generated from the
+ * commander definitions at build time (#1004 PR 0). Consumers — chiefly the
+ * content repo's prose validator — pin a released manifest and fail CI when
+ * documentation names a command or flag that does not exist here.
+ *
+ * Follows the `schema_version` precedent set by src/utils/skill-cache.ts.
+ */
+export const COMMAND_MANIFEST_SCHEMA_VERSION = 1;
+export const COMMAND_MANIFEST_FILE = 'command-manifest.json';
+
+export interface ManifestOption {
+    /** The raw commander flags string, e.g. "-e, --env <environment>". */
+    flags: string;
+    /** Long form including leading dashes, e.g. "--env" or "--no-cache"; null if the option has none. */
+    long: string | null;
+    /** Short form including the leading dash, e.g. "-e"; null if the option has none. */
+    short: string | null;
+    description: string;
+    /** Declared with .requiredOption() — the option itself must be supplied. */
+    required: boolean;
+    /** A value must follow the option, e.g. "--env <environment>". */
+    value_required: boolean;
+    /** A value may follow the option, e.g. "--env [environment]". */
+    value_optional: boolean;
+    variadic: boolean;
+    /** A "--no-x" boolean. */
+    negated: boolean;
+    /** Declared with .hideHelp() — parses, but is not part of the public surface. */
+    hidden: boolean;
+    default?: unknown;
+    default_description?: string;
+    choices?: string[];
+}
+
+export interface ManifestArgument {
+    name: string;
+    required: boolean;
+    variadic: boolean;
+    description: string;
+    default?: unknown;
+    choices?: string[];
+}
+
+export interface ManifestCommand {
+    /** Noun-verb path from the program root, e.g. ["crew", "env", "set"]. */
+    path: string[];
+    name: string;
+    description: string;
+    /** Declared with { hidden: true } — parses, but is not part of the public surface. */
+    hidden: boolean;
+    arguments: ManifestArgument[];
+    options: ManifestOption[];
+}
+
+export interface CommandManifest {
+    schema_version: typeof COMMAND_MANIFEST_SCHEMA_VERSION;
+    cli_name: string;
+    cli_version: string;
+    /** Options declared on the program itself; they apply to every command. */
+    global_options: ManifestOption[];
+    commands: ManifestCommand[];
+}
+
+/**
+ * True when `value` survives JSON.stringify without becoming undefined —
+ * functions, symbols and undefined do not, and must never reach the manifest.
+ */
+function isJsonSafe(value: unknown): boolean {
+    try {
+        return JSON.stringify(value) !== undefined;
+    } catch {
+        return false;
+    }
+}
+
+function applyDefault(
+    target: { default?: unknown; default_description?: string },
+    defaultValue: unknown,
+    defaultValueDescription: string | undefined,
+): void {
+    if (defaultValue === undefined) {
+        if (defaultValueDescription !== undefined) {
+            target.default_description = defaultValueDescription;
+        }
+        return;
+    }
+    if (isJsonSafe(defaultValue)) {
+        target.default = defaultValue;
+        if (defaultValueDescription !== undefined) {
+            target.default_description = defaultValueDescription;
+        }
+        return;
+    }
+    target.default_description = defaultValueDescription ?? String(defaultValue);
+}
+
+function describeOption(option: Option): ManifestOption {
+    const entry: ManifestOption = {
+        flags: option.flags,
+        long: option.long ?? null,
+        short: option.short ?? null,
+        description: option.description,
+        required: option.mandatory === true,
+        value_required: option.required === true,
+        value_optional: option.optional === true,
+        variadic: option.variadic === true,
+        negated: option.negate === true,
+        hidden: option.hidden === true,
+    };
+    applyDefault(entry, option.defaultValue, option.defaultValueDescription);
+    if (option.argChoices) {
+        entry.choices = [...option.argChoices];
+    }
+    return entry;
+}
+
+function describeArgument(argument: Argument): ManifestArgument {
+    const entry: ManifestArgument = {
+        name: argument.name(),
+        required: argument.required === true,
+        variadic: argument.variadic === true,
+        description: argument.description,
+    };
+    applyDefault(entry, argument.defaultValue, argument.defaultValueDescription);
+    if (argument.argChoices) {
+        entry.choices = [...argument.argChoices];
+    }
+    return entry;
+}
+
+/**
+ * commander exposes no public getter for a command hidden via
+ * `.command(name, { hidden: true })` — the flag lives on the private `_hidden`
+ * field, which its own help renderer reads. Read it the same way.
+ */
+function isHiddenCommand(command: Command): boolean {
+    return (command as unknown as { _hidden?: boolean })._hidden === true;
+}
+
+function describeCommand(command: Command, parentPath: string[]): ManifestCommand[] {
+    const path = [...parentPath, command.name()];
+    const entry: ManifestCommand = {
+        path,
+        name: command.name(),
+        description: command.description(),
+        hidden: isHiddenCommand(command),
+        arguments: command.registeredArguments.map(describeArgument),
+        options: command.options.map(describeOption),
+    };
+    return [entry, ...command.commands.flatMap((child) => describeCommand(child, path))];
+}
+
+/**
+ * Walk an assembled commander program into its manifest. Declaration order is
+ * preserved throughout: it is already deterministic and mirrors help ordering.
+ */
+export function buildCommandManifest(program: Command, cliVersion: string): CommandManifest {
+    return {
+        schema_version: COMMAND_MANIFEST_SCHEMA_VERSION,
+        cli_name: program.name(),
+        cli_version: cliVersion,
+        global_options: program.options.map(describeOption),
+        commands: program.commands.flatMap((command) => describeCommand(command, [])),
+    };
+}

--- a/src/utils/command-manifest.ts
+++ b/src/utils/command-manifest.ts
@@ -188,6 +188,48 @@ function describeHelpOption(command: Command): ManifestOption | null {
     };
 }
 
+/**
+ * commander adds an implicit `help [command]` (sub)command to any command
+ * that has children, no action handler of its own, and no explicit `help`
+ * command already registered (`_hasImplicitHelpCommand()` in command.js) —
+ * but, like the `-h, --help` option above, it is synthesized at help-render
+ * time (see `Help.visibleCommands` in lib/help.js) rather than living in
+ * `command.commands`, so the recursive walk in `describeCommand` never sees
+ * it. It is real and typable at every level it applies — both
+ * `solidactions help project` and `solidactions project help view` work —
+ * so downstream doc validators need an entry for it too. Reconstruct it the
+ * same way commander's own help renderer does (there is no public API for
+ * any of `_hasImplicitHelpCommand`, `_helpCommandnameAndArgs`,
+ * `_helpCommandDescription`): build a throwaway `Command` from those private
+ * fields, then run it through the normal `describeCommand` walk so its shape
+ * (path, aliases, options via `describeHelpOption`, etc.) matches every
+ * other command for free.
+ */
+function describeImplicitHelpCommand(command: Command, path: string[]): ManifestCommand[] {
+    const cmd = command as unknown as {
+        _hasImplicitHelpCommand?: () => boolean;
+        _helpCommandnameAndArgs?: string;
+        _helpCommandDescription?: string;
+    };
+    if (typeof cmd._hasImplicitHelpCommand !== 'function' || !cmd._hasImplicitHelpCommand()) {
+        return [];
+    }
+    const nameAndArgs = cmd._helpCommandnameAndArgs ?? 'help [command]';
+    const match = nameAndArgs.match(/([^ ]+) *(.*)/);
+    const helpName = match?.[1] ?? 'help';
+    const helpArgs = match?.[2] ?? '';
+    // Same construction as commander's Help.visibleCommands: a fresh command
+    // with its own help option turned off (commander never lists "-h, --help"
+    // twice for the same invocation) and, when the nameAndArgs spec carries
+    // one (e.g. "[command]"), the optional target-command argument.
+    const helpCommand = command.createCommand(helpName).helpOption(false);
+    helpCommand.description(cmd._helpCommandDescription ?? '');
+    if (helpArgs) {
+        helpCommand.arguments(helpArgs);
+    }
+    return describeCommand(helpCommand, path);
+}
+
 function describeCommand(command: Command, parentPath: string[]): ManifestCommand[] {
     const path = [...parentPath, command.name()];
     const options = command.options.map(describeOption);
@@ -204,7 +246,11 @@ function describeCommand(command: Command, parentPath: string[]): ManifestComman
         arguments: command.registeredArguments.map(describeArgument),
         options,
     };
-    return [entry, ...command.commands.flatMap((child) => describeCommand(child, path))];
+    return [
+        entry,
+        ...command.commands.flatMap((child) => describeCommand(child, path)),
+        ...describeImplicitHelpCommand(command, path),
+    ];
 }
 
 /**
@@ -212,11 +258,25 @@ function describeCommand(command: Command, parentPath: string[]): ManifestComman
  * preserved throughout: it is already deterministic and mirrors help ordering.
  */
 export function buildCommandManifest(program: Command, cliVersion: string): CommandManifest {
+    // The root program's `-h, --help` is the same commander-synthesized
+    // option as describeHelpOption handles per-command (see that function's
+    // comment) — commander keeps it outside `program.options` too, so the
+    // plain `program.options.map(describeOption)` walk below would otherwise
+    // silently drop it from global_options even though `solidactions --help`
+    // works (README.md documents it).
+    const globalOptions = program.options.map(describeOption);
+    const rootHelpOption = describeHelpOption(program);
+    if (rootHelpOption) {
+        globalOptions.push(rootHelpOption);
+    }
     return {
         schema_version: COMMAND_MANIFEST_SCHEMA_VERSION,
         cli_name: program.name(),
         cli_version: cliVersion,
-        global_options: program.options.map(describeOption),
-        commands: program.commands.flatMap((command) => describeCommand(command, [])),
+        global_options: globalOptions,
+        commands: [
+            ...program.commands.flatMap((command) => describeCommand(command, [])),
+            ...describeImplicitHelpCommand(program, []),
+        ],
     };
 }

--- a/src/utils/command-manifest.ts
+++ b/src/utils/command-manifest.ts
@@ -61,7 +61,12 @@ export interface CommandManifest {
     schema_version: typeof COMMAND_MANIFEST_SCHEMA_VERSION;
     cli_name: string;
     cli_version: string;
-    /** Options declared on the program itself; they apply to every command. */
+    /**
+     * Options declared on the program itself. Most (e.g. `-w, --workspace-override`)
+     * apply to every command, but `--version` is a commander-root-only special
+     * case: `solidactions --version` works, `solidactions project deploy --version`
+     * does not.
+     */
     global_options: ManifestOption[];
     commands: ManifestCommand[];
 }
@@ -142,8 +147,54 @@ function isHiddenCommand(command: Command): boolean {
     return (command as unknown as { _hidden?: boolean })._hidden === true;
 }
 
+/**
+ * commander auto-adds a `-h, --help` option to every command, but it is
+ * synthesized at help-render time (see lib/help.js `visibleOptions`) rather
+ * than being a real `Option` living in `command.options` — so the plain
+ * `command.options.map(describeOption)` walk below silently drops it from
+ * the manifest. Downstream doc validators need it (real prose documents
+ * `--help`), so read the same private fields commander's own help renderer
+ * reads (`_hasHelpOption`, `_helpFlags`, `_helpShortFlag`, `_helpLongFlag`,
+ * `_helpDescription` — there is no public getter for any of them) and
+ * synthesize an equivalent manifest entry by hand.
+ */
+function describeHelpOption(command: Command): ManifestOption | null {
+    const cmd = command as unknown as {
+        _hasHelpOption?: boolean;
+        _helpFlags?: string;
+        _helpShortFlag?: string;
+        _helpLongFlag?: string;
+        _helpDescription?: string;
+    };
+    if (cmd._hasHelpOption !== true) {
+        return null;
+    }
+    const short = cmd._helpShortFlag ?? null;
+    const long = cmd._helpLongFlag ?? null;
+    if (!short && !long) {
+        return null;
+    }
+    return {
+        flags: cmd._helpFlags ?? [short, long].filter((flag): flag is string => flag !== null).join(', '),
+        long,
+        short,
+        description: cmd._helpDescription ?? '',
+        required: false,
+        value_required: false,
+        value_optional: false,
+        variadic: false,
+        negated: false,
+        hidden: false,
+    };
+}
+
 function describeCommand(command: Command, parentPath: string[]): ManifestCommand[] {
     const path = [...parentPath, command.name()];
+    const options = command.options.map(describeOption);
+    const helpOption = describeHelpOption(command);
+    if (helpOption) {
+        options.push(helpOption);
+    }
     const entry: ManifestCommand = {
         path,
         name: command.name(),
@@ -151,7 +202,7 @@ function describeCommand(command: Command, parentPath: string[]): ManifestComman
         description: command.description(),
         hidden: isHiddenCommand(command),
         arguments: command.registeredArguments.map(describeArgument),
-        options: command.options.map(describeOption),
+        options,
     };
     return [entry, ...command.commands.flatMap((child) => describeCommand(child, path))];
 }

--- a/tests/command-manifest-artifact.test.ts
+++ b/tests/command-manifest-artifact.test.ts
@@ -1,0 +1,41 @@
+// #1004 PR 0: the build must emit dist/command-manifest.json, and that artifact
+// must agree with a freshly-walked program — a stale artifact is the exact
+// drift this manifest exists to prevent.
+import { describe, expect, it } from 'vitest';
+import path from 'path';
+import fs from 'fs';
+import { buildCommandManifest } from '../src/utils/command-manifest';
+
+const DIST = path.resolve(__dirname, '../dist');
+const MANIFEST_PATH = path.join(DIST, 'command-manifest.json');
+const CLI_BINARY = path.join(DIST, 'index.js');
+const pkg = require('../package.json');
+
+describe('command-manifest.json build artifact', () => {
+    it('is emitted by the build', () => {
+        expect(fs.existsSync(MANIFEST_PATH)).toBe(true); // run `npm run build` first
+    });
+
+    it('is valid JSON carrying the schema version and the package version', () => {
+        const manifest = JSON.parse(fs.readFileSync(MANIFEST_PATH, 'utf8'));
+
+        expect(manifest.schema_version).toBe(1);
+        expect(manifest.cli_name).toBe('solidactions');
+        expect(manifest.cli_version).toBe(pkg.version);
+    });
+
+    it('matches a manifest walked fresh from the built program', () => {
+        expect(fs.existsSync(CLI_BINARY)).toBe(true);
+        const { program } = require(CLI_BINARY);
+
+        const onDisk = JSON.parse(fs.readFileSync(MANIFEST_PATH, 'utf8'));
+        const fresh = JSON.parse(JSON.stringify(buildCommandManifest(program, pkg.version)));
+
+        expect(onDisk).toEqual(fresh);
+    });
+
+    it('ships inside dist/, which is the only published directory', () => {
+        expect(pkg.files).toContain('dist');
+        expect(path.relative(DIST, MANIFEST_PATH)).toBe('command-manifest.json');
+    });
+});

--- a/tests/command-manifest.test.ts
+++ b/tests/command-manifest.test.ts
@@ -86,6 +86,24 @@ describe('buildCommandManifest — synthetic trees', () => {
         expect(opt.negated).toBe(true);
     });
 
+    it('records the implicit `true` default of a negated option with no explicit default', () => {
+        const program = new Command().name('demo');
+        program.command('deploy').option('--no-cache', 'Force a fresh build');
+
+        const opt = findCommand(buildCommandManifest(program, '0.0.0'), 'deploy')!.options[0];
+
+        expect(opt.default).toBe(true);
+    });
+
+    it('keeps an explicit default on a negated option instead of the implicit `true`', () => {
+        const program = new Command().name('demo');
+        program.command('deploy').option('--no-verify', 'Skip verification', false);
+
+        const opt = findCommand(buildCommandManifest(program, '0.0.0'), 'deploy')!.options[0];
+
+        expect(opt.default).toBe(false);
+    });
+
     it('records JSON-safe defaults and omits unserializable ones', () => {
         const program = new Command().name('demo');
         program
@@ -168,6 +186,21 @@ describe('buildCommandManifest — synthetic trees', () => {
         expect(help!.short).toBe('-h');
         expect(help!.flags.length).toBeGreaterThan(0);
         expect(help!.description.length).toBeGreaterThan(0);
+    });
+
+    it('omits a help flag form claimed by a real option on the same command', () => {
+        const program = new Command().name('demo');
+        program.command('go').option('-h, --human', 'Human-readable output');
+
+        const options = findCommand(buildCommandManifest(program, '0.0.0'), 'go')!.options;
+        const help = options.find((o) => o.long === '--help');
+        const human = options.find((o) => o.long === '--human');
+
+        expect(help).toBeDefined();
+        expect(help!.short).toBeNull();
+        expect(help!.flags).toBe('--help');
+        expect(human!.short).toBe('-h');
+        expect(options.filter((o) => o.short === '-h')).toEqual([human]);
     });
 
     it('omits the help option when it is disabled with .helpOption(false)', () => {

--- a/tests/command-manifest.test.ts
+++ b/tests/command-manifest.test.ts
@@ -153,6 +153,28 @@ describe('buildCommandManifest — synthetic trees', () => {
         expect(findCommand(manifest, 'remove')!.aliases).toEqual(['rm', 'del']);
     });
 
+    it('includes the implicit commander help option in a command manifest entry', () => {
+        const program = new Command().name('demo');
+        program.command('go').option('--flag', 'A flag');
+
+        const options = findCommand(buildCommandManifest(program, '0.0.0'), 'go')!.options;
+        const help = options.find((o) => o.long === '--help');
+
+        expect(help).toBeDefined();
+        expect(help!.short).toBe('-h');
+        expect(help!.flags.length).toBeGreaterThan(0);
+        expect(help!.description.length).toBeGreaterThan(0);
+    });
+
+    it('omits the help option when it is disabled with .helpOption(false)', () => {
+        const program = new Command().name('demo');
+        program.command('go').helpOption(false).option('--flag', 'A flag');
+
+        const options = findCommand(buildCommandManifest(program, '0.0.0'), 'go')!.options;
+
+        expect(options.find((o) => o.long === '--help')).toBeUndefined();
+    });
+
     it('produces output that survives a JSON round-trip unchanged', () => {
         const program = new Command().name('demo');
         program.command('go').alias('g').option('-e, --env <e>', 'Env', 'dev').argument('<name>', 'Name');
@@ -182,6 +204,7 @@ describe('buildCommandManifest — the real solidactions program', () => {
         expect(deploy.options.find((o) => o.long === '--env')!.short).toBe('-e');
         expect(deploy.options.find((o) => o.long === '--create')).toBeDefined();
         expect(deploy.options.find((o) => o.long === '--no-cache')!.negated).toBe(true);
+        expect(deploy.options.find((o) => o.long === '--help')).toBeDefined();
         expect(deploy.arguments.map((a) => a.name)).toEqual(['project-name', 'path']);
 
         expect(findCommand(manifest, 'crew', 'env', 'set')).toBeDefined();

--- a/tests/command-manifest.test.ts
+++ b/tests/command-manifest.test.ts
@@ -1,0 +1,171 @@
+// #1004 PR 0: the walker turns the commander tree into the machine-readable
+// manifest the content repo pins. Real Command objects, no mocks.
+import { describe, expect, it } from 'vitest';
+import { Command, Option } from 'commander';
+import path from 'path';
+import fs from 'fs';
+import { buildCommandManifest, COMMAND_MANIFEST_SCHEMA_VERSION } from '../src/utils/command-manifest';
+
+const CLI_BINARY = path.resolve(__dirname, '../dist/index.js');
+const pkg = require('../package.json');
+
+function findCommand(manifest: ReturnType<typeof buildCommandManifest>, ...segments: string[]) {
+    return manifest.commands.find((c) => c.path.join(' ') === segments.join(' '));
+}
+
+describe('buildCommandManifest — synthetic trees', () => {
+    it('records nouns, verbs, and nesting depth as path arrays', () => {
+        const program = new Command().name('demo');
+        const crew = program.command('crew').description('Manage crews');
+        const crewEnv = crew.command('env').description('Manage crew variables');
+        crewEnv.command('set').description('Set a variable');
+
+        const manifest = buildCommandManifest(program, '9.9.9');
+
+        expect(manifest.schema_version).toBe(COMMAND_MANIFEST_SCHEMA_VERSION);
+        expect(manifest.cli_name).toBe('demo');
+        expect(manifest.cli_version).toBe('9.9.9');
+        expect(findCommand(manifest, 'crew', 'env', 'set')).toBeDefined();
+        expect(findCommand(manifest, 'crew', 'env', 'set')!.description).toBe('Set a variable');
+    });
+
+    it('captures both long and short option forms', () => {
+        const program = new Command().name('demo');
+        program.command('go').option('-e, --env <environment>', 'Environment');
+
+        const opt = findCommand(buildCommandManifest(program, '0.0.0'), 'go')!.options[0];
+
+        expect(opt.long).toBe('--env');
+        expect(opt.short).toBe('-e');
+        expect(opt.flags).toBe('-e, --env <environment>');
+        expect(opt.value_required).toBe(true);
+    });
+
+    it('marks hideHelp options hidden and leaves visible options visible', () => {
+        const program = new Command().name('demo');
+        program
+            .command('login')
+            .addOption(new Option('--host <url>', 'Custom API host URL').hideHelp())
+            .option('--device', 'Device login');
+
+        const options = findCommand(buildCommandManifest(program, '0.0.0'), 'login')!.options;
+
+        expect(options.find((o) => o.long === '--host')!.hidden).toBe(true);
+        expect(options.find((o) => o.long === '--device')!.hidden).toBe(false);
+    });
+
+    it('marks commands declared with { hidden: true } as hidden', () => {
+        const program = new Command().name('demo');
+        const skill = program.command('skill');
+        skill.command('run', { hidden: true }).description('Deprecated alias');
+        skill.command('dev').description('Run a skill');
+
+        const manifest = buildCommandManifest(program, '0.0.0');
+
+        expect(findCommand(manifest, 'skill', 'run')!.hidden).toBe(true);
+        expect(findCommand(manifest, 'skill', 'dev')!.hidden).toBe(false);
+    });
+
+    it('marks requiredOption as required and plain options as not', () => {
+        const program = new Command().name('demo');
+        program.command('exec').requiredOption('--target <target>', 'Where to execute').option('--dry-run', 'Preview');
+
+        const options = findCommand(buildCommandManifest(program, '0.0.0'), 'exec')!.options;
+
+        expect(options.find((o) => o.long === '--target')!.required).toBe(true);
+        expect(options.find((o) => o.long === '--dry-run')!.required).toBe(false);
+    });
+
+    it('records negated boolean options under their --no- spelling', () => {
+        const program = new Command().name('demo');
+        program.command('deploy').option('--no-cache', 'Force a fresh build');
+
+        const opt = findCommand(buildCommandManifest(program, '0.0.0'), 'deploy')!.options[0];
+
+        expect(opt.long).toBe('--no-cache');
+        expect(opt.negated).toBe(true);
+    });
+
+    it('records JSON-safe defaults and omits unserializable ones', () => {
+        const program = new Command().name('demo');
+        program
+            .command('list')
+            .option('-e, --env <environment>', 'Environment', 'dev')
+            .option('--parsed <n>', 'Parsed number', parseInt)
+            .addOption(new Option('--computed <v>', 'Computed').default(() => 1, 'a computed value'));
+
+        const options = findCommand(buildCommandManifest(program, '0.0.0'), 'list')!.options;
+
+        expect(options.find((o) => o.long === '--env')!.default).toBe('dev');
+        expect(options.find((o) => o.long === '--parsed')).toMatchObject({ long: '--parsed' });
+        expect(options.find((o) => o.long === '--parsed')!.default).toBeUndefined();
+        expect(options.find((o) => o.long === '--computed')!.default).toBeUndefined();
+        expect(options.find((o) => o.long === '--computed')!.default_description).toBe('a computed value');
+    });
+
+    it('captures positional arguments from both declaration idioms', () => {
+        const program = new Command().name('demo');
+        program.command('deploy').argument('<project-name>', 'Project name').argument('[path]', 'Source directory');
+        program.command('search <platform> [query]').description('Search');
+        program.command('upload <files...>').description('Upload');
+
+        const manifest = buildCommandManifest(program, '0.0.0');
+
+        expect(findCommand(manifest, 'deploy')!.arguments).toMatchObject([
+            { name: 'project-name', required: true, variadic: false },
+            { name: 'path', required: false, variadic: false },
+        ]);
+        expect(findCommand(manifest, 'search')!.arguments).toMatchObject([
+            { name: 'platform', required: true },
+            { name: 'query', required: false },
+        ]);
+        expect(findCommand(manifest, 'upload')!.arguments).toMatchObject([{ name: 'files', variadic: true }]);
+    });
+
+    it('separates program-level global options from command options', () => {
+        const program = new Command().name('demo');
+        program.option('-w, --workspace-override <id>', 'Override workspace');
+        program.command('go').option('--flag', 'A flag');
+
+        const manifest = buildCommandManifest(program, '0.0.0');
+
+        expect(manifest.global_options.map((o) => o.long)).toEqual(['--workspace-override']);
+        expect(manifest.commands.map((c) => c.path.join(' '))).toEqual(['go']);
+    });
+
+    it('produces output that survives a JSON round-trip unchanged', () => {
+        const program = new Command().name('demo');
+        program.command('go').option('-e, --env <e>', 'Env', 'dev').argument('<name>', 'Name');
+
+        const manifest = buildCommandManifest(program, '0.0.0');
+
+        expect(JSON.parse(JSON.stringify(manifest))).toEqual(manifest);
+    });
+});
+
+describe('buildCommandManifest — the real solidactions program', () => {
+    it('captures the real hidden flags, hidden command, and required option', () => {
+        expect(fs.existsSync(CLI_BINARY)).toBe(true); // CLI not built — run `npm run build` first
+        const { program } = require(CLI_BINARY);
+
+        const manifest = buildCommandManifest(program, pkg.version);
+
+        const login = findCommand(manifest, 'login')!;
+        expect(login.options.find((o) => o.long === '--host')!.hidden).toBe(true);
+        expect(login.options.find((o) => o.long === '--dev')!.hidden).toBe(true);
+        expect(login.options.find((o) => o.long === '--device')!.hidden).toBe(false);
+
+        expect(findCommand(manifest, 'skill', 'run')!.hidden).toBe(true);
+        expect(findCommand(manifest, 'skill', 'exec')!.options.find((o) => o.long === '--target')!.required).toBe(true);
+
+        const deploy = findCommand(manifest, 'project', 'deploy')!;
+        expect(deploy.options.find((o) => o.long === '--env')!.short).toBe('-e');
+        expect(deploy.options.find((o) => o.long === '--create')).toBeDefined();
+        expect(deploy.options.find((o) => o.long === '--no-cache')!.negated).toBe(true);
+        expect(deploy.arguments.map((a) => a.name)).toEqual(['project-name', 'path']);
+
+        expect(findCommand(manifest, 'crew', 'env', 'set')).toBeDefined();
+        expect(manifest.global_options.map((o) => o.long)).toContain('--workspace-override');
+        expect(manifest.cli_name).toBe('solidactions');
+    });
+});

--- a/tests/command-manifest.test.ts
+++ b/tests/command-manifest.test.ts
@@ -133,9 +133,29 @@ describe('buildCommandManifest — synthetic trees', () => {
         expect(manifest.commands.map((c) => c.path.join(' '))).toEqual(['go']);
     });
 
+    it('records a single alias declared with .alias() and an empty array when none is declared', () => {
+        const program = new Command().name('demo');
+        program.command('deploy').alias('d');
+        program.command('go');
+
+        const manifest = buildCommandManifest(program, '0.0.0');
+
+        expect(findCommand(manifest, 'deploy')!.aliases).toEqual(['d']);
+        expect(findCommand(manifest, 'go')!.aliases).toEqual([]);
+    });
+
+    it('records multiple aliases declared with .aliases() in declaration order', () => {
+        const program = new Command().name('demo');
+        program.command('remove').aliases(['rm', 'del']);
+
+        const manifest = buildCommandManifest(program, '0.0.0');
+
+        expect(findCommand(manifest, 'remove')!.aliases).toEqual(['rm', 'del']);
+    });
+
     it('produces output that survives a JSON round-trip unchanged', () => {
         const program = new Command().name('demo');
-        program.command('go').option('-e, --env <e>', 'Env', 'dev').argument('<name>', 'Name');
+        program.command('go').alias('g').option('-e, --env <e>', 'Env', 'dev').argument('<name>', 'Name');
 
         const manifest = buildCommandManifest(program, '0.0.0');
 

--- a/tests/command-manifest.test.ts
+++ b/tests/command-manifest.test.ts
@@ -124,6 +124,10 @@ describe('buildCommandManifest — synthetic trees', () => {
 
     it('separates program-level global options from command options', () => {
         const program = new Command().name('demo');
+        // Disable both commander-synthesized entries so this assertion stays
+        // focused on the global/per-command split; they have their own tests.
+        program.helpOption(false);
+        program.addHelpCommand(false);
         program.option('-w, --workspace-override <id>', 'Override workspace');
         program.command('go').option('--flag', 'A flag');
 
@@ -183,6 +187,61 @@ describe('buildCommandManifest — synthetic trees', () => {
 
         expect(JSON.parse(JSON.stringify(manifest))).toEqual(manifest);
     });
+
+    it('includes the root program help option in global_options', () => {
+        const program = new Command().name('demo');
+        program.command('go');
+
+        const help = buildCommandManifest(program, '0.0.0').global_options.find((o) => o.long === '--help');
+
+        expect(help).toBeDefined();
+        expect(help!.short).toBe('-h');
+        expect(help!.description.length).toBeGreaterThan(0);
+    });
+
+    it('omits the root help option from global_options when disabled with .helpOption(false)', () => {
+        const program = new Command().name('demo');
+        program.helpOption(false);
+        program.command('go');
+
+        const globalOptions = buildCommandManifest(program, '0.0.0').global_options;
+
+        expect(globalOptions.find((o) => o.long === '--help')).toBeUndefined();
+    });
+
+    it('records the implicit help command with a path, description, and empty aliases/options', () => {
+        const program = new Command().name('demo');
+        program.command('go').description('Go somewhere');
+
+        const help = findCommand(buildCommandManifest(program, '0.0.0'), 'help')!;
+
+        expect(help.name).toBe('help');
+        expect(help.aliases).toEqual([]);
+        expect(help.hidden).toBe(false);
+        expect(help.description.length).toBeGreaterThan(0);
+        expect(help.options).toEqual([]);
+        expect(help.arguments).toMatchObject([{ name: 'command', required: false, variadic: false }]);
+    });
+
+    it('omits the implicit help command when disabled with .addHelpCommand(false)', () => {
+        const program = new Command().name('demo');
+        program.addHelpCommand(false);
+        program.command('go');
+
+        const manifest = buildCommandManifest(program, '0.0.0');
+
+        expect(findCommand(manifest, 'help')).toBeUndefined();
+    });
+
+    it('records a nested implicit help command under a subcommand group that has its own children', () => {
+        const program = new Command().name('demo');
+        const project = program.command('project').description('Manage projects');
+        project.command('view').description('View a project');
+
+        const manifest = buildCommandManifest(program, '0.0.0');
+
+        expect(findCommand(manifest, 'project', 'help')).toBeDefined();
+    });
 });
 
 describe('buildCommandManifest — the real solidactions program', () => {
@@ -210,5 +269,14 @@ describe('buildCommandManifest — the real solidactions program', () => {
         expect(findCommand(manifest, 'crew', 'env', 'set')).toBeDefined();
         expect(manifest.global_options.map((o) => o.long)).toContain('--workspace-override');
         expect(manifest.cli_name).toBe('solidactions');
+    });
+
+    it('captures the root --help option and the implicit help command (cleanroom QA regressions)', () => {
+        const { program } = require(CLI_BINARY);
+
+        const manifest = buildCommandManifest(program, pkg.version);
+
+        expect(manifest.global_options.map((o) => o.long)).toContain('--help');
+        expect(findCommand(manifest, 'help')).toBeDefined();
     });
 });

--- a/tests/command-tree-export.test.ts
+++ b/tests/command-tree-export.test.ts
@@ -1,0 +1,34 @@
+// #1004 PR 0: the command tree must be importable so the manifest generator can
+// walk it. Requiring the module must NOT parse argv or exit the process.
+import { describe, expect, it } from 'vitest';
+import path from 'path';
+import fs from 'fs';
+
+const CLI_BINARY = path.resolve(__dirname, '../dist/index.js');
+
+describe('command tree export', () => {
+    it('requires the built CLI without parsing argv or exiting', () => {
+        expect(fs.existsSync(CLI_BINARY)).toBe(true); // CLI not built — run `npm run build` first
+        const mod = require(CLI_BINARY);
+        expect(mod.program).toBeDefined();
+    });
+
+    it('exposes the assembled noun-verb tree', () => {
+        const { program } = require(CLI_BINARY);
+        const nouns = program.commands.map((c: any) => c.name());
+        expect(nouns).toContain('project');
+        expect(nouns).toContain('login');
+        expect(nouns).toContain('skill');
+
+        const project = program.commands.find((c: any) => c.name() === 'project');
+        const verbs = project.commands.map((c: any) => c.name());
+        expect(verbs).toContain('deploy');
+        expect(verbs).toContain('view');
+    });
+
+    it('exposes the program-level global option', () => {
+        const { program } = require(CLI_BINARY);
+        const longs = program.options.map((o: any) => o.long);
+        expect(longs).toContain('--workspace-override');
+    });
+});

--- a/tests/publish-workflow-manifest.test.ts
+++ b/tests/publish-workflow-manifest.test.ts
@@ -1,0 +1,47 @@
+// #1004 PR 0: the release workflow must attach the command manifest as a release
+// asset (the content repo's pinnable artifact), and must build AFTER the tag-derived
+// version rewrite so the manifest carries the released version, not package.json's
+// vestigial one.
+import { describe, expect, it } from 'vitest';
+import path from 'path';
+import fs from 'fs';
+
+const WORKFLOW_PATH = path.resolve(__dirname, '../.github/workflows/publish.yml');
+const workflow = fs.readFileSync(WORKFLOW_PATH, 'utf8');
+
+describe('publish workflow — command manifest release asset', () => {
+    it('grants contents: write so the asset can be uploaded', () => {
+        expect(workflow).toMatch(/contents:\s*write/);
+        expect(workflow).not.toMatch(/contents:\s*read/);
+    });
+
+    it('keeps id-token: write for npm provenance', () => {
+        expect(workflow).toMatch(/id-token:\s*write/);
+    });
+
+    it('uploads dist/command-manifest.json to the release', () => {
+        expect(workflow).toContain('dist/command-manifest.json');
+        expect(workflow).toMatch(/gh release upload/);
+        expect(workflow).toContain('--clobber');
+    });
+
+    it('builds after the tag-derived version rewrite so the manifest carries the released version', () => {
+        const versionRewrite = workflow.indexOf('npm version --no-git-tag-version');
+        const build = workflow.indexOf('npm run build');
+        const publish = workflow.indexOf('npm publish');
+        const upload = workflow.indexOf('gh release upload');
+
+        expect(versionRewrite).toBeGreaterThan(-1);
+        expect(build).toBeGreaterThan(versionRewrite);
+        expect(publish).toBeGreaterThan(build);
+        expect(upload).toBeGreaterThan(publish);
+    });
+
+    it('still asserts the release tag is a literal semver before rewriting the version', () => {
+        const assertion = workflow.indexOf('is not a semver version');
+        const versionRewrite = workflow.indexOf('npm version --no-git-tag-version');
+
+        expect(assertion).toBeGreaterThan(-1);
+        expect(assertion).toBeLessThan(versionRewrite);
+    });
+});

--- a/tests/publish-workflow-manifest.test.ts
+++ b/tests/publish-workflow-manifest.test.ts
@@ -5,18 +5,22 @@
 import { describe, expect, it } from 'vitest';
 import path from 'path';
 import fs from 'fs';
+import yaml from 'js-yaml';
 
 const WORKFLOW_PATH = path.resolve(__dirname, '../.github/workflows/publish.yml');
 const workflow = fs.readFileSync(WORKFLOW_PATH, 'utf8');
+const parsedWorkflow = yaml.load(workflow) as {
+    jobs: { publish: { permissions: Record<string, string> } };
+};
+const permissions = parsedWorkflow.jobs.publish.permissions;
 
 describe('publish workflow — command manifest release asset', () => {
-    it('grants contents: write so the asset can be uploaded', () => {
-        expect(workflow).toMatch(/contents:\s*write/);
-        expect(workflow).not.toMatch(/contents:\s*read/);
+    it('grants contents: write (not read) so the asset can be uploaded', () => {
+        expect(permissions.contents).toBe('write');
     });
 
     it('keeps id-token: write for npm provenance', () => {
-        expect(workflow).toMatch(/id-token:\s*write/);
+        expect(permissions['id-token']).toBe('write');
     });
 
     it('uploads dist/command-manifest.json to the release', () => {
@@ -28,7 +32,9 @@ describe('publish workflow — command manifest release asset', () => {
     it('builds after the tag-derived version rewrite so the manifest carries the released version', () => {
         const versionRewrite = workflow.indexOf('npm version --no-git-tag-version');
         const build = workflow.indexOf('npm run build');
-        const publish = workflow.indexOf('npm publish');
+        // Anchor on the step invocation, not the bare phrase — the restored
+        // #77 comment above the version-rewrite step also mentions "npm publish".
+        const publish = workflow.indexOf('- run: npm publish');
         const upload = workflow.indexOf('gh release upload');
 
         expect(versionRewrite).toBeGreaterThan(-1);

--- a/tests/publish-workflow-manifest.test.ts
+++ b/tests/publish-workflow-manifest.test.ts
@@ -32,15 +32,22 @@ describe('publish workflow — command manifest release asset', () => {
     it('builds after the tag-derived version rewrite so the manifest carries the released version', () => {
         const versionRewrite = workflow.indexOf('npm version --no-git-tag-version');
         const build = workflow.indexOf('npm run build');
-        // Anchor on the step invocation, not the bare phrase — the restored
+        const publishGuard = workflow.indexOf('npm view "@solidactions/cli@$VERSION"');
+        // Anchor on the flagged invocation, not the bare phrase — the restored
         // #77 comment above the version-rewrite step also mentions "npm publish".
-        const publish = workflow.indexOf('- run: npm publish');
+        const publish = workflow.indexOf('npm publish --provenance');
         const upload = workflow.indexOf('gh release upload');
 
         expect(versionRewrite).toBeGreaterThan(-1);
         expect(build).toBeGreaterThan(versionRewrite);
-        expect(publish).toBeGreaterThan(build);
+        expect(publishGuard).toBeGreaterThan(build);
+        expect(publish).toBeGreaterThan(publishGuard);
         expect(upload).toBeGreaterThan(publish);
+    });
+
+    it('guards npm publish with an already-published check so a rerun after a failed upload can proceed', () => {
+        expect(workflow).toContain('npm view "@solidactions/cli@$VERSION" version');
+        expect(workflow).toContain('npm publish --provenance --access public');
     });
 
     it('still asserts the release tag is a literal semver before rewriting the version', () => {


### PR DESCRIPTION
Implements **PR 0** of the #1004 docs-monorepo wave — the first of five, and the one that breaks the circularity: the content repo cannot validate prose against the CLI until the CLI publishes a machine-readable description of its own command surface.

App issue: SolidActions/solidactions-app#1004 · Spec: [`2026-07-31-issue-1004-docs-monorepo.md`](https://github.com/SolidActions/solidactions-app/blob/main/docs/superpowers/specs/2026-07-31-issue-1004-docs-monorepo.md) §Ordering.0 (codex SPEC-APPROVED, round 6)

## Why

User/AI-facing prose is authored in three repos today and drifts from the CLI. The canonical failure was #994: docs kept teaching every AI a `--host` flag that had been deliberately un-advertised. The fix is a single content source whose CI validates prose against the CLI's real command surface — and that requires the CLI to emit that surface as data. This PR does exactly that and nothing else.

## What

`dist/command-manifest.json`, generated from the commander definitions at build time:

- **`src/index.ts`** exports the assembled `program`, and `parseAsync()` is now guarded by `require.main === module` so the tree can be required without consuming the caller's argv. No command, flag, description or help output changed.
- **`src/utils/command-manifest.ts`** — pure walker, `Command` tree → versioned JSON (`schema_version: 1`, following the `skill-cache.ts` precedent). Captures nouns/verbs as path arrays (including the 3-level `crew env set`), long **and** short option forms, `hidden`/`required`/`default` metadata, negated booleans, variadic and positional arguments, choices, and command aliases.
- **`scripts/generate-command-manifest.mjs`** runs after `tsc` in `npm run build`. Emitting into `dist/` means the existing `"files": ["dist"]` publishes it — no packaging change.
- **`.github/workflows/publish.yml`** — `contents: write` and a `gh release upload ... --clobber` step, so each release carries the manifest as a pinnable asset. The build also moved **after** the tag-derived `npm version` rewrite.

66 commands captured. `dist/` stays gitignored — the manifest is a build artifact, never committed.

## Correctness details worth a reviewer's eye

**Hidden surface is recorded, not omitted.** `login --host`/`--dev`, the `--environment` aliases, and the hidden `skill run` command all appear with `hidden: true`. The manifest is a description of what *parses*, not of what `--help` prints — a validator needs both halves to tell "undocumented on purpose" from "does not exist".

**The help option is synthesised.** Commander keeps the automatic `-h, --help` outside `command.options`, so a naive walk omits it — and real prose documents it (`README.md:155`; the app guide's `solidactions login --help`). Left unfixed, the downstream validator would have rejected correct documentation. Caught in live smoke against the packed tarball, not by the unit tests; both a synthetic and a real-program regression test now pin it.

**Build ordering.** The published version comes from the git tag; `package.json`'s committed `version` is vestigial. Building after the version rewrite means the explicitly-built artifact carries the released version without depending on the `prepublishOnly` hook, and skips the build entirely when the semver assertion rejects a tag. (An earlier draft of this change justified the reorder with a claim about `prepublishOnly` that review disproved — the comment in the file now states the real reason.)

## Testing

- 919 tests green via `npm run check:release` (build + full vitest suite + `smoke:init`) — the same command CI runs.
- New: `tests/command-tree-export.test.ts`, `tests/command-manifest.test.ts` (synthetic trees + the real program), `tests/command-manifest-artifact.test.ts` (artifact vs. a fresh walk — the staleness gate), `tests/publish-workflow-manifest.test.ts` (permissions, step order, upload step).
- The pre-existing e2e tests that spawn `dist/index.js` are the regression net for the entry-point guard; all still pass.
- **Live smoke:** packed the tarball, installed it into a scratch prefix, authenticated against a real dev stack and ran `whoami` / `workspace list` / `project list` against real endpoints. Help output is byte-identical to `main`, and the installed package ships the manifest.

## Not in this PR

Wave PRs 1–4 are filed and gated on this one being merged **and released** (the content repo pins a released artifact): content-repo extraction (solidactions-app#1027), CLI content repoint + `--offline` + bootstrap `init` (#1028), app `workflows_guide` renderer (#1029), marketing build-time pull (#1030).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
