### PR TITLE
fix(#1009): EOF-safe, retrying workspace chooser for existing configs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1017,9 +1017,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,6 +1,5 @@
 import fs from 'fs';
 import path from 'path';
-import readline from 'readline';
 import chalk from 'chalk';
 import prompts from 'prompts';
 import {
@@ -20,7 +19,15 @@ import {
     WriteTarget,
     WritePromptDependencies,
 } from '../utils/config-write-target';
-import { fetchWorkspaces, matchWorkspace, WorkspaceLookupRecord, WorkspaceScope } from '../utils/workspace-lookup';
+import {
+    fetchWorkspaces,
+    matchWorkspace,
+    selectWorkspaceInteractively,
+    WorkspaceLookupRecord,
+    WorkspaceScope,
+} from '../utils/workspace-lookup';
+
+export { selectWorkspaceInteractively } from '../utils/workspace-lookup';
 
 export type { Config };
 
@@ -279,74 +286,6 @@ export function loginHostLines(resolved: { host: string; isDefault: boolean }): 
         return [`Logging into ${resolved.host} (SolidActions Cloud)`];
     }
     return [`Host: ${resolved.host}`];
-}
-
-/**
- * Prompt the user to pick a workspace from an already-fetched list. Auto-
- * selects when there's exactly one. Invalid answers re-prompt; EOF or a
- * closed input returns undefined without selecting anything.
- */
-interface WorkspaceSelectionDependencies {
-    question?: () => Promise<string | undefined>;
-}
-
-export async function selectWorkspaceInteractively(
-    workspaces: WorkspaceLookupRecord[],
-    dependencies: WorkspaceSelectionDependencies = {},
-): Promise<WorkspaceLookupRecord | undefined> {
-    if (workspaces.length === 0) {
-        console.log(chalk.yellow('No workspaces found. Create one at your SolidActions dashboard, then run `solidactions workspace set <name>`.'));
-        return undefined;
-    }
-    if (workspaces.length === 1) {
-        console.log(chalk.gray(`Auto-selected workspace: ${workspaces[0].name}`));
-        return workspaces[0];
-    }
-
-    console.log(chalk.blue('\nSelect your default workspace (change anytime with `solidactions workspace set`):\n'));
-    workspaces.forEach((ws, i) => {
-        console.log(`  ${chalk.white(`${i + 1}.`)} ${ws.name}`);
-    });
-    console.log('');
-
-    const rl = dependencies.question
-        ? null
-        : readline.createInterface({ input: process.stdin, output: process.stdout });
-    const question = dependencies.question ?? (async () => {
-        if (!rl || (rl as any).closed) return undefined;
-        return new Promise<string | undefined>((resolve) => {
-            let answered = false;
-            const onClose = () => {
-                if (!answered) resolve(undefined);
-            };
-            rl.once('close', onClose);
-            rl.question(chalk.blue('Enter number: '), (answer) => {
-                answered = true;
-                rl.removeListener('close', onClose);
-                resolve(answer);
-            });
-        });
-    });
-
-    try {
-        while (true) {
-            const answer = await question();
-            if (answer === undefined) {
-                console.log(chalk.yellow(
-                    'Workspace selection cancelled. Run `solidactions workspace list`, then '
-                    + '`solidactions workspace set <name>` when ready.',
-                ));
-                return undefined;
-            }
-            const index = parseInt(answer, 10) - 1;
-            if (!isNaN(index) && index >= 0 && index < workspaces.length) {
-                return workspaces[index];
-            }
-            console.error(chalk.red('Invalid selection. Enter one of the numbers shown.'));
-        }
-    } finally {
-        rl?.close();
-    }
 }
 
 /**

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,8 +1,12 @@
 import axios from 'axios';
 import chalk from 'chalk';
-import readline from 'readline';
 import { Config, ResolvedConfig, resolveConfig, writeConfigFile, getGlobalConfigPath } from './config';
-import { resolveWorkspaceInput } from './workspace-lookup';
+import {
+    resolveWorkspaceInput,
+    selectWorkspaceInteractively,
+    WorkspaceLookupRecord,
+    WorkspaceSelectionDependencies,
+} from './workspace-lookup';
 
 // Backend (solidactions-app PR #128) returns: "Project '<slug>' not found in your active workspace '<workspace-slug>'."
 // We require the literal single-quotes around the slug so plausible future error messages
@@ -242,7 +246,10 @@ export function authFailureMessage(config: Config, sources: ResolvedConfig['sour
     return `Authentication failed against ${config.host} (key from ${keySource}). Run \`solidactions login --global\` to re-configure.`;
 }
 
-export async function ensureWorkspaceSelected(config: Config): Promise<Config> {
+export async function ensureWorkspaceSelected(
+    config: Config,
+    dependencies: WorkspaceSelectionDependencies = {},
+): Promise<Config> {
     if (config.workspaceId) {
         return config;
     }
@@ -296,7 +303,7 @@ export async function ensureWorkspaceSelected(config: Config): Promise<Config> {
         process.exit(1);
     }
 
-    let selected: typeof workspaces[0];
+    let selected: WorkspaceLookupRecord;
 
     if (workspaces.length === 1) {
         selected = workspaces[0];
@@ -310,24 +317,14 @@ export async function ensureWorkspaceSelected(config: Config): Promise<Config> {
             process.exit(1);
         }
 
-        console.log(chalk.blue('\nSelect your default workspace (change anytime with `solidactions workspace set`):\n'));
-        workspaces.forEach((ws, i) => {
-            console.log(`  ${chalk.white(`${i + 1}.`)} ${ws.name} ${chalk.gray(`(${ws.org_name}, ${ws.role})`)}`);
+        const chosen = await selectWorkspaceInteractively(workspaces, {
+            ...dependencies,
+            label: (ws) => `${ws.name} ${chalk.gray(`(${ws.org_name}, ${ws.role})`)}`,
         });
-        console.log('');
-
-        const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-        const answer = await new Promise<string>((resolve) => {
-            rl.question(chalk.blue('Enter number: '), resolve);
-        });
-        rl.close();
-
-        const index = parseInt(answer, 10) - 1;
-        if (isNaN(index) || index < 0 || index >= workspaces.length) {
-            console.error(chalk.red('Invalid selection.'));
+        if (!chosen) {
             process.exit(1);
         }
-        selected = workspaces[index];
+        selected = chosen;
     }
 
     config.workspace = selected.slug ?? selected.name;

--- a/src/utils/workspace-lookup.ts
+++ b/src/utils/workspace-lookup.ts
@@ -1,11 +1,14 @@
 import axios from 'axios';
 import chalk from 'chalk';
+import readline from 'readline';
 import { Config } from './config';
 
 export interface WorkspaceLookupRecord {
     id: string;
     slug?: string;
     name: string;
+    org_name?: string;
+    role?: string;
 }
 
 /** Device-flow token scope, as returned by GET /api/v1/workspaces. Null for user-scoped Sanctum PATs. */
@@ -54,6 +57,77 @@ export async function fetchWorkspaces(config: Config): Promise<FetchWorkspacesRe
     }
     const scope = (response.data.scope as WorkspaceScope | null) ?? null;
     return { workspaces: out, scope };
+}
+
+/**
+ * Prompt the user to pick a workspace from an already-fetched list. Auto-
+ * selects when there's exactly one. Invalid answers re-prompt; EOF or a
+ * closed input returns undefined without selecting anything.
+ */
+export interface WorkspaceSelectionDependencies {
+    question?: () => Promise<string | undefined>;
+    label?: (ws: WorkspaceLookupRecord) => string;
+}
+
+export async function selectWorkspaceInteractively(
+    workspaces: WorkspaceLookupRecord[],
+    dependencies: WorkspaceSelectionDependencies = {},
+): Promise<WorkspaceLookupRecord | undefined> {
+    if (workspaces.length === 0) {
+        console.log(chalk.yellow('No workspaces found. Create one at your SolidActions dashboard, then run `solidactions workspace set <name>`.'));
+        return undefined;
+    }
+    if (workspaces.length === 1) {
+        console.log(chalk.gray(`Auto-selected workspace: ${workspaces[0].name}`));
+        return workspaces[0];
+    }
+
+    const label = dependencies.label ?? ((ws: WorkspaceLookupRecord) => ws.name);
+
+    console.log(chalk.blue('\nSelect your default workspace (change anytime with `solidactions workspace set`):\n'));
+    workspaces.forEach((ws, i) => {
+        console.log(`  ${chalk.white(`${i + 1}.`)} ${label(ws)}`);
+    });
+    console.log('');
+
+    const rl = dependencies.question
+        ? null
+        : readline.createInterface({ input: process.stdin, output: process.stdout });
+    const question = dependencies.question ?? (async () => {
+        if (!rl || (rl as any).closed) return undefined;
+        return new Promise<string | undefined>((resolve) => {
+            let answered = false;
+            const onClose = () => {
+                if (!answered) resolve(undefined);
+            };
+            rl.once('close', onClose);
+            rl.question(chalk.blue('Enter number: '), (answer) => {
+                answered = true;
+                rl.removeListener('close', onClose);
+                resolve(answer);
+            });
+        });
+    });
+
+    try {
+        while (true) {
+            const answer = await question();
+            if (answer === undefined) {
+                console.log(chalk.yellow(
+                    'Workspace selection cancelled. Run `solidactions workspace list`, then '
+                    + '`solidactions workspace set <name>` when ready.',
+                ));
+                return undefined;
+            }
+            const index = parseInt(answer, 10) - 1;
+            if (!isNaN(index) && index >= 0 && index < workspaces.length) {
+                return workspaces[index];
+            }
+            console.error(chalk.red('Invalid selection. Enter one of the numbers shown.'));
+        }
+    } finally {
+        rl?.close();
+    }
 }
 
 /**

--- a/tests/ensure-workspace-selected-interactive.test.ts
+++ b/tests/ensure-workspace-selected-interactive.test.ts
@@ -1,0 +1,111 @@
+import fs from 'fs';
+import http from 'http';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { ensureWorkspaceSelected } from '../src/utils/api';
+import { makeTmpEnv, writeGlobal } from './helpers';
+
+class ProcessExitError extends Error {
+    constructor(public readonly code: number | undefined) {
+        super(`process.exit(${code})`);
+    }
+}
+
+describe('ensureWorkspaceSelected interactive multi-workspace selection', () => {
+    let server: http.Server;
+    let port: number;
+    let workspaceBody: unknown;
+    let env: ReturnType<typeof makeTmpEnv>;
+    let originalExit: typeof process.exit;
+    let originalIsTTY: boolean | undefined;
+    let originalLog: typeof console.log;
+    let logLines: string[];
+
+    beforeAll(async () => {
+        server = http.createServer((_req, res) => {
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify(workspaceBody));
+        });
+        await new Promise<void>((resolve) => {
+            server.listen(0, '127.0.0.1', () => {
+                port = (server.address() as { port: number }).port;
+                resolve();
+            });
+        });
+    });
+
+    afterAll(() => new Promise<void>((resolve, reject) => {
+        server.close((error) => error ? reject(error) : resolve());
+    }));
+
+    beforeEach(() => {
+        env = makeTmpEnv();
+        originalExit = process.exit;
+        (process as any).exit = (code?: number) => { throw new ProcessExitError(code); };
+        originalIsTTY = process.stdin.isTTY;
+        Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
+        originalLog = console.log;
+        logLines = [];
+        console.log = (...args: unknown[]) => { logLines.push(args.map(String).join(' ')); };
+        workspaceBody = {
+            workspaces: {
+                'Acme Org': [
+                    { id: 'ws-1', name: 'First Workspace', slug: 'first-workspace', tenant_name: 'Acme Org', role: 'admin' },
+                    { id: 'ws-2', name: 'Second Workspace', slug: 'second-workspace', tenant_name: 'Acme Org', role: 'member' },
+                ],
+            },
+        };
+    });
+
+    afterEach(() => {
+        (process as any).exit = originalExit;
+        Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true });
+        console.log = originalLog;
+        env.cleanup();
+    });
+
+    it('treats EOF as cancellation, exits 1, and persists no workspace', async () => {
+        const configPath = writeGlobal(env.home, {
+            host: `http://127.0.0.1:${port}`,
+            apiKey: 'existing-token',
+        });
+
+        await expect(
+            ensureWorkspaceSelected(
+                { host: `http://127.0.0.1:${port}`, apiKey: 'existing-token' },
+                { question: async () => undefined },
+            ),
+        ).rejects.toMatchObject({ code: 1 });
+
+        expect(JSON.parse(fs.readFileSync(configPath, 'utf-8')).workspaceId).toBeUndefined();
+    });
+
+    it('re-prompts on invalid input and persists the later valid selection', async () => {
+        const configPath = writeGlobal(env.home, {
+            host: `http://127.0.0.1:${port}`,
+            apiKey: 'existing-token',
+        });
+        const answers = ['banana', '9', '2'];
+
+        const config = await ensureWorkspaceSelected(
+            { host: `http://127.0.0.1:${port}`, apiKey: 'existing-token' },
+            { question: async () => answers.shift() },
+        );
+
+        expect(config.workspaceId).toBe('ws-2');
+        expect(JSON.parse(fs.readFileSync(configPath, 'utf-8')).workspaceId).toBe('ws-2');
+    });
+
+    it('prints the (org_name, role) annotation for each workspace in the numbered list', async () => {
+        writeGlobal(env.home, {
+            host: `http://127.0.0.1:${port}`,
+            apiKey: 'existing-token',
+        });
+
+        await ensureWorkspaceSelected(
+            { host: `http://127.0.0.1:${port}`, apiKey: 'existing-token' },
+            { question: async () => '1' },
+        );
+
+        expect(logLines.some((line) => line.includes('First Workspace') && line.includes('(Acme Org, admin)'))).toBe(true);
+    });
+});


### PR DESCRIPTION
Fixes the CLI half of SolidActions/solidactions-app#1009.

## The bug

`src/utils/api.ts::ensureWorkspaceSelected` — the path an **existing config**
takes when it has an API key but no `workspaceId` — hand-rolled its own readline
prompt for the multi-workspace TTY case:

```ts
const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
const answer = await new Promise<string>((resolve) => {
    rl.question(chalk.blue('Enter number: '), resolve);
});
rl.close();

const index = parseInt(answer, 10) - 1;
if (isNaN(index) || index < 0 || index >= workspaces.length) {
    console.error(chalk.red('Invalid selection.'));
    process.exit(1);
}
```

Two defects:

1. **EOF is unhandled.** No `close` listener, so the promise never settles when
   stdin ends.
2. **One typo is fatal.** Any non-matching answer exits 1 instead of re-prompting.

`login.ts::selectWorkspaceInteractively` already solved both (EOF-safe
`rl.once('close')` cancellation + a re-prompt loop). #1002's sole-workspace work
returned early at cardinality one, so it never reached this branch and the
hardening was never shared with it.

## The fix

Share the hardened selector rather than re-hardening the duplicate:

- **Moved** `selectWorkspaceInteractively` + `WorkspaceSelectionDependencies`
  from `src/commands/login.ts` to `src/utils/workspace-lookup.ts`. `api.ts`
  already imports that module, so this avoids a `utils → commands` import
  inversion. `login.ts` re-exports the name, so its importers and
  `tests/workspace-selection.test.ts` are untouched.
- Added an optional `label?: (ws) => string` to the dependencies so the caller
  owns the per-line rendering. `api.ts` passes its existing
  `(org_name, role)` annotation; `login.ts` passes nothing and its printed
  output is unchanged.
- `ensureWorkspaceSelected`'s multi-workspace TTY branch now calls the shared
  selector and exits 1 on `undefined` (the selector already prints the
  cancellation guidance).
- Optional `dependencies` param on `ensureWorkspaceSelected` for test injection,
  matching login's existing DI style.

Untouched by design: `api.ts`'s own inline `/api/v1/workspaces` fetch (it needs
`org_name`/`role`, which `fetchWorkspaces` drops), the non-TTY branch, and the
zero/one-workspace branches.

## Verification

`npm test` — **932/932 pass**. `npm run build` — clean.

New `tests/ensure-workspace-selected-interactive.test.ts` covers the
existing-config path with multiple workspaces and `isTTY = true`: EOF cancels
without persisting, invalid answers re-prompt then persist the valid pick, and
the `(org_name, role)` annotation is still rendered.

**Live smoke** against a local dev stack, three real workspaces, real pty via
`script`, comparing this branch to base `6c318a0`:

| case | base `6c318a0` | this branch |
|---|---|---|
| Ctrl-D at the prompt | exits **0 silently** — selects nothing, never runs the command | prints `Workspace selection cancelled. Run ...` and exits **1** |
| pty held open, no input | waits (correct — no EOF is ever delivered) | waits (unchanged) |
| `banana` → `9` → `2` | `Invalid selection.` → **exit 1** on the first typo | re-prompts twice, then `Workspace set: Second Workspace`, persists `workspaceId`, and `project list` runs |

**Cleanroom QA:** a context-free agent, given only the goal "find out what
projects exist in your account" and no knowledge that a fix existed, hit the
picker cold and reported: *"list, numbered, one keystroke, re-prompts on bad
input, cancels cleanly"* — the nicest part of the flow. Its five adjacent
findings are filed as SolidActions/solidactions-app#1062-#1066; a sixth
(a "hang" on a pty that never closes) reproduced identically on base and is not
an EOF bug — analysis recorded in `docs/dev-shop-digest.md` under Noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
