### PR TITLE
Add paused schedule deployment controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Use `solidactions <command> --help` for full flag details on any command.
 | Command | Key Flags | Description |
 |---------|-----------|-------------|
 | `project create <name>` | `-e` | Create an empty project (no source/build); `-e` defaults to `production` |
-| `project deploy <name> [path]` | `-e`, `--create`, `--config-only`, `--no-git-metadata` | Deploy or sync config only |
+| `project deploy <name> [path]` | `-e`, `--create`, `--config-only`, `--paused`, `--no-git-metadata` | Deploy or sync config only; optionally land YAML schedules paused |
 | `project view <project>` | `-e` | View status and client-reported deployed revision |
 | `project pull <name> [path]` | `-y` | Pull source (warns before overwriting) |
 | `project logs <name>` | | View build logs |
@@ -205,12 +205,17 @@ which default to dev.
 
 | Command | Key Flags | Description |
 |---------|-----------|-------------|
-| `schedule set <project> <cron>` | `--workflow`, `-i`, `-z`, `-y` | Set cron schedule and optional IANA timezone (warns if exists) |
-| `schedule list <project>` | | List schedules |
-| `schedule delete <project> <id>` | `-y` | Delete a schedule |
+| `schedule set <project> <cron>` | `--workflow`, `-i`, `-z`, `-e`, `--paused`, `-y` | Set cron schedule and optional IANA timezone (warns if exists) |
+| `schedule list <project>` | `-e` | List effective state and operator/YAML disagreement |
+| `schedule enable <project> <id>` | `-e` | Enable a schedule with a sticky override |
+| `schedule disable <project> <id>` | `-e` | Disable a schedule with a sticky override |
+| `schedule reset <project> <id>` | `-e` | Return a schedule to its last declared YAML state |
+| `schedule delete <project> <id>` | `-e`, `-y` | Delete a schedule |
 
 ```bash
 solidactions schedule set my-project '0 9 * * 1-5' --workflow daily-summary --timezone America/Chicago
+solidactions project deploy my-project -e production --paused
+solidactions schedule enable my-project 42 -e production
 ```
 
 ### webhook

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -739,8 +739,14 @@ export async function deploy(projectName: string, sourcePath?: string, options: 
 
                         if (options.paused) {
                             console.log('');
-                            console.log(chalk.green('Schedules deployed paused.'));
-                            console.log(chalk.gray(`Enable one when ready with: solidactions schedule enable ${projectSlug} <schedule-id>`));
+                            if (acceptedDeployment.schedulesPaused === true) {
+                                console.log(chalk.green('Schedules deployed paused.'));
+                                console.log(chalk.gray(`Enable one when ready with: solidactions schedule enable ${projectSlug} <schedule-id>`));
+                            } else {
+                                console.log(chalk.yellow(
+                                    'Warning: server did not acknowledge paused schedules; verify schedules before relying on them being paused.',
+                                ));
+                            }
                         }
 
                         cleanupArchive();

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -140,6 +140,7 @@ interface DeployOptions {
     configOnly?: boolean;
     noCache?: boolean;
     gitMetadata?: boolean;
+    paused?: boolean;
 }
 
 export function projectStatusUrl(host: string, projectSlug: string): string {
@@ -638,6 +639,9 @@ export async function deploy(projectName: string, sourcePath?: string, options: 
 
         try {
             const form = buildDeployForm(archivePath, sourceMetadata);
+            if (options.paused) {
+                form.append('paused', '1');
+            }
 
             console.log(chalk.yellow('Uploading...'));
             if (process.env.SOLIDACTIONS_DEPLOY_DEBUG === '1') {
@@ -731,6 +735,12 @@ export async function deploy(projectName: string, sourcePath?: string, options: 
                             console.log('');
                             console.log(chalk.blue(`ℹ  Webhook secret: run \`solidactions webhook secret ${projectName}${envFlag}\` to retrieve the generated secret.`));
                             console.log(chalk.gray(`   Set the same value in your sender (e.g. Telegram setWebhook secret_token).`));
+                        }
+
+                        if (options.paused) {
+                            console.log('');
+                            console.log(chalk.green('Schedules deployed paused.'));
+                            console.log(chalk.gray(`Enable one when ready with: solidactions schedule enable ${projectSlug} <schedule-id>`));
                         }
 
                         cleanupArchive();

--- a/src/commands/schedule-delete.ts
+++ b/src/commands/schedule-delete.ts
@@ -2,15 +2,24 @@ import axios from 'axios';
 import chalk from 'chalk';
 import prompts from 'prompts';
 import { getApiHeaders, requireConfigWithWorkspace } from '../utils/api';
+import { projectSlugForView } from './project-view';
 
-export async function scheduleDelete(projectName: string, scheduleId: string, options: { yes?: boolean } = {}) {
+export async function scheduleDelete(projectName: string, scheduleId: string, options: { yes?: boolean; env?: string } = {}) {
     const config = await requireConfigWithWorkspace();
+    let projectSlug: string;
+    try {
+        projectSlug = projectSlugForView(projectName, options.env);
+    } catch (error: any) {
+        console.error(chalk.red(error.message));
+        process.exit(1);
+        return;
+    }
 
     console.log(chalk.blue(`Deleting schedule ${scheduleId} from project "${projectName}"...`));
 
     try {
         // First, get the schedule details for confirmation
-        const listResponse = await axios.get(`${config.host}/api/v1/projects/${projectName}/schedules`, {
+        const listResponse = await axios.get(`${config.host}/api/v1/projects/${projectSlug}/schedules`, {
             headers: getApiHeaders(config),
         });
 
@@ -38,7 +47,7 @@ export async function scheduleDelete(projectName: string, scheduleId: string, op
         }
 
         // Delete the schedule
-        await axios.delete(`${config.host}/api/v1/projects/${projectName}/schedules/${scheduleId}`, {
+        await axios.delete(`${config.host}/api/v1/projects/${projectSlug}/schedules/${scheduleId}`, {
             headers: getApiHeaders(config),
         });
 

--- a/src/commands/schedule-list.ts
+++ b/src/commands/schedule-list.ts
@@ -1,14 +1,42 @@
 import axios from 'axios';
 import chalk from 'chalk';
 import { getApiHeaders, requireConfigWithWorkspace } from '../utils/api';
+import { projectSlugForView } from './project-view';
 
-export async function scheduleList(projectName: string) {
+export interface ScheduleListItem {
+    enabled: boolean;
+    enabled_override?: boolean;
+    yaml_enabled?: boolean | null;
+}
+
+export function formatScheduleState(schedule: ScheduleListItem): string {
+    const effective = schedule.enabled ? 'yes' : 'no';
+    if (!schedule.enabled_override) {
+        return effective;
+    }
+    if (schedule.yaml_enabled !== null
+        && schedule.yaml_enabled !== undefined
+        && schedule.yaml_enabled !== schedule.enabled) {
+        return `${effective} (override; last declared YAML: ${schedule.yaml_enabled ? 'yes' : 'no'})`;
+    }
+    return `${effective} (override)`;
+}
+
+export async function scheduleList(projectName: string, options: { env?: string } = {}) {
     const config = await requireConfigWithWorkspace();
+    let projectSlug: string;
+    try {
+        projectSlug = projectSlugForView(projectName, options.env);
+    } catch (error: any) {
+        console.error(chalk.red(error.message));
+        process.exit(1);
+        return;
+    }
 
     console.log(chalk.blue(`Schedules for project "${projectName}":`));
 
     try {
-        const response = await axios.get(`${config.host}/api/v1/projects/${projectName}/schedules`, {
+        const response = await axios.get(`${config.host}/api/v1/projects/${projectSlug}/schedules`, {
             headers: getApiHeaders(config),
         });
 
@@ -20,8 +48,8 @@ export async function scheduleList(projectName: string) {
         }
 
         console.log('');
-        console.log(chalk.gray('ID'.padEnd(8) + 'WORKFLOW'.padEnd(25) + 'CRON'.padEnd(18) + 'TIMEZONE'.padEnd(20) + 'ENABLED'.padEnd(10) + 'NEXT RUN'));
-        console.log(chalk.gray('-'.repeat(105)));
+        console.log(chalk.gray('ID'.padEnd(8) + 'WORKFLOW'.padEnd(25) + 'CRON'.padEnd(18) + 'TIMEZONE'.padEnd(20) + 'ENABLED'.padEnd(48) + 'NEXT RUN'));
+        console.log(chalk.gray('-'.repeat(143)));
 
         for (const schedule of schedules) {
             const id = schedule.id?.toString() || '?';
@@ -29,6 +57,7 @@ export async function scheduleList(projectName: string) {
             const cron = schedule.cron_expression || '?';
             const timezone = schedule.timezone || 'UTC';
             const enabled = schedule.enabled;
+            const enabledState = formatScheduleState(schedule);
             const nextRun = schedule.next_run_at ? formatRelativeTime(schedule.next_run_at) : '-';
 
             const enabledColor = enabled ? chalk.green : chalk.red;
@@ -38,7 +67,7 @@ export async function scheduleList(projectName: string) {
                 workflow.padEnd(25) +
                 chalk.cyan(cron.padEnd(18)) +
                 chalk.gray(timezone.padEnd(20)) +
-                enabledColor((enabled ? 'yes' : 'no').padEnd(10)) +
+                enabledColor(enabledState.padEnd(48)) +
                 chalk.gray(nextRun)
             );
         }

--- a/src/commands/schedule-set.ts
+++ b/src/commands/schedule-set.ts
@@ -2,10 +2,20 @@ import axios from 'axios';
 import chalk from 'chalk';
 import prompts from 'prompts';
 import { getApiHeaders, requireConfigWithWorkspace } from '../utils/api';
+import { projectSlugForView } from './project-view';
+
+export interface ScheduleSetOptions {
+    workflow?: string;
+    input?: string;
+    timezone?: string;
+    yes?: boolean;
+    paused?: boolean;
+    env?: string;
+}
 
 export function buildSchedulePayload(
     cron: string,
-    options: { workflow?: string; input?: string; timezone?: string },
+    options: Pick<ScheduleSetOptions, 'workflow' | 'input' | 'timezone' | 'paused'>,
     inputData?: Record<string, any>,
 ): Record<string, any> {
     const payload: Record<string, any> = { cron };
@@ -17,6 +27,9 @@ export function buildSchedulePayload(
     }
     if (options.timezone) {
         payload.timezone = options.timezone;
+    }
+    if (options.paused) {
+        payload.enabled = false;
     }
     return payload;
 }
@@ -39,8 +52,16 @@ export const EXISTING_SCHEDULE_CHOICES = [
     { title: 'Cancel', value: 'cancel' },
 ];
 
-export async function scheduleSet(projectName: string, cron: string, options: { workflow?: string; input?: string; timezone?: string; yes?: boolean }) {
+export async function scheduleSet(projectName: string, cron: string, options: ScheduleSetOptions) {
     const config = await requireConfigWithWorkspace();
+    let projectSlug: string;
+    try {
+        projectSlug = projectSlugForView(projectName, options.env);
+    } catch (error: any) {
+        console.error(chalk.red(error.message));
+        process.exit(1);
+        return;
+    }
 
     // Parse input JSON if provided
     let inputData: Record<string, any> | undefined;
@@ -56,7 +77,7 @@ export async function scheduleSet(projectName: string, cron: string, options: { 
     // Check for existing schedule on the same workflow
     if (!options.yes) {
         try {
-            const listResponse = await axios.get(`${config.host}/api/v1/projects/${projectName}/schedules`, {
+            const listResponse = await axios.get(`${config.host}/api/v1/projects/${projectSlug}/schedules`, {
                 headers: getApiHeaders(config),
             });
             const schedules = listResponse.data.data || listResponse.data || [];
@@ -94,7 +115,7 @@ export async function scheduleSet(projectName: string, cron: string, options: { 
     try {
         const payload = buildSchedulePayload(cron, options, inputData);
 
-        const response = await axios.post(`${config.host}/api/v1/projects/${projectName}/schedules`, payload, {
+        const response = await axios.post(`${config.host}/api/v1/projects/${projectSlug}/schedules`, payload, {
             headers: getApiHeaders(config, 'application/json'),
         });
 
@@ -119,6 +140,9 @@ export async function scheduleSet(projectName: string, cron: string, options: { 
         }
         if (inputData) {
             console.log(chalk.gray(`  Input: ${JSON.stringify(inputData)}`));
+        }
+        if (options.paused) {
+            console.log(chalk.gray('  Enabled: no (sticky override; survives redeploy)'));
         }
     } catch (error: any) {
         if (error.response) {

--- a/src/commands/schedule-state.ts
+++ b/src/commands/schedule-state.ts
@@ -1,0 +1,95 @@
+import axios from 'axios';
+import chalk from 'chalk';
+import { getApiHeaders, requireConfigWithWorkspace } from '../utils/api';
+import { projectSlugForView } from './project-view';
+
+export interface ScheduleStateOptions {
+    env?: string;
+}
+
+type ScheduleTarget = 'enable' | 'disable';
+
+function renderScheduleStateError(error: any, projectName: string, scheduleId: string): never {
+    if (error.response) {
+        if (error.response.status === 401) {
+            console.error(chalk.red('Authentication failed. Run "solidactions login --global" to re-configure.'));
+        } else if (error.response.status === 404) {
+            console.error(chalk.red(error.response.data?.message ?? `Project "${projectName}" or schedule ${scheduleId} not found.`));
+        } else if (error.response.status === 422) {
+            console.error(chalk.red(error.response.data?.message ?? 'Validation error.'));
+        } else {
+            console.error(chalk.red(`Failed: ${error.response.status}`), error.response.data?.message ?? error.response.data);
+        }
+    } else {
+        console.error(chalk.red('Connection failed:'), error.message);
+    }
+    process.exit(1);
+}
+
+function resolveProjectSlug(projectName: string, options: ScheduleStateOptions): string {
+    try {
+        return projectSlugForView(projectName, options.env);
+    } catch (error: any) {
+        console.error(chalk.red(error.message));
+        process.exit(1);
+    }
+}
+
+async function setScheduleTarget(
+    projectName: string,
+    scheduleId: string,
+    target: ScheduleTarget,
+    options: ScheduleStateOptions = {},
+): Promise<void> {
+    const config = await requireConfigWithWorkspace();
+    const projectSlug = resolveProjectSlug(projectName, options);
+    const enabled = target === 'enable';
+
+    try {
+        await axios.patch(
+            `${config.host}/api/v1/projects/${encodeURIComponent(projectSlug)}/schedules/${encodeURIComponent(scheduleId)}`,
+            { enabled },
+            { headers: getApiHeaders(config, 'application/json') },
+        );
+        console.log(chalk.green(`Schedule ${scheduleId} ${enabled ? 'enabled' : 'disabled'}.`));
+        console.log(chalk.gray('This is a sticky override and survives redeploy until changed or reset.'));
+    } catch (error: any) {
+        renderScheduleStateError(error, projectName, scheduleId);
+    }
+}
+
+export async function scheduleEnable(
+    projectName: string,
+    scheduleId: string,
+    options: ScheduleStateOptions = {},
+): Promise<void> {
+    await setScheduleTarget(projectName, scheduleId, 'enable', options);
+}
+
+export async function scheduleDisable(
+    projectName: string,
+    scheduleId: string,
+    options: ScheduleStateOptions = {},
+): Promise<void> {
+    await setScheduleTarget(projectName, scheduleId, 'disable', options);
+}
+
+export async function scheduleReset(
+    projectName: string,
+    scheduleId: string,
+    options: ScheduleStateOptions = {},
+): Promise<void> {
+    const config = await requireConfigWithWorkspace();
+    const projectSlug = resolveProjectSlug(projectName, options);
+
+    try {
+        await axios.post(
+            `${config.host}/api/v1/projects/${encodeURIComponent(projectSlug)}/schedules/${encodeURIComponent(scheduleId)}/reset`,
+            {},
+            { headers: getApiHeaders(config, 'application/json') },
+        );
+        console.log(chalk.green(`Schedule ${scheduleId} reset. YAML controls this schedule again.`));
+    } catch (error: any) {
+        renderScheduleStateError(error, projectName, scheduleId);
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import { envSet } from './commands/env-set';
 import { scheduleSet } from './commands/schedule-set';
 import { scheduleList } from './commands/schedule-list';
 import { scheduleDelete } from './commands/schedule-delete';
+import { scheduleDisable, scheduleEnable, scheduleReset } from './commands/schedule-state';
 import { webhookList } from './commands/webhook-list';
 import { webhookSecret } from './commands/webhook-secret';
 import { dev } from './commands/dev';
@@ -215,6 +216,7 @@ project
     .option('-e, --env <environment>', 'Target environment (production/staging/dev). Required on first deploy of a new project.')
     .option('--create', 'Create environment project if it doesn\'t exist')
     .option('--config-only', 'Sync YAML env declarations without building/deploying')
+    .option('--paused', 'Deploy with all YAML-declared schedules initially paused')
     .option('--no-cache', 'Force a fresh build, bypassing all build caches')
     .option('--force-rebuild', 'Force a fresh build, bypassing all build caches (alias for --no-cache)')
     .option(
@@ -464,6 +466,8 @@ schedule
     .option('--workflow <name>', 'Workflow name (if project has multiple)')
     .option('-i, --input <json>', 'JSON input to pass to scheduled runs')
     .option('-z, --timezone <iana>', 'IANA timezone the cron is evaluated in (e.g. America/Chicago); defaults to UTC')
+    .option('-e, --env <environment>', 'Resolve an explicit environment (production/staging/dev)')
+    .option('--paused', 'Create or replace the schedule disabled')
     .option('-y, --yes', 'Skip confirmation if schedule already exists')
     .action((projectName, cron, options) => {
         scheduleSet(projectName, cron, options);
@@ -473,8 +477,39 @@ schedule
     .command('list')
     .description('List schedules for a project')
     .argument('<project>', 'Project name')
-    .action((projectName) => {
-        scheduleList(projectName);
+    .option('-e, --env <environment>', 'Resolve an explicit environment (production/staging/dev)')
+    .action((projectName, options) => {
+        scheduleList(projectName, options);
+    });
+
+schedule
+    .command('enable')
+    .description('Enable a schedule with a sticky operator override')
+    .argument('<project>', 'Project name')
+    .argument('<schedule-id>', 'Schedule ID')
+    .option('-e, --env <environment>', 'Resolve an explicit environment (production/staging/dev)')
+    .action((projectName, scheduleId, options) => {
+        scheduleEnable(projectName, scheduleId, options);
+    });
+
+schedule
+    .command('disable')
+    .description('Disable a schedule with a sticky operator override')
+    .argument('<project>', 'Project name')
+    .argument('<schedule-id>', 'Schedule ID')
+    .option('-e, --env <environment>', 'Resolve an explicit environment (production/staging/dev)')
+    .action((projectName, scheduleId, options) => {
+        scheduleDisable(projectName, scheduleId, options);
+    });
+
+schedule
+    .command('reset')
+    .description('Return a schedule to its last declared YAML configuration')
+    .argument('<project>', 'Project name')
+    .argument('<schedule-id>', 'Schedule ID')
+    .option('-e, --env <environment>', 'Resolve an explicit environment (production/staging/dev)')
+    .action((projectName, scheduleId, options) => {
+        scheduleReset(projectName, scheduleId, options);
     });
 
 schedule
@@ -482,6 +517,7 @@ schedule
     .description('Delete a schedule')
     .argument('<project>', 'Project name')
     .argument('<schedule-id>', 'Schedule ID')
+    .option('-e, --env <environment>', 'Resolve an explicit environment (production/staging/dev)')
     .option('-y, --yes', 'Skip confirmation prompt')
     .action((projectName, scheduleId, options) => {
         scheduleDelete(projectName, scheduleId, options);

--- a/src/utils/source-provenance.ts
+++ b/src/utils/source-provenance.ts
@@ -27,6 +27,7 @@ export interface DeployAcceptance {
     deploymentId: string | null;
     sourceMetadata: SourceMetadata | null;
     sourceMetadataRejected: string | null;
+    schedulesPaused: boolean | null;
 }
 
 type Environment = Record<string, string | undefined>;
@@ -314,5 +315,8 @@ export function parseDeployAcceptance(data: unknown): DeployAcceptance {
         deploymentId: nullableString(body.deployment_id),
         sourceMetadata,
         sourceMetadataRejected: nullableString(body.source_metadata_rejected),
+        schedulesPaused: typeof body.schedules_paused === 'boolean'
+            ? body.schedules_paused
+            : null,
     };
 }

--- a/tests/command-tree-export.test.ts
+++ b/tests/command-tree-export.test.ts
@@ -24,6 +24,16 @@ describe('command tree export', () => {
         const verbs = project.commands.map((c: any) => c.name());
         expect(verbs).toContain('deploy');
         expect(verbs).toContain('view');
+
+        const schedule = program.commands.find((c: any) => c.name() === 'schedule');
+        const scheduleVerbs = schedule.commands.map((c: any) => c.name());
+        expect(scheduleVerbs).toEqual(expect.arrayContaining(['set', 'list', 'enable', 'disable', 'reset', 'delete']));
+
+        const deploy = project.commands.find((c: any) => c.name() === 'deploy');
+        expect(deploy.options.map((o: any) => o.long)).toContain('--paused');
+
+        const scheduleSet = schedule.commands.find((c: any) => c.name() === 'set');
+        expect(scheduleSet.options.map((o: any) => o.long)).toContain('--paused');
     });
 
     it('exposes the program-level global option', () => {

--- a/tests/deploy-live-wiring.test.ts
+++ b/tests/deploy-live-wiring.test.ts
@@ -54,6 +54,7 @@ let deployRequests: Array<{ body: string }> = [];
 let confirmationCallCount = 0;
 let mismatchesBeforeMatch = 0;
 let projectStatus = 'deployed';
+let acceptedSchedulesPaused: boolean | undefined = true;
 
 function confirmationBody(): unknown {
     return {
@@ -88,8 +89,13 @@ beforeAll(async () => {
 
             if (req.method === 'POST' && url.endsWith('/deploy')) {
                 deployRequests.push({ body });
-                res.writeHead(200, { 'Content-Type': 'application/json' });
-                res.end(JSON.stringify({ deployment_id: 'dep-1' }));
+                res.writeHead(202, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({
+                    deployment_id: 'dep-1',
+                    ...(acceptedSchedulesPaused === undefined
+                        ? {}
+                        : { schedules_paused: acceptedSchedulesPaused }),
+                }));
                 return;
             }
             if (req.method === 'GET' && url.includes('include=deployment')) {
@@ -133,6 +139,7 @@ beforeEach(() => {
     confirmationCallCount = 0;
     mismatchesBeforeMatch = 0;
     projectStatus = 'deployed';
+    acceptedSchedulesPaused = true;
     process.env.SOLIDACTIONS_HOST = `http://127.0.0.1:${port}`;
     process.env.SOLIDACTIONS_API_KEY = 'test-key';
     process.env.SOLIDACTIONS_WORKSPACE_ID = 'workspace-1';
@@ -202,6 +209,23 @@ describe('deploy() live wiring — paused schedules', () => {
         expect(logs.join('\n')).toContain('solidactions schedule enable');
         expect(logs.findIndex((line) => line.includes('Schedules deployed paused')))
             .toBeGreaterThan(logs.findIndex((line) => line.includes('Deployed to')));
+    }, 10_000);
+
+    it('warns instead of claiming schedules are paused when the server does not acknowledge the flag', async () => {
+        acceptedSchedulesPaused = undefined;
+        const logs: string[] = [];
+        const originalLog = console.log;
+        console.log = (...args: unknown[]) => { logs.push(args.map(String).join(' ')); };
+        try {
+            await runDeploy({ paused: true });
+        } finally {
+            console.log = originalLog;
+        }
+
+        const output = logs.join('\n');
+        expect(output).not.toContain('Schedules deployed paused');
+        expect(output).toContain('server did not acknowledge paused schedules');
+        expect(output).toContain('verify schedules');
     }, 10_000);
 
     it('omits paused from ordinary deploys', async () => {

--- a/tests/deploy-live-wiring.test.ts
+++ b/tests/deploy-live-wiring.test.ts
@@ -53,6 +53,7 @@ let port: number;
 let deployRequests: Array<{ body: string }> = [];
 let confirmationCallCount = 0;
 let mismatchesBeforeMatch = 0;
+let projectStatus = 'deployed';
 
 function confirmationBody(): unknown {
     return {
@@ -104,7 +105,7 @@ beforeAll(async () => {
                 // Shared by the pre-deploy existence check and every poll tick —
                 // only the poll reads `status`; the existence check reads `slug`.
                 res.writeHead(200, { 'Content-Type': 'application/json' });
-                res.end(JSON.stringify({ slug: PROJECT_NAME, status: 'deployed' }));
+                res.end(JSON.stringify({ slug: PROJECT_NAME, status: projectStatus }));
                 return;
             }
             res.writeHead(200, { 'Content-Type': 'application/json' });
@@ -131,6 +132,7 @@ beforeEach(() => {
     sourceDirs = [];
     confirmationCallCount = 0;
     mismatchesBeforeMatch = 0;
+    projectStatus = 'deployed';
     process.env.SOLIDACTIONS_HOST = `http://127.0.0.1:${port}`;
     process.env.SOLIDACTIONS_API_KEY = 'test-key';
     process.env.SOLIDACTIONS_WORKSPACE_ID = 'workspace-1';
@@ -154,7 +156,7 @@ afterEach(() => {
  * deploy-plan-limit.test.ts's header comment). So completion must be
  * observed via the eventual process.exit() call, not via awaiting deploy().
  */
-async function runDeploy(options: { gitMetadata?: boolean } = {}): Promise<void> {
+async function runDeploy(options: { gitMetadata?: boolean; paused?: boolean } = {}): Promise<void> {
     const dir = makeSourceDir();
     sourceDirs.push(dir);
 
@@ -180,6 +182,52 @@ describe('deploy() live wiring — source provenance', () => {
 
         expect(deployRequests).toHaveLength(1);
         expect(deployRequests[0].body).not.toContain('name="source_metadata"');
+    }, 10_000);
+});
+
+describe('deploy() live wiring — paused schedules', () => {
+    it('sends the exact multipart paused=1 field and reports the pause only after deployed', async () => {
+        const logs: string[] = [];
+        const originalLog = console.log;
+        console.log = (...args: unknown[]) => { logs.push(args.map(String).join(' ')); };
+        try {
+            await runDeploy({ paused: true });
+        } finally {
+            console.log = originalLog;
+        }
+
+        expect(deployRequests).toHaveLength(1);
+        expect(deployRequests[0].body).toMatch(/name="paused"\r\n\r\n1\r\n/);
+        expect(logs.join('\n')).toContain('Schedules deployed paused');
+        expect(logs.join('\n')).toContain('solidactions schedule enable');
+        expect(logs.findIndex((line) => line.includes('Schedules deployed paused')))
+            .toBeGreaterThan(logs.findIndex((line) => line.includes('Deployed to')));
+    }, 10_000);
+
+    it('omits paused from ordinary deploys', async () => {
+        await runDeploy();
+
+        expect(deployRequests).toHaveLength(1);
+        expect(deployRequests[0].body).not.toContain('name="paused"');
+    }, 10_000);
+
+    it('never prints paused success copy when the build fails', async () => {
+        projectStatus = 'error';
+        const logs: string[] = [];
+        const errors: string[] = [];
+        const originalLog = console.log;
+        const originalError = console.error;
+        console.log = (...args: unknown[]) => { logs.push(args.map(String).join(' ')); };
+        console.error = (...args: unknown[]) => { errors.push(args.map(String).join(' ')); };
+        try {
+            await runDeploy({ paused: true });
+        } finally {
+            console.log = originalLog;
+            console.error = originalError;
+        }
+
+        expect(errors.join('\n')).toContain('Build Failed');
+        expect(logs.join('\n')).not.toContain('Schedules deployed paused');
     }, 10_000);
 });
 

--- a/tests/schedule-list-state.test.ts
+++ b/tests/schedule-list-state.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { formatScheduleState } from '../src/commands/schedule-list';
+
+describe('schedule list enabled-state detail', () => {
+    it('marks an operator override and shows effective/YAML values when they disagree', () => {
+        expect(formatScheduleState({ enabled: false, enabled_override: true, yaml_enabled: true }))
+            .toBe('no (override; last declared YAML: yes)');
+        expect(formatScheduleState({ enabled: true, enabled_override: true, yaml_enabled: false }))
+            .toBe('yes (override; last declared YAML: no)');
+    });
+
+    it('marks a matching override without redundant YAML state', () => {
+        expect(formatScheduleState({ enabled: false, enabled_override: true, yaml_enabled: false }))
+            .toBe('no (override)');
+    });
+
+    it('keeps declarative and ad-hoc state compact', () => {
+        expect(formatScheduleState({ enabled: true, enabled_override: false, yaml_enabled: true })).toBe('yes');
+        expect(formatScheduleState({ enabled: false, enabled_override: false, yaml_enabled: null })).toBe('no');
+    });
+});

--- a/tests/schedule-state-controls.test.ts
+++ b/tests/schedule-state-controls.test.ts
@@ -1,0 +1,163 @@
+import * as http from 'http';
+import { AddressInfo } from 'net';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { scheduleDisable, scheduleEnable, scheduleReset } from '../src/commands/schedule-state';
+import { scheduleSet } from '../src/commands/schedule-set';
+
+type RequestRecord = {
+    method: string;
+    url: string;
+    body: string;
+    authorization?: string;
+    accept?: string;
+    contentType?: string;
+    workspace?: string;
+};
+
+let server: http.Server;
+let port: number;
+let requests: RequestRecord[] = [];
+let responseStatus = 200;
+let responseBody: Record<string, unknown> = {};
+
+beforeAll(async () => {
+    server = http.createServer((req, res) => {
+        const chunks: Buffer[] = [];
+        req.on('data', (chunk: Buffer) => chunks.push(chunk));
+        req.on('end', () => {
+            requests.push({
+                method: req.method ?? '',
+                url: req.url ?? '',
+                body: Buffer.concat(chunks).toString('utf8'),
+                authorization: req.headers.authorization,
+                accept: req.headers.accept,
+                contentType: req.headers['content-type'],
+                workspace: req.headers['x-workspace-id'] as string | undefined,
+            });
+            res.writeHead(responseStatus, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify(responseBody));
+        });
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    port = (server.address() as AddressInfo).port;
+});
+
+afterAll(() => new Promise<void>((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve());
+}));
+
+beforeEach(() => {
+    requests = [];
+    responseStatus = 200;
+    responseBody = { schedule: { id: 42, enabled: true } };
+    process.env.SOLIDACTIONS_HOST = `http://127.0.0.1:${port}`;
+    process.env.SOLIDACTIONS_API_KEY = 'test-key';
+    process.env.SOLIDACTIONS_WORKSPACE_ID = 'workspace-1';
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.SOLIDACTIONS_HOST;
+    delete process.env.SOLIDACTIONS_API_KEY;
+    delete process.env.SOLIDACTIONS_WORKSPACE_ID;
+});
+
+describe('schedule target-state commands', () => {
+    it('enables idempotently with the exact API path, JSON body, and auth/workspace headers', async () => {
+        const logs: string[] = [];
+        vi.spyOn(console, 'log').mockImplementation((...args) => { logs.push(args.map(String).join(' ')); });
+
+        await scheduleEnable('billing', '42');
+        await scheduleEnable('billing', '42');
+
+        expect(requests).toHaveLength(2);
+        for (const request of requests) {
+            expect(request).toMatchObject({
+                method: 'PATCH',
+                url: '/api/v1/projects/billing/schedules/42',
+                body: JSON.stringify({ enabled: true }),
+                authorization: 'Bearer test-key',
+                accept: 'application/json',
+                contentType: 'application/json',
+                workspace: 'workspace-1',
+            });
+        }
+        expect(logs.join('\n')).toContain('sticky override');
+        expect(logs.join('\n')).toContain('survives redeploy');
+    });
+
+    it('disables with an explicit false target and resolves an explicit environment slug', async () => {
+        responseBody = { schedule: { id: 42, enabled: false } };
+
+        await scheduleDisable('billing', '42', { env: 'dev' });
+
+        expect(requests).toHaveLength(1);
+        expect(requests[0]).toMatchObject({
+            method: 'PATCH',
+            url: '/api/v1/projects/billing-dev/schedules/42',
+            body: JSON.stringify({ enabled: false }),
+        });
+    });
+
+    it('resets through the exact POST endpoint and explains that YAML controls the schedule again', async () => {
+        const logs: string[] = [];
+        vi.spyOn(console, 'log').mockImplementation((...args) => { logs.push(args.map(String).join(' ')); });
+        responseBody = { schedule: { id: 42, enabled: true, enabled_override: false, yaml_enabled: true } };
+
+        await scheduleReset('billing', '42', { env: 'production' });
+
+        expect(requests).toHaveLength(1);
+        expect(requests[0]).toMatchObject({
+            method: 'POST',
+            url: '/api/v1/projects/billing/schedules/42/reset',
+            body: JSON.stringify({}),
+            authorization: 'Bearer test-key',
+            accept: 'application/json',
+            contentType: 'application/json',
+            workspace: 'workspace-1',
+        });
+        expect(logs.join('\n')).toContain('YAML controls this schedule again');
+    });
+
+    it('exits nonzero and renders the API message on a rejected reset', async () => {
+        responseStatus = 422;
+        responseBody = { message: 'This schedule has no YAML declaration to reset to.' };
+        const errors: string[] = [];
+        vi.spyOn(console, 'error').mockImplementation((...args) => { errors.push(args.map(String).join(' ')); });
+        const exit = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+            throw new Error(`exit:${code}`);
+        }) as never);
+
+        await expect(scheduleReset('billing', '42')).rejects.toThrow('exit:1');
+
+        expect(exit).toHaveBeenCalledWith(1);
+        expect(errors.join('\n')).toContain('This schedule has no YAML declaration to reset to.');
+    });
+});
+
+describe('schedule set paused wire contract', () => {
+    it('sends enabled=false only when --paused is present', async () => {
+        responseBody = { schedule: { id: 42, enabled: false } };
+
+        await scheduleSet('billing', '* * * * *', { yes: true, paused: true, env: 'dev' });
+
+        expect(requests).toHaveLength(1);
+        expect(requests[0]).toMatchObject({
+            method: 'POST',
+            url: '/api/v1/projects/billing-dev/schedules',
+            body: JSON.stringify({ cron: '* * * * *', enabled: false }),
+            authorization: 'Bearer test-key',
+            accept: 'application/json',
+            contentType: 'application/json',
+            workspace: 'workspace-1',
+        });
+
+        requests = [];
+        responseBody = { schedule: { id: 42, enabled: false } };
+        await scheduleSet('billing', '* * * * *', { yes: true });
+
+        expect(requests).toHaveLength(1);
+        expect(JSON.parse(requests[0].body)).toEqual({ cron: '* * * * *' });
+        expect(JSON.parse(requests[0].body)).not.toHaveProperty('enabled');
+    });
+});

--- a/tests/schedule-timezone.test.ts
+++ b/tests/schedule-timezone.test.ts
@@ -8,6 +8,12 @@ describe('buildSchedulePayload', () => {
         expect(buildSchedulePayload('0 7 * * 1', {})).toEqual({ cron: '0 7 * * 1' });
     });
 
+    it('sends an explicit disabled target only for --paused', () => {
+        expect(buildSchedulePayload('0 7 * * 1', { paused: true })).toEqual({ cron: '0 7 * * 1', enabled: false });
+        expect(buildSchedulePayload('0 7 * * 1', { paused: false })).toEqual({ cron: '0 7 * * 1' });
+        expect(buildSchedulePayload('0 7 * * 1', {})).toEqual({ cron: '0 7 * * 1' });
+    });
+
     it('keeps workflow and input alongside timezone', () => {
         expect(buildSchedulePayload('0 7 * * 1', { workflow: 'report', timezone: 'UTC' }, { mode: 'weekly' }))
             .toEqual({ cron: '0 7 * * 1', workflow: 'report', input: { mode: 'weekly' }, timezone: 'UTC' });

--- a/tests/source-provenance.test.ts
+++ b/tests/source-provenance.test.ts
@@ -403,16 +403,19 @@ describe('deploy provenance transport', () => {
             deployment_id: 'deployment-123',
             source_metadata: metadata,
             source_metadata_rejected: 'invalid_commit_sha',
+            schedules_paused: true,
         })).toEqual({
             deploymentId: 'deployment-123',
             sourceMetadata: metadata,
             sourceMetadataRejected: 'invalid_commit_sha',
+            schedulesPaused: true,
         });
 
         expect(parseDeployAcceptance({ message: 'queued' })).toEqual({
             deploymentId: null,
             sourceMetadata: null,
             sourceMetadataRejected: null,
+            schedulesPaused: null,
         });
     });
 });


### PR DESCRIPTION
Companion CLI implementation for SolidActions/solidactions-app#970.\n\nAdds project deploy --paused, schedule set --paused, schedule enable/disable/reset, environment-aware schedule targeting, and effective-vs-YAML state rendering.\n\nVerification: npm run build; 944 CLI tests passing.