### PR TITLE
feat: add project and workflow state controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,16 +170,33 @@ Use `solidactions <command> --help` for full flag details on any command.
 |---------|-----------|-------------|
 | `project create <name>` | `-e` | Create an empty project (no source/build); `-e` defaults to `production` |
 | `project deploy <name> [path]` | `-e`, `--create`, `--config-only`, `--no-git-metadata` | Deploy or sync config only |
-| `project view <project>` | `-e` | View status and client-reported deployed revision |
+| `project enable <project>` | `-e` (default `dev`) | Allow new starts through this project gate |
+| `project disable <project>` | `-e` (default `dev`) | Block new root starts without cancelling existing roots |
+| `project view <project>` | `-e` | View status, `Enabled: on|off`, and client-reported deployed revision |
 | `project pull <name> [path]` | `-y` | Pull source (warns before overwriting) |
 | `project logs <name>` | | View build logs |
-| `project list` | | List all projects |
+| `project list` | `--json` | List project families; environments render as `environment:on/off` |
 
 For `project view`, omitting `--env` treats `<project>` as an exact slug.
 Passing `--env production` uses the supplied production name/slug unchanged;
 `--env staging` and `--env dev` derive the same suffixed slug as deploy. This
 is deliberately different from historical commands such as `run start`,
 which default to dev.
+
+Project enable/disable is an explicit, non-interactive operator action. It does
+not cascade to workflows or schedules, and deploy does not undo the manual
+state.
+
+### workflow
+
+| Command | Key Flags | Description |
+|---------|-----------|-------------|
+| `workflow enable <project> <workflow>` | `-e` (default `dev`) | Enable the workflow gate; direct starts still require the project, and scheduled starts also require the schedule |
+| `workflow disable <project> <workflow>` | `-e` (default `dev`) | Block new root starts without cancelling existing roots |
+
+Workflow enable/disable accepts a workflow name or slug and does not prompt.
+The manual state is sticky across deploys; enabling a workflow does not enable
+its project or schedule.
 
 ### run
 
@@ -217,7 +234,7 @@ solidactions schedule set my-project '0 9 * * 1-5' --workflow daily-summary --ti
 
 | Command | Key Flags | Description |
 |---------|-----------|-------------|
-| `webhook list <project>` | `-e`, `--show-secrets` | List webhook URLs |
+| `webhook list <project>` | `-e`, `--format table|json`, `--show-secrets` | List webhook URLs and state: `retired`, `off`, `blocked (project off)`, or `on` |
 
 ### skill
 

--- a/docs/decisions/0001-cli-command-taxonomy.md
+++ b/docs/decisions/0001-cli-command-taxonomy.md
@@ -18,6 +18,10 @@
 6. **Verb canon = `view`** for "show one"; migrate `oauth-actions show` → `view`. *(Executed in #84 — see the conformance table below.)*
 7. **Hot-path promotion** to bare top-level is limited to unambiguous actions (`deploy`, `dev`); `push`/`pull`/`list` stay noun-scoped.
 8. **Verbs come in families; each noun declares its family** — file-sync (`push`/`pull`), content-CRUD (`create`/`edit`/`delete`/`list`/`view`), execution-lifecycle (`start`/`invoke`/…), KV-upsert (`set`, e.g. `env`). "Full CRUD" is not "bolt create/edit/delete onto everything."
+9. **Activation-lifecycle uses `enable` / `disable`.** These verbs gate whether
+   an executable resource admits new work without deleting its configuration.
+   They are distinct from content CRUD and from execution-lifecycle verbs that
+   start or invoke one individual run.
 
 ### Deferred
 

--- a/src/commands/project-list.ts
+++ b/src/commands/project-list.ts
@@ -1,10 +1,33 @@
 import axios from 'axios';
 import chalk from 'chalk';
 import { getApiHeaders, requireConfigWithWorkspace } from '../utils/api';
-import { renderTable } from '../utils/table';
+import { renderTable, sanitizeCell, truncateCell } from '../utils/table';
 
 interface ProjectListOptions {
     json?: boolean;
+}
+
+interface EnvironmentDetail {
+    environment: string;
+    slug: string;
+    enabled: boolean;
+}
+
+function projectEnvironments(project: any): string {
+    const details: EnvironmentDetail[] | undefined = project.environment_details;
+    if (Array.isArray(details) && details.length > 0) {
+        return details
+            .map((detail) => `${detail.environment}:${detail.enabled ? 'on' : 'off'}`)
+            .join(', ');
+    }
+
+    return (project.environments || [project.environment || 'production']).join(', ');
+}
+
+function colorizeEnvironmentStates(value: string): string {
+    return value.replace(/\b(on|off)\b/g, (state) => (
+        state === 'on' ? chalk.green(state) : chalk.red(state)
+    ));
 }
 
 export async function projectList(options: ProjectListOptions = {}) {
@@ -31,18 +54,29 @@ export async function projectList(options: ProjectListOptions = {}) {
             return;
         }
 
-        const rows = projects.map((project: any) => {
-            const envs = (project.environments || [project.environment || 'production']).join(', ');
-            return [project.name || '?', project.status || '?', project.snapshot_name || '-', envs];
-        });
+        // Reconstruction below colorizes only the final ENVIRONMENTS cell. Use
+        // the renderer's exact sanitized/truncated value so adding ANSI color
+        // can never reintroduce discarded content or corrupt prefix slicing.
+        const environmentCells = projects.map((project: any) => (
+            truncateCell(sanitizeCell(projectEnvironments(project)))
+        ));
+        const rows = projects.map((project: any, index: number) => [
+            project.name || '?',
+            project.status || '?',
+            project.snapshot_name || '-',
+            environmentCells[index],
+        ]);
 
         const lines = renderTable(['NAME', 'STATUS', 'SNAPSHOT', 'ENVIRONMENTS'], rows, {
             minWidths: [25, 15, 30],
         });
         console.log(chalk.gray(lines[0]));
         console.log(chalk.gray(lines[1]));
-        for (const line of lines.slice(2)) {
-            console.log(line);
+        for (let index = 0; index < projects.length; index++) {
+            const line = lines[index + 2];
+            const environmentCell = environmentCells[index];
+            const prefix = line.slice(0, line.length - environmentCell.length);
+            console.log(prefix + colorizeEnvironmentStates(environmentCell));
         }
 
         console.log('');

--- a/src/commands/project-view.ts
+++ b/src/commands/project-view.ts
@@ -30,6 +30,7 @@ export interface ProjectDeploymentDetail {
     slug?: string;
     name?: string;
     status?: string;
+    enabled?: boolean;
     deployed_hash?: string | null;
     deployment_matches_deployed_hash?: boolean;
     latest_successful_deployment?: DeploymentDetail | null;
@@ -117,6 +118,9 @@ export function formatProjectView(project: ProjectDeploymentDetail): string[] {
     const slug = sanitizeDisplayText(project.slug ?? project.name, 255) ?? 'unknown';
     const status = sanitizeDisplayText(project.status, 64) ?? 'unknown';
     const lines = [`Project: ${slug}`, `Status: ${status}`];
+    if (typeof project.enabled === 'boolean') {
+        lines.push(`Enabled: ${project.enabled ? 'on' : 'off'}`);
+    }
     const deployment = project.latest_successful_deployment ?? null;
 
     if (!project.deployed_hash && !deployment) {

--- a/src/commands/state.ts
+++ b/src/commands/state.ts
@@ -1,0 +1,179 @@
+import axios from 'axios';
+import chalk from 'chalk';
+import { formatValidationError, getApiHeaders, requireConfigWithWorkspace } from '../utils/api';
+import type { Config } from '../utils/config';
+import { buildProjectSlug } from '../utils/slug';
+
+export type StateEnvironment = 'production' | 'staging' | 'dev';
+
+export interface StateCommandOptions {
+    env?: string;
+}
+
+type StateTarget =
+    | { type: 'project'; project: string }
+    | { type: 'workflow'; project: string; workflow: string };
+
+const STATE_ENVIRONMENTS: StateEnvironment[] = ['production', 'staging', 'dev'];
+
+export function resolveStateEnvironment(environment?: string): StateEnvironment {
+    const resolved = environment ?? 'dev';
+    if (!STATE_ENVIRONMENTS.includes(resolved as StateEnvironment)) {
+        throw new Error('Environment must be production, staging, or dev.');
+    }
+
+    return resolved as StateEnvironment;
+}
+
+export function projectSlugForState(project: string, environment: StateEnvironment): string {
+    const slug = buildProjectSlug(project, environment);
+    if (!slug || slug === `-${environment}`) {
+        throw new Error('Project must contain at least one letter or number.');
+    }
+
+    return slug;
+}
+
+function stateUrl(config: Config, target: StateTarget, environment: StateEnvironment): string {
+    const projectSlug = encodeURIComponent(projectSlugForState(target.project, environment));
+    const base = `${config.host}/api/v1/projects/${projectSlug}`;
+
+    if (target.type === 'workflow') {
+        return `${base}/workflows/${encodeURIComponent(target.workflow)}/enabled`;
+    }
+
+    return `${base}/enabled`;
+}
+
+function inverseVerb(enabled: boolean): 'enable' | 'disable' {
+    return enabled ? 'disable' : 'enable';
+}
+
+function printDisableResult(target: StateTarget, environment: StateEnvironment): void {
+    if (target.type === 'workflow') {
+        console.log(chalk.green(`Workflow "${target.workflow}" in project "${target.project}" (${environment}) disabled.`));
+    } else {
+        console.log(chalk.green(`Project "${target.project}" (${environment}) disabled.`));
+    }
+
+    console.log('New root starts are blocked through CLI/API, schedules, webhooks, MCP, manual dead-letter retry, and manual rerun paths.');
+    console.log('Already-created roots continue, including their queued work, automatic retries, child legs, sleeping/signal-waiting phases, and running work.');
+    console.log('Deploy will not undo this manual state.');
+}
+
+function printEnableResult(target: StateTarget, environment: StateEnvironment): void {
+    if (target.type === 'workflow') {
+        console.log(chalk.green(`Workflow "${target.workflow}" in project "${target.project}" (${environment}) enabled.`));
+        console.log('Direct starts require an enabled parent project.');
+        console.log('Scheduled starts additionally require an enabled schedule.');
+        console.log('Enabling this workflow does not enable its project or schedule.');
+    } else {
+        console.log(chalk.green(`Project "${target.project}" (${environment}) enabled.`));
+        console.log('Direct starts require an enabled target workflow.');
+        console.log('Scheduled starts additionally require an enabled schedule.');
+        console.log('Enabling this project does not enable its workflows or schedules.');
+    }
+
+    console.log('Deploy will not undo this manual state.');
+}
+
+function printInverseCommand(target: StateTarget, environment: StateEnvironment, enabled: boolean): void {
+    const verb = inverseVerb(enabled);
+    const command = target.type === 'workflow'
+        ? `solidactions workflow ${verb} ${target.project} ${target.workflow} --env ${environment}`
+        : `solidactions project ${verb} ${target.project} --env ${environment}`;
+
+    console.log(chalk.gray(`Undo: ${command}`));
+}
+
+function errorMessage(error: any, target: StateTarget): string {
+    if (!error.response) {
+        return `Connection failed: ${error.message}`;
+    }
+
+    if (error.response.status === 401) {
+        return 'Authentication failed. Run "solidactions login --global" to re-configure.';
+    }
+
+    if (error.response.status === 422) {
+        return formatValidationError(error.response.data);
+    }
+
+    const serverMessage = error.response.data?.message;
+    if (typeof serverMessage === 'string' && serverMessage.trim() !== '') {
+        return serverMessage;
+    }
+
+    if (error.response.status === 404) {
+        return target.type === 'workflow'
+            ? `Project or workflow "${target.workflow}" not found.`
+            : `Project "${target.project}" not found.`;
+    }
+
+    return `Failed to update state: ${error.response.status}`;
+}
+
+export async function setStateWithConfig(
+    target: StateTarget,
+    enabled: boolean,
+    options: StateCommandOptions,
+    config: Config,
+): Promise<void> {
+    let environment: StateEnvironment;
+    let url: string;
+    try {
+        environment = resolveStateEnvironment(options.env);
+        url = stateUrl(config, target, environment);
+    } catch (error: any) {
+        console.error(chalk.red(error.message));
+        process.exit(1);
+        return;
+    }
+
+    try {
+        await axios.put(
+            url,
+            { enabled },
+            { headers: getApiHeaders(config, 'application/json') },
+        );
+
+        if (enabled) {
+            printEnableResult(target, environment);
+        } else {
+            printDisableResult(target, environment);
+        }
+        printInverseCommand(target, environment, enabled);
+    } catch (error: any) {
+        console.error(chalk.red(errorMessage(error, target)));
+        process.exit(1);
+    }
+}
+
+async function setState(target: StateTarget, enabled: boolean, options: StateCommandOptions): Promise<void> {
+    const config = await requireConfigWithWorkspace();
+    await setStateWithConfig(target, enabled, options, config);
+}
+
+export async function projectEnable(project: string, options: StateCommandOptions = {}): Promise<void> {
+    await setState({ type: 'project', project }, true, options);
+}
+
+export async function projectDisable(project: string, options: StateCommandOptions = {}): Promise<void> {
+    await setState({ type: 'project', project }, false, options);
+}
+
+export async function workflowEnable(
+    project: string,
+    workflow: string,
+    options: StateCommandOptions = {},
+): Promise<void> {
+    await setState({ type: 'workflow', project, workflow }, true, options);
+}
+
+export async function workflowDisable(
+    project: string,
+    workflow: string,
+    options: StateCommandOptions = {},
+): Promise<void> {
+    await setState({ type: 'workflow', project, workflow }, false, options);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,12 @@ import { crewEnvSet } from './commands/crew-env-set';
 import { crewEnvList } from './commands/crew-env-list';
 import { crewEnvDelete } from './commands/crew-env-delete';
 import { crewEnvPush } from './commands/crew-env-push';
+import {
+    projectDisable,
+    projectEnable,
+    workflowDisable,
+    workflowEnable,
+} from './commands/state';
 import { setCliWorkspaceOverride } from './utils/config';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -255,6 +261,50 @@ project
     .option('--json', 'Output as JSON')
     .action((options) => {
         projectList(options);
+    });
+
+project
+    .command('enable')
+    .description('Allow new workflow starts for a project environment')
+    .argument('<project>', 'Project name')
+    .option('-e, --env <environment>', 'Environment (production/staging/dev). Defaults to dev.', 'dev')
+    .action(async (projectName, options) => {
+        await projectEnable(projectName, options);
+    });
+
+project
+    .command('disable')
+    .description('Block new workflow starts for a project environment')
+    .argument('<project>', 'Project name')
+    .option('-e, --env <environment>', 'Environment (production/staging/dev). Defaults to dev.', 'dev')
+    .action(async (projectName, options) => {
+        await projectDisable(projectName, options);
+    });
+
+// =============================================================================
+// workflow <subcommand>
+// =============================================================================
+
+const workflow = program.command('workflow').description('Manage deployed workflows');
+
+workflow
+    .command('enable')
+    .description('Allow new starts for a deployed workflow')
+    .argument('<project>', 'Project name')
+    .argument('<workflow>', 'Workflow name or slug')
+    .option('-e, --env <environment>', 'Environment (production/staging/dev). Defaults to dev.', 'dev')
+    .action(async (projectName, workflowName, options) => {
+        await workflowEnable(projectName, workflowName, options);
+    });
+
+workflow
+    .command('disable')
+    .description('Block new starts for a deployed workflow')
+    .argument('<project>', 'Project name')
+    .argument('<workflow>', 'Workflow name or slug')
+    .option('-e, --env <environment>', 'Environment (production/staging/dev). Defaults to dev.', 'dev')
+    .action(async (projectName, workflowName, options) => {
+        await workflowDisable(projectName, workflowName, options);
     });
 
 // =============================================================================

--- a/src/utils/webhook-formatters.ts
+++ b/src/utils/webhook-formatters.ts
@@ -7,6 +7,10 @@ export interface WebhookRow {
     webhook_path_url?: string;
     webhook_url?: string;
     webhook_secret?: string;
+    enabled?: boolean;
+    project_enabled?: boolean;
+    retired?: boolean;
+    effective_enabled?: boolean;
 }
 
 export interface FormatOptions {
@@ -17,18 +21,39 @@ function columnWidth(min: number, values: string[]): number {
     return Math.max(min, ...values.map(v => v.length)) + 2;
 }
 
+export type WebhookState = 'retired' | 'off' | 'blocked (project off)' | 'on';
+
+export function webhookState(webhook: WebhookRow): WebhookState {
+    if (webhook.retired === true) return 'retired';
+    if (webhook.enabled === false) return 'off';
+    if (webhook.project_enabled === false) return 'blocked (project off)';
+    return 'on';
+}
+
+function colorizeState(state: WebhookState, width: number): string {
+    const padded = state.padEnd(width);
+    if (state === 'on') return chalk.green(padded);
+    if (state === 'off') return chalk.red(padded);
+    if (state === 'blocked (project off)') return chalk.yellow(padded);
+    return chalk.gray(padded);
+}
+
 export function formatTable(webhooks: WebhookRow[], opts: FormatOptions): string[] {
     const names = webhooks.map(w => w.workflow_name || w.workflow_slug || '?');
+    const states = webhooks.map(webhookState);
     const urls = webhooks.map(w => w.webhook_path_url || w.webhook_url || '?');
 
     const nameWidth = columnWidth(30, names);
+    const stateWidth = columnWidth(22, states);
     const urlWidth = columnWidth(60, urls);
 
     const headerPlain = opts.showSecrets
-        ? 'WORKFLOW'.padEnd(nameWidth) + 'URL'.padEnd(urlWidth) + 'SECRET'
-        : 'WORKFLOW'.padEnd(nameWidth) + 'URL';
+        ? 'WORKFLOW'.padEnd(nameWidth) + 'STATE'.padEnd(stateWidth) + 'URL'.padEnd(urlWidth) + 'SECRET'
+        : 'WORKFLOW'.padEnd(nameWidth) + 'STATE'.padEnd(stateWidth) + 'URL';
 
-    const dividerWidth = opts.showSecrets ? nameWidth + urlWidth + 64 : nameWidth + urlWidth;
+    const dividerWidth = opts.showSecrets
+        ? nameWidth + stateWidth + urlWidth + 64
+        : nameWidth + stateWidth + urlWidth;
 
     const lines: string[] = [];
     lines.push(chalk.gray(headerPlain));
@@ -36,8 +61,11 @@ export function formatTable(webhooks: WebhookRow[], opts: FormatOptions): string
 
     for (let i = 0; i < webhooks.length; i++) {
         const name = names[i];
+        const state = states[i];
         const url = urls[i];
-        let line = name.padEnd(nameWidth) + chalk.cyan(url.padEnd(urlWidth));
+        let line = name.padEnd(nameWidth)
+            + colorizeState(state, stateWidth)
+            + chalk.cyan(url.padEnd(urlWidth));
         if (opts.showSecrets) {
             const secret = webhooks[i].webhook_secret || '-';
             line += chalk.gray(secret);
@@ -50,9 +78,23 @@ export function formatTable(webhooks: WebhookRow[], opts: FormatOptions): string
 
 export function formatJson(webhooks: WebhookRow[], opts: FormatOptions): string {
     const rows = webhooks.map(w => {
-        const base: { workflow: string | null; url: string | null; secret?: string } = {
+        const base: {
+            workflow: string | null;
+            url: string | null;
+            state: WebhookState;
+            enabled?: boolean;
+            project_enabled?: boolean;
+            retired?: boolean;
+            effective_enabled?: boolean;
+            secret?: string;
+        } = {
             workflow: w.workflow_name ?? w.workflow_slug ?? null,
             url: w.webhook_path_url ?? w.webhook_url ?? null,
+            state: webhookState(w),
+            enabled: w.enabled,
+            project_enabled: w.project_enabled,
+            retired: w.retired,
+            effective_enabled: w.effective_enabled,
         };
         if (opts.showSecrets) {
             base.secret = w.webhook_secret ?? '';

--- a/tests/output-polish.test.ts
+++ b/tests/output-polish.test.ts
@@ -76,14 +76,75 @@ describe('project list / env list --json', () => {
         env.cleanup();
     });
 
-    it('project list --json prints the raw project array, not the table', async () => {
-        nextBody = { data: [{ name: 'demo', status: 'ready', slug: 'demo' }] };
+    it('project list --json passes through compatibility environments and environment details', async () => {
+        nextBody = {
+            data: [{
+                name: 'demo',
+                status: 'ready',
+                slug: 'demo',
+                environments: ['production', 'dev'],
+                environment_details: [
+                    { environment: 'production', slug: 'demo', enabled: true },
+                    { environment: 'dev', slug: 'demo-dev', enabled: false },
+                ],
+            }],
+        };
 
         await projectList({ json: true });
 
         const parsed = JSON.parse(logLines.join('\n'));
-        expect(parsed).toEqual([{ name: 'demo', status: 'ready', slug: 'demo' }]);
+        expect(parsed).toEqual((nextBody as any).data);
         expect(logLines.some((l) => l.includes('Projects:'))).toBe(false);
+    });
+
+    it('project list renders environment details as environment:on/off and preserves legacy fallback rows', async () => {
+        nextBody = {
+            data: [
+                {
+                    name: 'stateful',
+                    status: 'ready',
+                    environments: ['production', 'staging', 'dev'],
+                    environment_details: [
+                        { environment: 'production', slug: 'stateful', enabled: true },
+                        { environment: 'staging', slug: 'stateful-staging', enabled: false },
+                        { environment: 'dev', slug: 'stateful-dev', enabled: true },
+                    ],
+                },
+                {
+                    name: 'legacy',
+                    status: 'ready',
+                    environments: ['production', 'dev'],
+                },
+            ],
+        };
+
+        await projectList({});
+
+        const output = logLines.join('\n');
+        expect(output).toContain('production:on, staging:off, dev:on');
+        expect(output).toMatch(/legacy.*production, dev/);
+    });
+
+    it('project list colors the exact sanitized and truncated environment cell', async () => {
+        nextBody = {
+            data: [{
+                name: 'bounded-row',
+                status: 'ready',
+                environment_details: [{
+                    environment: `${'x'.repeat(80)}\ninjected-tail`,
+                    slug: 'bounded-row',
+                    enabled: true,
+                }],
+            }],
+        };
+
+        await projectList({});
+
+        const dataLine = logLines.find((line) => line.includes('bounded-row'));
+        expect(dataLine).toBeDefined();
+        expect(dataLine).not.toContain('\n');
+        expect(dataLine).toContain('…');
+        expect(dataLine).not.toContain('injected-tail');
     });
 
     it('project list prints "Projects:" only after a successful fetch, not before an auth failure', async () => {

--- a/tests/project-view.test.ts
+++ b/tests/project-view.test.ts
@@ -84,6 +84,14 @@ describe('project slug resolution for view', () => {
 });
 
 describe('project view request and rendering', () => {
+    it('renders enabled state immediately after deployment status', () => {
+        const enabled = formatProjectView({ slug: 'billing', status: 'deployed', enabled: true } as any);
+        const disabled = formatProjectView({ slug: 'billing', status: 'deployed', enabled: false } as any);
+
+        expect(enabled.slice(0, 3)).toEqual(['Project: billing', 'Status: deployed', 'Enabled: on']);
+        expect(disabled.slice(0, 3)).toEqual(['Project: billing', 'Status: deployed', 'Enabled: off']);
+    });
+
     it('requests the exact slug with the bounded deployment include', async () => {
         const lines: string[] = [];
         await projectViewWithConfig('billing-dev', {}, config(), (line) => lines.push(line));

--- a/tests/readme-contract.test.ts
+++ b/tests/readme-contract.test.ts
@@ -4,6 +4,10 @@ import { describe, expect, it } from 'vitest';
 import { SOLIDACTIONS_SKILL_NAMES } from '../src/utils/skills';
 
 const README = fs.readFileSync(path.resolve(__dirname, '../README.md'), 'utf8');
+const COMMAND_TAXONOMY = fs.readFileSync(
+    path.resolve(__dirname, '../docs/decisions/0001-cli-command-taxonomy.md'),
+    'utf8',
+);
 
 describe('public README setup contract', () => {
     it('uses the secret-safe current login, deploy, and run commands', () => {
@@ -28,5 +32,18 @@ describe('public README setup contract', () => {
         for (const skillName of SOLIDACTIONS_SKILL_NAMES) {
             expect(README).toContain(`\`${skillName}\``);
         }
+    });
+
+    it('documents activation lifecycle commands and state visibility', () => {
+        expect(README).toContain('project enable <project>');
+        expect(README).toContain('project disable <project>');
+        expect(README).toContain('workflow enable <project> <workflow>');
+        expect(README).toContain('workflow disable <project> <workflow>');
+        expect(README).toContain('environment:on/off');
+        expect(README).toContain('Enabled: on|off');
+        expect(README).toContain('blocked (project off)');
+
+        expect(COMMAND_TAXONOMY).toMatch(/activation-lifecycle/i);
+        expect(COMMAND_TAXONOMY).toMatch(/`enable`\s*\/\s*`disable`/);
     });
 });

--- a/tests/state-commands.test.ts
+++ b/tests/state-commands.test.ts
@@ -1,0 +1,324 @@
+/**
+ * Contract tests for project/workflow enable and disable.
+ *
+ * The real built CLI talks to an in-process HTTP server and reads a real
+ * temporary config, so registration, argument parsing, request shape, output,
+ * and exit status are covered together without mocks.
+ */
+import * as childProcess from 'child_process';
+import * as fs from 'fs';
+import * as http from 'http';
+import * as os from 'os';
+import * as path from 'path';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { writeGlobal } from './helpers';
+
+const CLI_BINARY = path.resolve(__dirname, '../dist/index.js');
+
+interface CapturedRequest {
+    method: string | undefined;
+    url: string | undefined;
+    headers: http.IncomingHttpHeaders;
+    body: unknown;
+}
+
+interface QueuedResponse {
+    status: number;
+    body: object;
+}
+
+let server: http.Server;
+let port: number;
+let requests: CapturedRequest[] = [];
+let responses: QueuedResponse[] = [];
+let temporaryRoots: string[] = [];
+
+beforeAll(async () => {
+    server = http.createServer((request, response) => {
+        let rawBody = '';
+        request.on('data', (chunk) => { rawBody += chunk; });
+        request.on('end', () => {
+            const body = rawBody ? JSON.parse(rawBody) : null;
+            requests.push({
+                method: request.method,
+                url: request.url,
+                headers: request.headers,
+                body,
+            });
+
+            const queued = responses.shift();
+            if (queued) {
+                response.writeHead(queued.status, { 'Content-Type': 'application/json' });
+                response.end(JSON.stringify(queued.body));
+                return;
+            }
+
+            const enabled = (body as { enabled?: boolean } | null)?.enabled === true;
+            const workflowMatch = request.url?.match(/\/workflows\/([^/]+)\/enabled$/);
+            response.writeHead(200, { 'Content-Type': 'application/json' });
+            response.end(JSON.stringify({
+                data: workflowMatch
+                    ? {
+                        type: 'workflow',
+                        name: decodeURIComponent(workflowMatch[1]),
+                        slug: decodeURIComponent(workflowMatch[1]),
+                        enabled,
+                        project_name: 'billing',
+                        project_slug: request.url?.split('/projects/')[1]?.split('/')[0],
+                        environment: request.url?.includes('-staging/')
+                            ? 'staging'
+                            : request.url?.includes('-dev/') ? 'dev' : 'production',
+                    }
+                    : {
+                        type: 'project',
+                        name: 'billing',
+                        slug: request.url?.split('/projects/')[1]?.split('/')[0],
+                        enabled,
+                        environment: request.url?.includes('-staging/')
+                            ? 'staging'
+                            : request.url?.includes('-dev/') ? 'dev' : 'production',
+                    },
+            }));
+        });
+    });
+
+    await new Promise<void>((resolve) => {
+        server.listen(0, '127.0.0.1', () => {
+            port = (server.address() as { port: number }).port;
+            resolve();
+        });
+    });
+});
+
+afterAll(() => new Promise<void>((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve());
+}));
+
+beforeEach(() => {
+    requests = [];
+    responses = [];
+});
+
+afterEach(() => {
+    for (const root of temporaryRoots) {
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+    temporaryRoots = [];
+});
+
+function configuredHome(): string {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'sa-cli-state-'));
+    const home = path.join(root, 'home');
+    fs.mkdirSync(home, { recursive: true });
+    writeGlobal(home, {
+        host: `http://127.0.0.1:${port}`,
+        apiKey: 'state-test-key',
+        workspaceId: 'workspace-state-1',
+    });
+    temporaryRoots.push(root);
+    return home;
+}
+
+interface CliResult {
+    stdout: string;
+    stderr: string;
+    status: number | null;
+}
+
+function runCli(args: string[], home = configuredHome()): Promise<CliResult> {
+    return new Promise((resolve, reject) => {
+        const environment: NodeJS.ProcessEnv = { ...process.env, HOME: home };
+        delete environment.SOLIDACTIONS_HOST;
+        delete environment.SOLIDACTIONS_API_KEY;
+        delete environment.SOLIDACTIONS_WORKSPACE_ID;
+
+        const child = childProcess.spawn(process.execPath, [CLI_BINARY, ...args], {
+            env: environment,
+        });
+        let stdout = '';
+        let stderr = '';
+        child.stdout.on('data', (chunk) => { stdout += chunk; });
+        child.stderr.on('data', (chunk) => { stderr += chunk; });
+
+        const timer = setTimeout(() => {
+            child.kill();
+            reject(new Error(`CLI timed out. stdout: ${stdout} stderr: ${stderr}`));
+        }, 15_000);
+
+        child.on('close', (status) => {
+            clearTimeout(timer);
+            resolve({ stdout, stderr, status });
+        });
+        child.on('error', (error) => {
+            clearTimeout(timer);
+            reject(error);
+        });
+    });
+}
+
+describe('project and workflow state command registration', () => {
+    it.each([
+        ['project', 'enable', '<project>'],
+        ['project', 'disable', '<project>'],
+        ['workflow', 'enable', '<project> <workflow>'],
+        ['workflow', 'disable', '<project> <workflow>'],
+    ])('registers solidactions %s %s with dev-default environment help', async (noun, verb, argumentsLabel) => {
+        const result = await runCli([noun, verb, '--help']);
+
+        expect(result.status).toBe(0);
+        expect(result.stderr).toBe('');
+        expect(result.stdout).toContain(`Usage: solidactions ${noun} ${verb} [options] ${argumentsLabel}`);
+        expect(result.stdout).toContain('-e, --env <environment>');
+        expect(result.stdout).toMatch(/Defaults to\s+dev/i);
+    });
+});
+
+describe('project state mutations', () => {
+    it('defaults disable to dev and PUTs the exact body with workspace headers', async () => {
+        const result = await runCli(['project', 'disable', 'billing']);
+
+        expect(result.status).toBe(0);
+        expect(result.stderr).toBe('');
+        expect(requests).toEqual([expect.objectContaining({
+            method: 'PUT',
+            url: '/api/v1/projects/billing-dev/enabled',
+            body: { enabled: false },
+        })]);
+        expect(requests[0].headers.authorization).toBe('Bearer state-test-key');
+        expect(requests[0].headers['x-workspace-id']).toBe('workspace-state-1');
+        expect(requests[0].headers['content-type']).toMatch(/^application\/json/);
+        expect(result.stdout).toContain('Project "billing" (dev) disabled.');
+        expect(result.stdout).toContain('New root starts are blocked');
+        expect(result.stdout).toContain('CLI/API, schedules, webhooks, MCP, manual dead-letter retry, and manual rerun');
+        expect(result.stdout).toContain('Already-created roots continue');
+        expect(result.stdout).toContain('queued work, automatic retries, child legs, sleeping/signal-waiting phases, and running work');
+        expect(result.stdout).toContain('Deploy will not undo this manual state.');
+        expect(result.stdout).toContain('solidactions project enable billing --env dev');
+        expect(result.stdout).not.toMatch(/confirm|continue\?/i);
+    });
+
+    it.each([
+        ['enable', 'production', '/api/v1/projects/billing/enabled', true],
+        ['disable', 'staging', '/api/v1/projects/billing-staging/enabled', false],
+    ])('resolves project %s --env %s and sends the explicit state', async (verb, environment, url, enabled) => {
+        const result = await runCli(['project', verb, 'billing', '--env', environment]);
+
+        expect(result.status).toBe(0);
+        expect(requests).toEqual([expect.objectContaining({ method: 'PUT', url, body: { enabled } })]);
+        expect(requests[0].headers.authorization).toBe('Bearer state-test-key');
+        expect(requests[0].headers['x-workspace-id']).toBe('workspace-state-1');
+    });
+
+    it('resolves the normalized production base slug and suffixes non-production environments', async () => {
+        const production = await runCli(['project', 'enable', 'Billing API', '--env', 'production']);
+        const staging = await runCli(['project', 'enable', 'Billing API', '--env', 'staging']);
+
+        expect(production.status).toBe(0);
+        expect(staging.status).toBe(0);
+        expect(requests.map((request) => request.url)).toEqual([
+            '/api/v1/projects/billing-api/enabled',
+            '/api/v1/projects/billing-api-staging/enabled',
+        ]);
+    });
+
+    it('prints the remaining workflow and schedule gates after enabling, including an idempotent response', async () => {
+        responses.push({
+            status: 200,
+            body: { data: { type: 'project', name: 'billing', slug: 'billing-dev', environment: 'dev', enabled: true } },
+        });
+
+        const result = await runCli(['project', 'enable', 'billing']);
+
+        expect(result.status).toBe(0);
+        expect(result.stdout).toContain('Project "billing" (dev) enabled.');
+        expect(result.stdout).toContain('Direct starts require an enabled target workflow');
+        expect(result.stdout).toContain('Scheduled starts additionally require an enabled schedule');
+        expect(result.stdout).toContain('does not enable its workflows or schedules');
+        expect(result.stdout).toContain('solidactions project disable billing --env dev');
+    });
+});
+
+describe('workflow state mutations', () => {
+    it('defaults enable to dev and PUTs the exact nested body with workspace headers', async () => {
+        const result = await runCli(['workflow', 'enable', 'billing', 'daily-report']);
+
+        expect(result.status).toBe(0);
+        expect(result.stderr).toBe('');
+        expect(requests).toEqual([expect.objectContaining({
+            method: 'PUT',
+            url: '/api/v1/projects/billing-dev/workflows/daily-report/enabled',
+            body: { enabled: true },
+        })]);
+        expect(requests[0].headers.authorization).toBe('Bearer state-test-key');
+        expect(requests[0].headers['x-workspace-id']).toBe('workspace-state-1');
+        expect(result.stdout).toContain('Workflow "daily-report" in project "billing" (dev) enabled.');
+        expect(result.stdout).toContain('Direct starts require an enabled parent project');
+        expect(result.stdout).toContain('Scheduled starts additionally require an enabled schedule');
+        expect(result.stdout).toContain('does not enable its project or schedule');
+        expect(result.stdout).toContain('Deploy will not undo this manual state.');
+        expect(result.stdout).toContain('solidactions workflow disable billing daily-report --env dev');
+    });
+
+    it.each([
+        ['enable', 'production', '/api/v1/projects/billing/workflows/daily-report/enabled', true],
+        ['disable', 'staging', '/api/v1/projects/billing-staging/workflows/daily-report/enabled', false],
+    ])('resolves workflow %s --env %s and sends the explicit state', async (verb, environment, url, enabled) => {
+        const result = await runCli(['workflow', verb, 'billing', 'daily-report', '-e', environment]);
+
+        expect(result.status).toBe(0);
+        expect(requests).toEqual([expect.objectContaining({ method: 'PUT', url, body: { enabled } })]);
+        expect(requests[0].headers.authorization).toBe('Bearer state-test-key');
+        expect(requests[0].headers['x-workspace-id']).toBe('workspace-state-1');
+    });
+
+    it('prints the full disable blast radius and inverse command for an idempotent response', async () => {
+        responses.push({
+            status: 200,
+            body: {
+                data: {
+                    type: 'workflow',
+                    name: 'daily-report',
+                    slug: 'daily-report',
+                    enabled: false,
+                    project_name: 'billing',
+                    project_slug: 'billing-dev',
+                    environment: 'dev',
+                },
+            },
+        });
+
+        const result = await runCli(['workflow', 'disable', 'billing', 'daily-report']);
+
+        expect(result.status).toBe(0);
+        expect(result.stdout).toContain('New root starts are blocked');
+        expect(result.stdout).toContain('Already-created roots continue');
+        expect(result.stdout).toContain('Deploy will not undo this manual state.');
+        expect(result.stdout).toContain('solidactions workflow enable billing daily-report --env dev');
+    });
+});
+
+describe('state command failures', () => {
+    it.each([
+        [401, { message: 'Unauthenticated.' }, /Authentication failed/i],
+        [404, { message: 'Project not found.' }, /Project not found/i],
+        [409, { error: 'workflow_retired', message: 'Workflow is not part of the current deployment.' }, /not part of the current deployment/i],
+        [422, { message: 'The enabled field must be true or false.', errors: { enabled: ['The enabled field must be true or false.'] } }, /enabled field must be true or false/i],
+        [500, { message: 'State service unavailable.' }, /State service unavailable/i],
+    ])('uses existing error conventions and exits non-zero for HTTP %s', async (status, body, expected) => {
+        responses.push({ status, body });
+
+        const result = await runCli(['workflow', 'disable', 'billing', 'daily-report']);
+
+        expect(result.status).toBe(1);
+        expect(result.stderr).toMatch(expected);
+        expect(result.stdout).toBe('');
+    });
+
+    it('rejects an unsupported environment without sending a request', async () => {
+        const result = await runCli(['project', 'enable', 'billing', '--env', 'qa']);
+
+        expect(result.status).toBe(1);
+        expect(result.stderr).toMatch(/production.*staging.*dev/i);
+        expect(requests).toHaveLength(0);
+    });
+});

--- a/tests/webhook-state-formatter.test.ts
+++ b/tests/webhook-state-formatter.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { formatJson, formatTable } from '../src/utils/webhook-formatters';
+
+const rows = [
+    {
+        workflow_name: 'retired-flow',
+        webhook_url: 'https://example.test/retired',
+        webhook_secret: 'retired-secret',
+        enabled: false,
+        project_enabled: false,
+        retired: true,
+        effective_enabled: false,
+    },
+    {
+        workflow_name: 'off-flow',
+        webhook_url: 'https://example.test/off',
+        webhook_secret: 'off-secret',
+        enabled: false,
+        project_enabled: false,
+        retired: false,
+        effective_enabled: false,
+    },
+    {
+        workflow_name: 'blocked-flow',
+        webhook_url: 'https://example.test/blocked',
+        webhook_secret: 'blocked-secret',
+        enabled: true,
+        project_enabled: false,
+        retired: false,
+        effective_enabled: false,
+    },
+    {
+        workflow_name: 'on-flow',
+        webhook_url: 'https://example.test/on',
+        webhook_secret: 'on-secret',
+        enabled: true,
+        project_enabled: true,
+        retired: false,
+        effective_enabled: true,
+    },
+] as any[];
+
+function plain(value: string): string {
+    return value.replace(/\u001b\[[0-9;]*m/g, '');
+}
+
+describe('webhook enabled-state formatting', () => {
+    it('adds a STATE table column with retired > off > blocked > on precedence', () => {
+        const lines = formatTable(rows, { showSecrets: false }).map(plain);
+
+        expect(lines[0]).toMatch(/^WORKFLOW\s+STATE\s+URL$/);
+        expect(lines.find((line) => line.includes('retired-flow'))).toContain('retired');
+        expect(lines.find((line) => line.includes('off-flow'))).toMatch(/off-flow\s+off\s+/);
+        expect(lines.find((line) => line.includes('blocked-flow'))).toContain('blocked (project off)');
+        expect(lines.find((line) => line.includes('on-flow'))).toMatch(/on-flow\s+on\s+/);
+    });
+
+    it('includes derived and raw state in JSON while redacting secrets by default', () => {
+        const output = JSON.parse(formatJson(rows, { showSecrets: false }));
+
+        expect(output.map((row: any) => row.state)).toEqual([
+            'retired',
+            'off',
+            'blocked (project off)',
+            'on',
+        ]);
+        expect(output[2]).toMatchObject({
+            enabled: true,
+            project_enabled: false,
+            retired: false,
+            effective_enabled: false,
+        });
+        expect(output[0]).not.toHaveProperty('secret');
+        expect(JSON.stringify(output)).not.toContain('retired-secret');
+    });
+
+    it('preserves opt-in secret output alongside state', () => {
+        const output = JSON.parse(formatJson([rows[3]], { showSecrets: true }));
+
+        expect(output[0]).toMatchObject({ state: 'on', secret: 'on-secret' });
+    });
+});


### PR DESCRIPTION
## Summary

- add non-interactive `project enable|disable` and `workflow enable|disable` commands
- default state mutations to `dev` while requiring explicit production targeting
- expose project enabled state in list/view and effective webhook state in table/JSON output
- document the activation-lifecycle verb family and operator blast radius

## Verification

- `npm test` — 958 passed
- `npm run build` — 87-command manifest
- local app-stack smoke: disable, rejected root, state visibility, enable, admitted root
- context-free Claude TUI cleanroom: workflow lifecycle passed

Related to SolidActions/solidactions-app#958. Companion app PR: SolidActions/solidactions-app#1100.