### PR TITLE
CLI: add workspace database command group

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,6 +16,28 @@ on:
         default: main
 
 jobs:
+  native-database-client:
+    name: Native database client (Node ${{ matrix.node }}, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+        node:
+          - '20'
+          - '24'
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+      - run: npm ci
+      - run: node scripts/probe-native-database-client.mjs
+
   release-candidate:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -38,6 +38,36 @@ jobs:
       - run: npm ci
       - run: node scripts/probe-native-database-client.mjs
 
+  database-client-remote-sync:
+    name: Database client remote sync
+    runs-on: ubuntu-latest
+    services:
+      database:
+        image: ghcr.io/tursodatabase/libsql-server:3ec6803@sha256:1bc51611928ccc51229bdc40ca0defcb915907f8f9f6a664b43529de0ca45fab
+        ports:
+          - 8080:8080
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: npm
+      - run: npm ci
+      - name: Wait for the database service
+        shell: bash
+        run: |
+          for attempt in {1..30}; do
+            if curl --fail --silent http://127.0.0.1:8080/health > /dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Database service did not become ready in 30 seconds." >&2
+          exit 1
+      - run: node scripts/probe-database-client-sync.mjs
+        env:
+          SOLIDACTIONS_DATABASE_SYNC_URL: http://127.0.0.1:8080
+
   release-candidate:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -77,6 +77,52 @@ installed skills and select `solidactions-deploy-and-config` for deployment.
 For an existing project, install or refresh the same tooling with
 `solidactions ai init --claude` or `solidactions ai init --agents`.
 
+## Database CLI
+
+Use the singular `solidactions database` group to manage databases in the
+active workspace. The complete command surface is:
+
+```bash
+solidactions database list --json
+solidactions database create analytics --from backup.sql --json
+solidactions database delete analytics --yes --json
+solidactions database undelete analytics --json
+solidactions database schema analytics --json
+solidactions database query analytics "SELECT * FROM events" --json
+solidactions database exec analytics "DELETE FROM events WHERE expired = 1" --yes --json
+solidactions database dump analytics backup.sql --yes
+solidactions database pull analytics .solidactions/databases/analytics.db --yes
+solidactions database pull analytics --writable
+solidactions database import analytics backup.sql --yes
+solidactions database import analytics backup.sql --resume <checkpoint> --yes
+```
+
+`--json` produces machine-readable output where supported. `delete`, `exec`,
+`dump` overwrites, `pull` overwrites, and `import` prompt before changing data;
+use `--yes` only when that change is already approved. A database `delete` is a
+soft-delete, and its output shows the purge clock during which `undelete` can
+restore it.
+
+`query` is read-only SQL; use `exec` for writes. `schema`, `query`, `exec`,
+`pull --writable`, and imports use ephemeral scoped access held only in memory.
+No durable credential or credential sidecar is written locally.
+
+By default, `pull` atomically publishes a read-only local replica at
+`.solidactions/databases/<safe-stem>.db`, or at an explicit path. Reuse that
+file for local analytics and transformations. `pull --writable` instead opens a
+foreground session: writes go to the live workspace database.
+No offline merge or background write-back continues after exit.
+
+`dump` publishes only a complete SQL file through an owned temporary path and
+refuses unsafe symlink or unapproved overwrite destinations. The CLI rejects
+any import containing `-- DOWNLOAD INCOMPLETE` before making changes. Use
+`create --from <file.sql>` to preflight, create, and load in one flow.
+
+Imports commit bounded batches and atomically record a source-bound checkpoint
+under `.solidactions/imports/`. After a partial failure, copy the exact printed
+`--resume <checkpoint>` command to continue without replaying completed
+batches; do not restart the same checkpointed source with a plain import.
+
 ## Configuration
 
 The CLI stores `host`, `apiKey`, and `workspaceId` in a JSON config file. Two locations are supported:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.33.0",
       "license": "MIT",
       "dependencies": {
+        "@libsql/client": "0.17.4",
         "archiver": "^8.0.0",
         "axios": "^1.18.1",
         "chalk": "^4.1.2",
@@ -56,6 +57,171 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@libsql/client": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@libsql/client/-/client-0.17.4.tgz",
+      "integrity": "sha512-lYayFWasDV78A+TjlEhr6ubb3odBV6OHjb+wdp8VQcyWWAEIjuwbCHaraEUS4m4yWoo0BvZo96It4VdzZRmRWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@libsql/core": "^0.17.4",
+        "@libsql/hrana-client": "^0.10.0",
+        "js-base64": "^3.7.5",
+        "libsql": "^0.5.28",
+        "promise-limit": "^2.7.0"
+      }
+    },
+    "node_modules/@libsql/core": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@libsql/core/-/core-0.17.4.tgz",
+      "integrity": "sha512-LqF9gIvnJ38nmAH1y/ChizHqDO/MO1wLgA96XrraulEEbqXxLjleSH92YWTolbuJKgPUmGu4aJk9W3UnAcxLOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "js-base64": "^3.7.5"
+      }
+    },
+    "node_modules/@libsql/darwin-arm64": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/@libsql/darwin-arm64/-/darwin-arm64-0.5.29.tgz",
+      "integrity": "sha512-K+2RIB1OGFPYQbfay48GakLhqf3ArcbHqPFu7EZiaUcRgFcdw8RoltsMyvbj5ix2fY0HV3Q3Ioa/ByvQdaSM0A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@libsql/darwin-x64": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/@libsql/darwin-x64/-/darwin-x64-0.5.29.tgz",
+      "integrity": "sha512-OtT+KFHsKFy1R5FVadr8FJ2Bb1mghtXTyJkxv0trocq7NuHntSki1eUbxpO5ezJesDvBlqFjnWaYYY516QNLhQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@libsql/hrana-client": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@libsql/hrana-client/-/hrana-client-0.10.0.tgz",
+      "integrity": "sha512-OoA4EMqRAC7kn7V2P6EQqRcpZf2W+AjsNIyCizBg339Tq/aMC7sRnzs3SklderhmQWAqEzvv8A2vhxVmWpkVvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@libsql/isomorphic-ws": "^0.1.5",
+        "js-base64": "^3.7.5"
+      }
+    },
+    "node_modules/@libsql/isomorphic-ws": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@libsql/isomorphic-ws/-/isomorphic-ws-0.1.5.tgz",
+      "integrity": "sha512-DtLWIH29onUYR00i0GlQ3UdcTRC6EP4u9w/h9LxpUZJWRMARk6dQwZ6Jkd+QdwVpuAOrdxt18v0K2uIYR3fwFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ws": "^8.5.4",
+        "ws": "^8.13.0"
+      }
+    },
+    "node_modules/@libsql/linux-arm-gnueabihf": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-arm-gnueabihf/-/linux-arm-gnueabihf-0.5.29.tgz",
+      "integrity": "sha512-CD4n4zj7SJTHso4nf5cuMoWoMSS7asn5hHygsDuhRl8jjjCTT3yE+xdUvI4J7zsyb53VO5ISh4cwwOtf6k2UhQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/linux-arm-musleabihf": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-arm-musleabihf/-/linux-arm-musleabihf-0.5.29.tgz",
+      "integrity": "sha512-2Z9qBVpEJV7OeflzIR3+l5yAd4uTOLxklScYTwpZnkm2vDSGlC1PRlueLaufc4EFITkLKXK2MWBpexuNJfMVcg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/linux-arm64-gnu": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-arm64-gnu/-/linux-arm64-gnu-0.5.29.tgz",
+      "integrity": "sha512-gURBqaiXIGGwFNEaUj8Ldk7Hps4STtG+31aEidCk5evMMdtsdfL3HPCpvys+ZF/tkOs2MWlRWoSq7SOuCE9k3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/linux-arm64-musl": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-arm64-musl/-/linux-arm64-musl-0.5.29.tgz",
+      "integrity": "sha512-fwgYZ0H8mUkyVqXZHF3mT/92iIh1N94Owi/f66cPVNsk9BdGKq5gVpoKO+7UxaNzuEH1roJp2QEwsCZMvBLpqg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/linux-x64-gnu": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-x64-gnu/-/linux-x64-gnu-0.5.29.tgz",
+      "integrity": "sha512-y14V0vY0nmMC6G0pHeJcEarcnGU2H6cm21ZceRkacWHvQAEhAG0latQkCtoS2njFOXiYIg+JYPfAoWKbi82rkg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/linux-x64-musl": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-x64-musl/-/linux-x64-musl-0.5.29.tgz",
+      "integrity": "sha512-gquqwA/39tH4pFl+J9n3SOMSymjX+6kZ3kWgY3b94nXFTwac9bnFNMffIomgvlFaC4ArVqMnOZD3nuJ3H3VO1w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/win32-x64-msvc": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/@libsql/win32-x64-msvc/-/win32-x64-msvc-0.5.29.tgz",
+      "integrity": "sha512-4/0CvEdhi6+KjMxMaVbFM2n2Z44escBRoEYpR+gZg64DdetzGnYm8mcNLcoySaDJZNaBd6wz5DNdgRmcI4hXcg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@neon-rs/load": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@neon-rs/load/-/load-0.0.4.tgz",
+      "integrity": "sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw==",
       "license": "MIT"
     },
     "node_modules/@oxc-project/types": {
@@ -567,7 +733,6 @@
       "version": "20.19.33",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.33.tgz",
       "integrity": "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -648,6 +813,15 @@
       "license": "ISC",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@vitest/expect": {
@@ -1755,6 +1929,12 @@
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
     },
+    "node_modules/js-base64": {
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.9.2.tgz",
+      "integrity": "sha512-6zayE8QlUdiweYI6cETD/XBSqFcoCUlufn/29PJR99r82x1yDnIprRca0YvAYpAW+ez0GuQkVBC6xG5QkD7OjA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/js-yaml": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
@@ -1915,6 +2095,47 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/libsql": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/libsql/-/libsql-0.5.29.tgz",
+      "integrity": "sha512-8lMP8iMgiBzzoNbAPQ59qdVcj6UaE/Vnm+fiwX4doX4Narook0a4GPKWBEv+CR8a1OwbfkgL18uBfBjWdF0Fzg==",
+      "cpu": [
+        "x64",
+        "arm64",
+        "wasm32",
+        "arm"
+      ],
+      "license": "MIT",
+      "os": [
+        "darwin",
+        "linux",
+        "win32"
+      ],
+      "dependencies": {
+        "@neon-rs/load": "^0.0.4",
+        "detect-libc": "2.0.2"
+      },
+      "optionalDependencies": {
+        "@libsql/darwin-arm64": "0.5.29",
+        "@libsql/darwin-x64": "0.5.29",
+        "@libsql/linux-arm-gnueabihf": "0.5.29",
+        "@libsql/linux-arm-musleabihf": "0.5.29",
+        "@libsql/linux-arm64-gnu": "0.5.29",
+        "@libsql/linux-arm64-musl": "0.5.29",
+        "@libsql/linux-x64-gnu": "0.5.29",
+        "@libsql/linux-x64-musl": "0.5.29",
+        "@libsql/win32-x64-msvc": "0.5.29"
+      }
+    },
+    "node_modules/libsql/node_modules/detect-libc": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
+      "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/lightningcss": {
@@ -2425,6 +2646,12 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
     },
+    "node_modules/promise-limit": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/promise-limit/-/promise-limit-2.7.0.tgz",
+      "integrity": "sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw==",
+      "license": "ISC"
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -2837,7 +3064,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/universalify": {
@@ -3054,7 +3280,6 @@
       "version": "8.21.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
       "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@libsql/client": "0.17.4",
     "archiver": "^8.0.0",
     "axios": "^1.18.1",
     "chalk": "^4.1.2",

--- a/scripts/probe-database-client-sync.mjs
+++ b/scripts/probe-database-client-sync.mjs
@@ -1,0 +1,62 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const EXPECTED_VALUE = 'remote-sync-ready';
+
+export async function runRemoteSyncProbe({ createClient, remoteUrl, localUrl }) {
+    let remoteClient;
+    let localClient;
+
+    try {
+        remoteClient = createClient({ url: remoteUrl, intMode: 'string' });
+        await remoteClient.execute(
+            'CREATE TABLE IF NOT EXISTS probe_results (id INTEGER PRIMARY KEY, value TEXT NOT NULL)',
+        );
+        await remoteClient.execute({
+            sql: 'INSERT INTO probe_results (id, value) VALUES (1, ?) ON CONFLICT(id) DO UPDATE SET value = excluded.value',
+            args: [EXPECTED_VALUE],
+        });
+
+        localClient = createClient({
+            url: localUrl,
+            syncUrl: remoteUrl,
+            intMode: 'string',
+        });
+        await localClient.sync();
+
+        const result = await localClient.execute('SELECT value FROM probe_results WHERE id = 1');
+        if (result.rows.length !== 1 || result.rows[0].value !== EXPECTED_VALUE) {
+            throw new Error('Remote database sync probe returned an unexpected result.');
+        }
+    } finally {
+        try {
+            localClient?.close();
+        } finally {
+            remoteClient?.close();
+        }
+    }
+}
+
+async function runDirectProbe() {
+    const probeDirectory = await mkdtemp(path.join(tmpdir(), 'solidactions-database-sync-probe-'));
+    const localUrl = pathToFileURL(path.join(probeDirectory, 'replica.db')).href;
+    const remoteUrl = process.env.SOLIDACTIONS_DATABASE_SYNC_URL ?? 'http://127.0.0.1:8080';
+
+    try {
+        const { createClient } = await import('@libsql/client');
+        await runRemoteSyncProbe({ createClient, remoteUrl, localUrl });
+        process.stdout.write('Remote database sync probe passed.\n');
+    } finally {
+        await rm(probeDirectory, { recursive: true, force: true });
+    }
+}
+
+const invokedPath = process.argv[1]
+    ? pathToFileURL(path.resolve(process.argv[1])).href
+    : null;
+
+if (invokedPath === import.meta.url) {
+    await runDirectProbe();
+}

--- a/scripts/probe-native-database-client.mjs
+++ b/scripts/probe-native-database-client.mjs
@@ -1,0 +1,32 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const probeDirectory = await mkdtemp(path.join(tmpdir(), 'solidactions-database-probe-'));
+const databaseUrl = pathToFileURL(path.join(probeDirectory, 'probe.db')).href;
+let client;
+
+try {
+    const { createClient } = await import('@libsql/client');
+    client = createClient({ url: databaseUrl });
+
+    await client.execute('CREATE TABLE probe_results (value TEXT NOT NULL)');
+    await client.execute({
+        sql: 'INSERT INTO probe_results (value) VALUES (?)',
+        args: ['embedded-client-ready'],
+    });
+    const result = await client.execute('SELECT value FROM probe_results');
+
+    if (result.rows.length !== 1 || result.rows[0].value !== 'embedded-client-ready') {
+        throw new Error('Embedded database probe returned an unexpected result.');
+    }
+
+    process.stdout.write('Embedded database client probe passed.\n');
+} finally {
+    try {
+        client?.close();
+    } finally {
+        await rm(probeDirectory, { recursive: true, force: true });
+    }
+}

--- a/scripts/probe-native-database-client.mjs
+++ b/scripts/probe-native-database-client.mjs
@@ -1,7 +1,9 @@
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
+
+import { removeNativeProbeDirectory } from './remove-native-probe-directory.mjs';
 
 const probeDirectory = await mkdtemp(path.join(tmpdir(), 'solidactions-database-probe-'));
 const databaseUrl = pathToFileURL(path.join(probeDirectory, 'probe.db')).href;
@@ -27,6 +29,6 @@ try {
     try {
         client?.close();
     } finally {
-        await rm(probeDirectory, { recursive: true, force: true });
+        await removeNativeProbeDirectory(probeDirectory);
     }
 }

--- a/scripts/remove-native-probe-directory.mjs
+++ b/scripts/remove-native-probe-directory.mjs
@@ -1,0 +1,12 @@
+import { rm } from 'node:fs/promises';
+
+const cleanupOptions = {
+    recursive: true,
+    force: true,
+    maxRetries: 5,
+    retryDelay: 100,
+};
+
+export async function removeNativeProbeDirectory(probeDirectory, remove = rm) {
+    await remove(probeDirectory, cleanupOptions);
+}

--- a/scripts/remove-native-probe-directory.mjs
+++ b/scripts/remove-native-probe-directory.mjs
@@ -7,6 +7,6 @@ const cleanupOptions = {
     retryDelay: 100,
 };
 
-export async function removeNativeProbeDirectory(probeDirectory, remove = rm) {
-    await remove(probeDirectory, cleanupOptions);
+export async function removeNativeProbeDirectory(probeDirectory) {
+    await rm(probeDirectory, cleanupOptions);
 }

--- a/scripts/smoke-init.mjs
+++ b/scripts/smoke-init.mjs
@@ -258,6 +258,12 @@ async function verifyScaffold(projectDir, target) {
   assert.deepEqual(installedSkills, [...skillNames].sort(), `${target} skill manifest drifted`);
   assert((await stat(path.join(projectDir, '.solidactions', 'sdk-reference.md'))).isFile(), 'SDK reference missing');
 
+  const deploySkill = await readFile(path.join(skillDir, 'solidactions-deploy-and-config.md'), 'utf8');
+  assert(
+    deploySkill.includes('## Recipe — Databases'),
+    'pinned solidactions-deploy-and-config.md is missing ## Recipe — Databases',
+  );
+
   const helper = await readFile(path.join(projectDir, targetFile), 'utf8');
   for (const skillName of skillNames) {
     assert(helper.includes(skillName), `${targetFile} does not name ${skillName}`);

--- a/src/commands/database.ts
+++ b/src/commands/database.ts
@@ -11,8 +11,10 @@ import {
     DatabaseOperationError,
     DatabaseRequestDependencies,
     DatabaseResultSet,
+    DEFAULT_DATABASE_DATA_PLANE_TIMEOUT_MS,
     formatDatabaseTableValue,
     normalizeDatabaseValue,
+    runDatabaseClientOperationWithDeadline,
     requestDatabaseAccess,
     requestDatabaseDumpStream,
     requestDatabaseOperation,
@@ -108,6 +110,7 @@ export interface DatabaseCommandDependencies extends DatabaseClientDependencies 
     input?: AsyncIterable<string>;
     now?: () => number;
     abortSignal?: AbortSignal;
+    sleep?: (milliseconds: number) => Promise<void>;
 }
 
 interface ResolvedCommandDependencies {
@@ -124,6 +127,9 @@ interface ResolvedCommandDependencies {
     input?: AsyncIterable<string>;
     now: () => number;
     abortSignal?: AbortSignal;
+    controlPlaneTimeoutMs: number | undefined;
+    dataPlaneTimeoutMs: number;
+    sleep: (milliseconds: number) => Promise<void>;
 }
 
 function defaultConfirmation(message: string): Promise<boolean> {
@@ -163,17 +169,27 @@ function resolveDependencies(dependencies: DatabaseCommandDependencies): Resolve
         input: dependencies.input,
         now: dependencies.now ?? Date.now,
         abortSignal: dependencies.abortSignal,
+        controlPlaneTimeoutMs: dependencies.controlPlaneTimeoutMs,
+        dataPlaneTimeoutMs: dependencies.dataPlaneTimeoutMs ?? DEFAULT_DATABASE_DATA_PLANE_TIMEOUT_MS,
+        sleep: dependencies.sleep ?? ((milliseconds) => new Promise((resolve) => {
+            setTimeout(resolve, milliseconds);
+        })),
     };
 }
 
 function requestDependencies(dependencies: ResolvedCommandDependencies): DatabaseRequestDependencies {
-    return { post: dependencies.post };
+    return {
+        post: dependencies.post,
+        controlPlaneTimeoutMs: dependencies.controlPlaneTimeoutMs,
+    };
 }
 
 function clientDependencies(dependencies: ResolvedCommandDependencies): DatabaseClientDependencies {
     return {
         post: dependencies.post,
         loadClient: dependencies.loadClient,
+        controlPlaneTimeoutMs: dependencies.controlPlaneTimeoutMs,
+        dataPlaneTimeoutMs: dependencies.dataPlaneTimeoutMs,
     };
 }
 
@@ -493,6 +509,7 @@ function renderSchema(schema: DatabaseSchemaResponse): string {
 const INCOMPLETE_DUMP_MARKER = '-- DOWNLOAD INCOMPLETE';
 const DUMP_TAIL_BYTES = 4096;
 const PULL_ATTEMPTS = 3;
+const PULL_RETRY_BACKOFF_MS = [250, 500] as const;
 
 function safeDatabaseStem(name: string): string {
     return name
@@ -838,6 +855,39 @@ function isAuthenticationExpired(error: unknown): boolean {
     return code === 'SQLITE_AUTH' && /expired|expiration|\bjwt\b/i.test(message);
 }
 
+type PullFailureClass = 'credential_expiry' | 'transient_transport' | 'deterministic';
+
+function classifyPullFailure(error: unknown): PullFailureClass {
+    if (isAuthenticationExpired(error)) return 'credential_expiry';
+
+    const value = error as { code?: unknown; name?: unknown; message?: unknown } | null;
+    const code = typeof value?.code === 'string' ? value.code.toUpperCase() : '';
+    const name = typeof value?.name === 'string' ? value.name : '';
+    const message = typeof value?.message === 'string' ? value.message : '';
+    const transientCodes = new Set([
+        'ECONNABORTED',
+        'ECONNREFUSED',
+        'ECONNRESET',
+        'EHOSTUNREACH',
+        'ENETDOWN',
+        'ENETUNREACH',
+        'ENOTFOUND',
+        'ETIMEDOUT',
+        'UND_ERR_CONNECT_TIMEOUT',
+        'UND_ERR_HEADERS_TIMEOUT',
+        'UND_ERR_SOCKET',
+    ]);
+    if (
+        transientCodes.has(code)
+        || name === 'AbortError'
+        || /\b(?:connection reset|network unavailable|temporary transport|transport failure|timed? ?out)\b/i.test(message)
+    ) {
+        return 'transient_transport';
+    }
+
+    return 'deterministic';
+}
+
 async function handoffReplicaReservation(
     io: ResolvedCommandDependencies,
     temp: string,
@@ -877,6 +927,15 @@ async function finalizeReplica(
 
     await assertOwnedMainFile();
     let finalizer: DatabaseClient | undefined;
+    let finalizerClosePromise: Promise<void> | undefined;
+    const closeFinalizer = (): Promise<void> => {
+        finalizerClosePromise ??= runDatabaseClientOperationWithDeadline(
+            async () => { await finalizer?.close(); },
+            undefined,
+            io.dataPlaneTimeoutMs,
+        );
+        return finalizerClosePromise;
+    };
     let checkpointResult: DatabaseResultSet | undefined;
     let finalizationFailed = false;
     try {
@@ -884,13 +943,17 @@ async function finalizeReplica(
             url: pathToFileURL(temp).href,
             intMode: 'string',
         });
-        checkpointResult = await finalizer.execute('PRAGMA wal_checkpoint(TRUNCATE)');
+        checkpointResult = await runDatabaseClientOperationWithDeadline(
+            () => finalizer!.execute('PRAGMA wal_checkpoint(TRUNCATE)'),
+            closeFinalizer,
+            io.dataPlaneTimeoutMs,
+        );
     } catch {
         finalizationFailed = true;
     } finally {
         if (finalizer) {
             try {
-                await finalizer.close();
+                await closeFinalizer();
             } catch {
                 finalizationFailed = true;
             }
@@ -971,6 +1034,8 @@ export async function databaseCreateWithConfig(
                         now: io.now,
                         post: io.post,
                         loadClient: io.loadClient,
+                        controlPlaneTimeoutMs: io.controlPlaneTimeoutMs,
+                        dataPlaneTimeoutMs: io.dataPlaneTimeoutMs,
                     },
                 );
             }
@@ -1031,6 +1096,8 @@ export async function databaseImportWithConfig(
         now: io.now,
         post: io.post,
         loadClient: io.loadClient,
+        controlPlaneTimeoutMs: io.controlPlaneTimeoutMs,
+        dataPlaneTimeoutMs: io.dataPlaneTimeoutMs,
     });
 }
 
@@ -1227,6 +1294,7 @@ export async function databaseDumpWithConfig(
         await assertNoSymlinkComponents(io.filesystem, target);
         await io.filesystem.rename(temp, target);
         ownsTemp = false;
+        await io.filesystem.chmod(target, 0o444);
         io.stdout(`Database dump saved to ${displayDestination(io, target)}.`);
     } catch (error) {
         if (handle) {
@@ -1261,13 +1329,21 @@ async function databaseWritablePullWithConfig(
     let localCreateClient: ((config: Record<string, unknown>) => DatabaseClient) | undefined;
     let expiresAt = 0;
     let inputSession: WritableInputSession | undefined;
+    let attachedClosePromise: Promise<void> | undefined;
 
     const closeAttachedClient = async (): Promise<void> => {
-        if (!client) return;
-        const closing = client;
-        client = undefined;
+        if (client) {
+            const closing = client;
+            client = undefined;
+            attachedClosePromise ??= runDatabaseClientOperationWithDeadline(
+                async () => { await closing.close(); },
+                undefined,
+                io.dataPlaneTimeoutMs,
+            );
+        }
+        if (!attachedClosePromise) return;
         try {
-            await closing.close();
+            await attachedClosePromise;
         } catch {
             throw new DatabaseOperationError('upstream_unavailable', 'Database file operation failed.');
         }
@@ -1335,10 +1411,23 @@ async function databaseWritablePullWithConfig(
             throw new DatabaseOperationError('upstream_unavailable', 'Database file operation failed.');
         }
 
+        let openedClosePromise: Promise<void> | undefined;
+        const closeOpened = (): Promise<void> => {
+            openedClosePromise ??= runDatabaseClientOperationWithDeadline(
+                async () => { await opened.close(); },
+                undefined,
+                io.dataPlaneTimeoutMs,
+            );
+            return openedClosePromise;
+        };
         let syncFailed = false;
         try {
             if (typeof opened.sync !== 'function') throw new Error('Database sync is unavailable.');
-            await opened.sync();
+            await runDatabaseClientOperationWithDeadline(
+                () => opened.sync!(),
+                closeOpened,
+                io.dataPlaneTimeoutMs,
+            );
         } catch {
             syncFailed = true;
         }
@@ -1352,13 +1441,14 @@ async function databaseWritablePullWithConfig(
             || !replicaStat.isFile()
         ) {
             try {
-                await opened.close();
+                await closeOpened();
             } catch {
                 // The stable setup error below takes precedence.
             }
             throw new DatabaseOperationError('upstream_unavailable', 'Database file operation failed.');
         }
 
+        attachedClosePromise = undefined;
         client = opened;
         localCreateClient = createClient;
         expiresAt = access.expiresAt;
@@ -1435,10 +1525,18 @@ async function databaseWritablePullWithConfig(
                         if (typeof client?.executeMultiple !== 'function') {
                             throw new Error('Multiple SQL execution is unavailable.');
                         }
-                        await client.executeMultiple(statement.sql);
+                        await runDatabaseClientOperationWithDeadline(
+                            () => client!.executeMultiple!(statement.sql),
+                            closeAttachedClient,
+                            io.dataPlaneTimeoutMs,
+                        );
                         io.stdout('Transaction group executed successfully.');
                     } else {
-                        const result = stableDirectResult(await client!.execute(statement.sql));
+                        const result = stableDirectResult(await runDatabaseClientOperationWithDeadline(
+                            () => client!.execute(statement.sql),
+                            closeAttachedClient,
+                            io.dataPlaneTimeoutMs,
+                        ));
                         io.stdout(
                             result.columns.length > 0
                                 ? renderDirectTable(result)
@@ -1446,6 +1544,13 @@ async function databaseWritablePullWithConfig(
                         );
                     }
                 } catch (error) {
+                    if (
+                        error instanceof DatabaseOperationError
+                        && error.message === 'Database operation timed out.'
+                    ) {
+                        sessionFailure = error;
+                        break;
+                    }
                     if (!isAuthenticationExpired(error)) {
                         io.stderr('Database statement failed.');
                         continue;
@@ -1569,6 +1674,7 @@ export async function databasePullWithConfig(
 
         let synced = false;
         let localCreateClient: ((config: Record<string, unknown>) => DatabaseClient) | undefined;
+        let credentialRemintUsed = false;
         for (let attempt = 0; attempt < PULL_ATTEMPTS; attempt += 1) {
             const { createClient, access } = await loadDatabaseClientBeforeMint(
                 () => requestDatabaseAccess(config, name, 'read', requestDependencies(io)),
@@ -1608,30 +1714,60 @@ export async function databasePullWithConfig(
                 throw new DatabaseOperationError('upstream_unavailable', 'Database file operation failed.');
             }
 
-            let attemptFailed = false;
+            let attemptFailure: unknown;
+            let closePromise: Promise<void> | undefined;
+            const closeClient = (): Promise<void> => {
+                closePromise ??= runDatabaseClientOperationWithDeadline(
+                    async () => { await client.close(); },
+                    undefined,
+                    io.dataPlaneTimeoutMs,
+                );
+                return closePromise;
+            };
             try {
                 if (typeof client.sync !== 'function') throw new Error('Database sync is unavailable.');
-                await client.sync();
-            } catch {
-                attemptFailed = true;
+                await runDatabaseClientOperationWithDeadline(
+                    () => client.sync!(),
+                    closeClient,
+                    io.dataPlaneTimeoutMs,
+                );
+            } catch (error) {
+                attemptFailure = error;
             } finally {
                 try {
-                    await client.close();
-                } catch {
-                    attemptFailed = true;
+                    await closeClient();
+                } catch (error) {
+                    if (!attemptFailure) attemptFailure = error;
                 }
             }
 
-            const replicaStat = await lstatIfPresent(io.filesystem, temp);
-            if (!replicaStat || replicaStat.isSymbolicLink() || !replicaStat.isFile()) {
-                throw new DatabaseOperationError('upstream_unavailable', 'Database file operation failed.');
-            }
-            ownsTemp = true;
-
-            if (!attemptFailed) {
+            if (!attemptFailure) {
+                const replicaStat = await lstatIfPresent(io.filesystem, temp);
+                if (!replicaStat || replicaStat.isSymbolicLink() || !replicaStat.isFile()) {
+                    throw new DatabaseOperationError('upstream_unavailable', 'Database file operation failed.');
+                }
+                ownsTemp = true;
                 synced = true;
                 break;
             }
+
+            const replicaStat = await lstatIfPresent(io.filesystem, temp);
+            if (replicaStat?.isSymbolicLink() || (replicaStat && !replicaStat.isFile())) {
+                throw new DatabaseOperationError('upstream_unavailable', 'Database file operation failed.');
+            }
+            if (replicaStat?.isFile()) ownsTemp = true;
+
+            const failureClass = classifyPullFailure(attemptFailure);
+            const hasAnotherAttempt = attempt + 1 < PULL_ATTEMPTS;
+            if (failureClass === 'credential_expiry' && !credentialRemintUsed && hasAnotherAttempt) {
+                credentialRemintUsed = true;
+                continue;
+            }
+            if (failureClass === 'transient_transport' && hasAnotherAttempt) {
+                await io.sleep(PULL_RETRY_BACKOFF_MS[attempt] ?? PULL_RETRY_BACKOFF_MS.at(-1)!);
+                continue;
+            }
+            break;
         }
 
         if (!synced) {

--- a/src/commands/database.ts
+++ b/src/commands/database.ts
@@ -1264,6 +1264,17 @@ async function databaseWritablePullWithConfig(
     };
 
     const openAttachedClient = async (initial: boolean): Promise<void> => {
+        if (!initial) {
+            await assertNoSymlinkComponents(io.filesystem, temp!);
+            const beforeMint = await lstatIfPresent(io.filesystem, temp!);
+            if (!beforeMint || beforeMint.isSymbolicLink() || !beforeMint.isFile()) {
+                throw new DatabaseOperationError(
+                    'unsafe_destination',
+                    'The database replica temporary path is unsafe.',
+                );
+            }
+        }
+
         let loaded: Awaited<ReturnType<typeof loadDatabaseClientBeforeMint>>;
         try {
             loaded = await loadDatabaseClientBeforeMint(

--- a/src/commands/database.ts
+++ b/src/commands/database.ts
@@ -956,6 +956,7 @@ export async function databasePullWithConfig(
         path.join('.solidactions', 'databases', `${safeDatabaseStem(name)}.db`),
     );
     let temp: string | undefined;
+    let reservationHandle: Awaited<ReturnType<DatabaseFileSystem['open']>> | undefined;
     let ownsTemp = false;
     let ownsSidecars = false;
 
@@ -964,8 +965,8 @@ export async function databasePullWithConfig(
 
         const reservation = await reserveDestinationTemp(io, target);
         temp = reservation.temp;
+        reservationHandle = reservation.handle;
         ownsTemp = true;
-        await reservation.handle.close();
 
         const sidecars = pullSidecars(temp);
         if (await anyPathExists(io.filesystem, sidecars)) {
@@ -983,8 +984,25 @@ export async function databasePullWithConfig(
                 { loadClient: io.loadClient },
             );
 
-            let client: DatabaseClient | undefined;
-            let attemptFailed = false;
+            if (attempt === 0) {
+                await assertNoSymlinkComponents(io.filesystem, temp);
+                const reservedStat = await reservationHandle!.stat();
+                const pathStat = await lstatIfPresent(io.filesystem, temp);
+                if (
+                    !pathStat
+                    || !pathStat.isFile()
+                    || pathStat.dev !== reservedStat.dev
+                    || pathStat.ino !== reservedStat.ino
+                ) {
+                    throw new DatabaseOperationError('upstream_unavailable', 'Database file operation failed.');
+                }
+                await reservationHandle!.close();
+                reservationHandle = undefined;
+                await io.filesystem.unlink(temp);
+                ownsTemp = false;
+            }
+
+            let client: DatabaseClient;
             try {
                 client = createClient({
                     url: pathToFileURL(temp).href,
@@ -992,19 +1010,29 @@ export async function databasePullWithConfig(
                     authToken: access.token,
                     intMode: 'string',
                 }) as DatabaseClient;
+            } catch {
+                throw new DatabaseOperationError('upstream_unavailable', 'Database file operation failed.');
+            }
+
+            let attemptFailed = false;
+            try {
                 if (typeof client.sync !== 'function') throw new Error('Database sync is unavailable.');
                 await client.sync();
             } catch {
                 attemptFailed = true;
             } finally {
-                if (client) {
-                    try {
-                        await client.close();
-                    } catch {
-                        attemptFailed = true;
-                    }
+                try {
+                    await client.close();
+                } catch {
+                    attemptFailed = true;
                 }
             }
+
+            const replicaStat = await lstatIfPresent(io.filesystem, temp);
+            if (!replicaStat || replicaStat.isSymbolicLink() || !replicaStat.isFile()) {
+                throw new DatabaseOperationError('upstream_unavailable', 'Database file operation failed.');
+            }
+            ownsTemp = true;
 
             if (!attemptFailed) {
                 synced = true;
@@ -1030,11 +1058,18 @@ export async function databasePullWithConfig(
         ownsSidecars = false;
         io.stdout(`Database replica saved to ${displayDestination(io, target)}.`);
     } catch (error) {
-        if (ownsTemp && temp) {
-            await removeOwnedFiles(
-                io.filesystem,
-                [temp, ...(ownsSidecars ? pullSidecars(temp) : [])],
-            );
+        if (reservationHandle) {
+            try {
+                await reservationHandle.close();
+            } catch {
+                // Cleanup below remains scoped to the exclusively reserved path.
+            }
+        }
+        if (temp) {
+            await removeOwnedFiles(io.filesystem, [
+                ...(ownsTemp ? [temp] : []),
+                ...(ownsSidecars ? pullSidecars(temp) : []),
+            ]);
         }
         throw freshSafeFileError(error);
     }

--- a/src/commands/database.ts
+++ b/src/commands/database.ts
@@ -19,6 +19,7 @@ import {
     withDatabaseClient,
 } from '../utils/database-data-plane';
 import { loadDatabaseClientBeforeMint } from '../utils/database-client-support';
+export { parseDatabaseImportSql } from '../utils/database-sql-import';
 import { renderTable } from '../utils/table';
 
 export interface DatabaseRecord {

--- a/src/commands/database.ts
+++ b/src/commands/database.ts
@@ -92,6 +92,9 @@ export interface DatabaseCommandDependencies extends DatabaseClientDependencies 
     cwd?: string;
     tempPath?: (target: string) => string;
     filesystem?: DatabaseFileSystem;
+    input?: AsyncIterable<string>;
+    now?: () => number;
+    abortSignal?: AbortSignal;
 }
 
 interface ResolvedCommandDependencies {
@@ -105,6 +108,9 @@ interface ResolvedCommandDependencies {
     cwd: string;
     tempPath: (target: string) => string;
     filesystem: DatabaseFileSystem;
+    input?: AsyncIterable<string>;
+    now: () => number;
+    abortSignal?: AbortSignal;
 }
 
 function defaultConfirmation(message: string): Promise<boolean> {
@@ -148,6 +154,9 @@ function resolveDependencies(dependencies: DatabaseCommandDependencies): Resolve
             `.${path.basename(target)}.solidactions-${randomUUID()}.tmp`,
         )),
         filesystem: dependencies.filesystem ?? fs.promises,
+        input: dependencies.input,
+        now: dependencies.now ?? Date.now,
+        abortSignal: dependencies.abortSignal,
     };
 }
 
@@ -701,6 +710,268 @@ function validateCheckpointResult(result: DatabaseResultSet): void {
     }
 }
 
+const WRITABLE_RENEWAL_WINDOW_MS = 30_000;
+const WRITABLE_WARNING = 'Writable live session: writes go to the live workspace database.';
+const WRITABLE_PROMPT = 'solidactions-db> ';
+const WRITABLE_CONTINUATION_PROMPT = '...> ';
+
+interface AccumulatedSql {
+    sql: string;
+    multiple: boolean;
+}
+
+/**
+ * A deliberately small SQLite statement accumulator. Task 8 needs quoted
+ * string awareness and transaction grouping; Task 9 extends this scanner for
+ * comments, quoted identifiers, and trigger bodies before it is reused for
+ * imports.
+ */
+class SqliteStatementAccumulator {
+    private lines: string[] = [];
+
+    get pending(): boolean {
+        return this.lines.some((line) => line.trim() !== '');
+    }
+
+    push(line: string): AccumulatedSql | null {
+        if (!this.pending && line.trim() === '') return null;
+        this.lines.push(line);
+        const sql = this.lines.join('\n');
+        const segments: string[] = [];
+        let inSingleQuote = false;
+        let segmentStart = 0;
+
+        for (let index = 0; index < sql.length; index += 1) {
+            if (sql[index] === "'") {
+                if (inSingleQuote && sql[index + 1] === "'") {
+                    index += 1;
+                    continue;
+                }
+                inSingleQuote = !inSingleQuote;
+                continue;
+            }
+
+            if (!inSingleQuote && sql[index] === ';') {
+                segments.push(sql.slice(segmentStart, index + 1));
+                segmentStart = index + 1;
+            }
+        }
+
+        if (inSingleQuote || sql.slice(segmentStart).trim() !== '' || segments.length === 0) {
+            return null;
+        }
+
+        const keyword = (statement: string): string => statement
+            .trim()
+            .replace(/;$/, '')
+            .trim()
+            .split(/\s+/, 1)[0]
+            ?.toUpperCase() ?? '';
+        const explicitTransaction = keyword(segments[0]) === 'BEGIN';
+        if (explicitTransaction && !['COMMIT', 'END', 'ROLLBACK'].includes(keyword(segments[segments.length - 1]))) {
+            return null;
+        }
+
+        this.lines = [];
+        return {
+            sql,
+            multiple: explicitTransaction || segments.length > 1,
+        };
+    }
+}
+
+interface WritableInputSession {
+    iterator: AsyncIterator<string>;
+    prompt: (pending: boolean) => void;
+    interrupted: () => boolean;
+    close: () => Promise<void>;
+}
+
+function createWritableInput(io: ResolvedCommandDependencies): WritableInputSession {
+    if (io.input) {
+        const iterator = io.input[Symbol.asyncIterator]();
+        return {
+            iterator,
+            prompt: () => undefined,
+            interrupted: () => false,
+            close: async () => {
+                await iterator.return?.();
+            },
+        };
+    }
+
+    const input = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout,
+        terminal: io.isTTY,
+    });
+    let interrupted = false;
+    const onSigint = () => {
+        interrupted = true;
+        input.close();
+    };
+    input.on('SIGINT', onSigint);
+    const iterator = input[Symbol.asyncIterator]();
+
+    return {
+        iterator,
+        prompt: (pending) => {
+            if (!io.isTTY) return;
+            input.setPrompt(pending ? WRITABLE_CONTINUATION_PROMPT : WRITABLE_PROMPT);
+            input.prompt();
+        },
+        interrupted: () => interrupted,
+        close: async () => {
+            input.off('SIGINT', onSigint);
+            input.close();
+        },
+    };
+}
+
+async function nextWritableInput(
+    iterator: AsyncIterator<string>,
+    signal: AbortSignal | undefined,
+): Promise<IteratorResult<string>> {
+    if (!signal) return iterator.next();
+    if (signal.aborted) return { done: true, value: undefined };
+
+    return new Promise((resolve, reject) => {
+        let settled = false;
+        const finish = (result: IteratorResult<string>) => {
+            if (settled) return;
+            settled = true;
+            signal.removeEventListener('abort', onAbort);
+            resolve(result);
+        };
+        const onAbort = () => finish({ done: true, value: undefined });
+        signal.addEventListener('abort', onAbort, { once: true });
+        iterator.next().then(finish, (error) => {
+            if (settled) return;
+            settled = true;
+            signal.removeEventListener('abort', onAbort);
+            reject(error);
+        });
+    });
+}
+
+function validateWritableAccess(access: unknown, now: number): {
+    url: string;
+    token: string;
+    expiresAt: number;
+} {
+    const value = access as Record<string, unknown> | null;
+    const url = typeof value?.url === 'string' ? value.url.trim() : '';
+    const token = typeof value?.token === 'string' ? value.token.trim() : '';
+    const expiresAt = typeof value?.expires_at === 'string' ? Date.parse(value.expires_at) : Number.NaN;
+    if (
+        value?.mode !== 'write'
+        || url === ''
+        || token === ''
+        || !Number.isFinite(now)
+        || !Number.isFinite(expiresAt)
+        || expiresAt <= now + WRITABLE_RENEWAL_WINDOW_MS
+    ) {
+        throw new DatabaseOperationError('upstream_unavailable', 'The database access response was invalid.');
+    }
+
+    return { url, token, expiresAt };
+}
+
+class WritableRenewalAttemptError extends Error {
+    readonly publicError: DatabaseOperationError;
+    readonly publishLastValid: boolean;
+
+    constructor(error: DatabaseOperationError, publishLastValid: boolean) {
+        super(error.message);
+        this.publicError = error;
+        this.publishLastValid = publishLastValid;
+        delete this.stack;
+    }
+}
+
+function isAuthenticationExpired(error: unknown): boolean {
+    const value = error as { code?: unknown; message?: unknown } | null;
+    const code = typeof value?.code === 'string' ? value.code.toUpperCase() : '';
+    const message = typeof value?.message === 'string' ? value.message : '';
+    if (['AUTH_TOKEN_EXPIRED', 'AUTH_EXPIRED', 'TOKEN_EXPIRED'].includes(code)) return true;
+    return code === 'SQLITE_AUTH' && /expired|expiration|\bjwt\b/i.test(message);
+}
+
+async function handoffReplicaReservation(
+    io: ResolvedCommandDependencies,
+    temp: string,
+    handle: Awaited<ReturnType<DatabaseFileSystem['open']>>,
+): Promise<void> {
+    await assertNoSymlinkComponents(io.filesystem, temp);
+    const reservedStat = await handle.stat();
+    const pathStat = await lstatIfPresent(io.filesystem, temp);
+    if (
+        !pathStat
+        || !pathStat.isFile()
+        || pathStat.dev !== reservedStat.dev
+        || pathStat.ino !== reservedStat.ino
+    ) {
+        throw new DatabaseOperationError('upstream_unavailable', 'Database file operation failed.');
+    }
+    await handle.close();
+    await io.filesystem.unlink(temp);
+}
+
+async function finalizeReplica(
+    io: ResolvedCommandDependencies,
+    temp: string,
+    target: string,
+    createClient: (config: Record<string, unknown>) => DatabaseClient,
+): Promise<void> {
+    const assertOwnedMainFile = async () => {
+        await assertNoSymlinkComponents(io.filesystem, temp);
+        const stat = await lstatIfPresent(io.filesystem, temp);
+        if (!stat || stat.isSymbolicLink() || !stat.isFile()) {
+            throw new DatabaseOperationError(
+                'unsafe_destination',
+                'The database replica temporary path is unsafe.',
+            );
+        }
+    };
+
+    await assertOwnedMainFile();
+    let finalizer: DatabaseClient | undefined;
+    let checkpointResult: DatabaseResultSet | undefined;
+    let finalizationFailed = false;
+    try {
+        finalizer = createClient({
+            url: pathToFileURL(temp).href,
+            intMode: 'string',
+        });
+        checkpointResult = await finalizer.execute('PRAGMA wal_checkpoint(TRUNCATE)');
+    } catch {
+        finalizationFailed = true;
+    } finally {
+        if (finalizer) {
+            try {
+                await finalizer.close();
+            } catch {
+                finalizationFailed = true;
+            }
+        }
+    }
+
+    if (finalizationFailed || !checkpointResult) {
+        throw new DatabaseOperationError('upstream_unavailable', 'Database file operation failed.');
+    }
+    validateCheckpointResult(checkpointResult);
+    await assertOwnedMainFile();
+
+    await removeOwnedFiles(io.filesystem, pullSidecars(temp));
+    if (await anyPathExists(io.filesystem, pullSidecars(temp))) {
+        throw new DatabaseOperationError('upstream_unavailable', 'Database file operation failed.');
+    }
+
+    await io.filesystem.chmod(temp, 0o444);
+    await assertNoSymlinkComponents(io.filesystem, target);
+    await io.filesystem.rename(temp, target);
+}
+
 export async function databaseListWithConfig(
     options: DatabaseListOptions,
     config: Config,
@@ -960,6 +1231,282 @@ export async function databaseDumpWithConfig(
     }
 }
 
+async function databaseWritablePullWithConfig(
+    name: string,
+    destination: string | undefined,
+    options: DatabasePullOptions,
+    config: Config,
+    io: ResolvedCommandDependencies,
+): Promise<void> {
+    const target = resolveDatabaseDestination(
+        io,
+        destination,
+        path.join('.solidactions', 'databases', `${safeDatabaseStem(name)}.db`),
+    );
+    let temp: string | undefined;
+    let reservationHandle: Awaited<ReturnType<DatabaseFileSystem['open']>> | undefined;
+    let ownsTemp = false;
+    let ownsSidecars = false;
+    let client: DatabaseClient | undefined;
+    let localCreateClient: ((config: Record<string, unknown>) => DatabaseClient) | undefined;
+    let expiresAt = 0;
+    let inputSession: WritableInputSession | undefined;
+
+    const closeAttachedClient = async (): Promise<void> => {
+        if (!client) return;
+        const closing = client;
+        client = undefined;
+        try {
+            await closing.close();
+        } catch {
+            throw new DatabaseOperationError('upstream_unavailable', 'Database file operation failed.');
+        }
+    };
+
+    const openAttachedClient = async (initial: boolean): Promise<void> => {
+        let loaded: Awaited<ReturnType<typeof loadDatabaseClientBeforeMint>>;
+        try {
+            loaded = await loadDatabaseClientBeforeMint(
+                () => requestDatabaseAccess(config, name, 'write', requestDependencies(io)),
+                { loadClient: io.loadClient },
+            );
+        } catch (error) {
+            const safeError = freshSafeFileError(error);
+            if (!initial && error instanceof DatabaseOperationError) {
+                throw new WritableRenewalAttemptError(safeError, true);
+            }
+            throw safeError;
+        }
+        const access = validateWritableAccess(loaded.access, io.now());
+        const createClient = loaded.createClient as (config: Record<string, unknown>) => DatabaseClient;
+
+        if (initial) {
+            await handoffReplicaReservation(io, temp!, reservationHandle!);
+            reservationHandle = undefined;
+            ownsTemp = false;
+        }
+
+        await assertNoSymlinkComponents(io.filesystem, temp!);
+        const beforeCreate = await lstatIfPresent(io.filesystem, temp!);
+        if (
+            (initial && beforeCreate !== null)
+            || (!initial && (!beforeCreate || beforeCreate.isSymbolicLink() || !beforeCreate.isFile()))
+        ) {
+            throw new DatabaseOperationError(
+                'unsafe_destination',
+                'The database replica temporary path is unsafe.',
+            );
+        }
+
+        let opened: DatabaseClient;
+        try {
+            opened = createClient({
+                url: pathToFileURL(temp!).href,
+                syncUrl: access.url,
+                authToken: access.token,
+                intMode: 'string',
+                readYourWrites: true,
+                offline: false,
+            });
+        } catch {
+            const createdStat = await lstatIfPresent(io.filesystem, temp!);
+            if (createdStat?.isFile() && !createdStat.isSymbolicLink()) ownsTemp = true;
+            throw new DatabaseOperationError('upstream_unavailable', 'Database file operation failed.');
+        }
+
+        let syncFailed = false;
+        try {
+            if (typeof opened.sync !== 'function') throw new Error('Database sync is unavailable.');
+            await opened.sync();
+        } catch {
+            syncFailed = true;
+        }
+
+        const replicaStat = await lstatIfPresent(io.filesystem, temp!);
+        if (replicaStat?.isFile() && !replicaStat.isSymbolicLink()) ownsTemp = true;
+        if (
+            syncFailed
+            || !replicaStat
+            || replicaStat.isSymbolicLink()
+            || !replicaStat.isFile()
+        ) {
+            try {
+                await opened.close();
+            } catch {
+                // The stable setup error below takes precedence.
+            }
+            throw new DatabaseOperationError('upstream_unavailable', 'Database file operation failed.');
+        }
+
+        client = opened;
+        localCreateClient = createClient;
+        expiresAt = access.expiresAt;
+    };
+
+    try {
+        if (!await confirmFileOverwrite(target, options, io)) return;
+
+        const reservation = await reserveDestinationTemp(io, target);
+        temp = reservation.temp;
+        reservationHandle = reservation.handle;
+        ownsTemp = true;
+        if (await anyPathExists(io.filesystem, pullSidecars(temp))) {
+            throw new DatabaseOperationError(
+                'upstream_unavailable',
+                'Database replica temporary files already exist.',
+            );
+        }
+        ownsSidecars = true;
+
+        await openAttachedClient(true);
+        io.stdout(WRITABLE_WARNING);
+        inputSession = createWritableInput(io);
+        const accumulator = new SqliteStatementAccumulator();
+        let sessionFailure: unknown;
+        let publishAfterFailure = false;
+
+        try {
+            while (true) {
+                if (io.abortSignal?.aborted || inputSession.interrupted()) break;
+
+                if (io.now() >= expiresAt - WRITABLE_RENEWAL_WINDOW_MS) {
+                    try {
+                        await closeAttachedClient();
+                        await openAttachedClient(false);
+                    } catch (error) {
+                        sessionFailure = error instanceof WritableRenewalAttemptError
+                            ? error.publicError
+                            : error;
+                        publishAfterFailure = error instanceof WritableRenewalAttemptError
+                            && error.publishLastValid;
+                        break;
+                    }
+                }
+
+                inputSession.prompt(accumulator.pending);
+                const next = await nextWritableInput(inputSession.iterator, io.abortSignal);
+                if (io.abortSignal?.aborted || inputSession.interrupted()) break;
+                if (next.done) {
+                    if (accumulator.pending) {
+                        sessionFailure = new DatabaseOperationError(
+                            'incomplete_sql',
+                            'The SQL input is incomplete.',
+                        );
+                    }
+                    break;
+                }
+
+                if (next.value.trim() === '.exit') {
+                    if (accumulator.pending) {
+                        sessionFailure = new DatabaseOperationError(
+                            'incomplete_sql',
+                            'The SQL input is incomplete.',
+                        );
+                    }
+                    break;
+                }
+
+                const statement = accumulator.push(next.value);
+                if (!statement) continue;
+
+                try {
+                    if (statement.multiple) {
+                        if (typeof client?.executeMultiple !== 'function') {
+                            throw new Error('Multiple SQL execution is unavailable.');
+                        }
+                        await client.executeMultiple(statement.sql);
+                        io.stdout('Transaction group executed successfully.');
+                    } else {
+                        const result = stableDirectResult(await client!.execute(statement.sql));
+                        io.stdout(
+                            result.columns.length > 0
+                                ? renderDirectTable(result)
+                                : `Rows affected: ${result.rowsAffected}`,
+                        );
+                    }
+                } catch (error) {
+                    if (!isAuthenticationExpired(error)) {
+                        io.stderr('Database statement failed.');
+                        continue;
+                    }
+
+                    io.stderr('Database statement has an unknown outcome because authorization expired.');
+                    try {
+                        await closeAttachedClient();
+                        await openAttachedClient(false);
+                    } catch (renewalError) {
+                        sessionFailure = renewalError instanceof WritableRenewalAttemptError
+                            ? renewalError.publicError
+                            : renewalError;
+                        publishAfterFailure = renewalError instanceof WritableRenewalAttemptError
+                            && renewalError.publishLastValid;
+                        break;
+                    }
+                }
+            }
+        } catch (error) {
+            sessionFailure = error;
+        } finally {
+            if (inputSession) {
+                try {
+                    await inputSession.close();
+                } catch {
+                    if (!sessionFailure) {
+                        sessionFailure = new DatabaseOperationError(
+                            'upstream_unavailable',
+                            'Database file operation failed.',
+                        );
+                    }
+                }
+                inputSession = undefined;
+            }
+            try {
+                await closeAttachedClient();
+            } catch (error) {
+                if (!sessionFailure) sessionFailure = error;
+                publishAfterFailure = false;
+            }
+        }
+
+        if (sessionFailure && !publishAfterFailure) throw sessionFailure;
+
+        await finalizeReplica(io, temp, target, localCreateClient!);
+        ownsTemp = false;
+        ownsSidecars = false;
+        if (sessionFailure) throw sessionFailure;
+        io.stdout(`Database replica saved to ${displayDestination(io, target)}.`);
+    } catch (error) {
+        if (inputSession) {
+            try {
+                await inputSession.close();
+            } catch {
+                // Cleanup remains scoped to this invocation's input session.
+            }
+        }
+        if (client) {
+            try {
+                await client.close();
+            } catch {
+                // Cleanup below remains scoped to this invocation's replica.
+            }
+        }
+        if (reservationHandle) {
+            try {
+                await reservationHandle.close();
+            } catch {
+                // Cleanup below remains scoped to the exclusively reserved path.
+            }
+        }
+        if (temp) {
+            await removeOwnedFiles(io.filesystem, [
+                ...(ownsTemp ? [temp] : []),
+                ...(ownsSidecars ? pullSidecars(temp) : []),
+            ]);
+        }
+        throw freshSafeFileError(error);
+    }
+}
+
 export async function databasePullWithConfig(
     name: string,
     destination: string | undefined,
@@ -969,10 +1516,7 @@ export async function databasePullWithConfig(
 ): Promise<void> {
     const io = resolveDependencies(dependencies);
     if (options.writable) {
-        throw new DatabaseOperationError(
-            'database_client_unsupported',
-            'Writable database pull is not available yet.',
-        );
+        return databaseWritablePullWithConfig(name, destination, options, config, io);
     }
 
     const target = resolveDatabaseDestination(
@@ -1073,41 +1617,7 @@ export async function databasePullWithConfig(
             throw new DatabaseOperationError('upstream_unavailable', 'Database file operation failed.');
         }
 
-        let finalizer: DatabaseClient | undefined;
-        let checkpointResult: DatabaseResultSet | undefined;
-        let finalizationFailed = false;
-        try {
-            finalizer = localCreateClient!({
-                url: pathToFileURL(temp).href,
-                intMode: 'string',
-            });
-            checkpointResult = await finalizer.execute('PRAGMA wal_checkpoint(TRUNCATE)');
-        } catch {
-            finalizationFailed = true;
-        } finally {
-            if (finalizer) {
-                try {
-                    await finalizer.close();
-                } catch {
-                    finalizationFailed = true;
-                }
-            }
-        }
-
-        if (finalizationFailed || !checkpointResult) {
-            throw new DatabaseOperationError('upstream_unavailable', 'Database file operation failed.');
-        }
-        validateCheckpointResult(checkpointResult);
-
-        await removeOwnedFiles(io.filesystem, pullSidecars(temp));
-        if (await anyPathExists(io.filesystem, pullSidecars(temp))) {
-            throw new DatabaseOperationError('upstream_unavailable', 'Database file operation failed.');
-        }
-        ownsSidecars = false;
-
-        await io.filesystem.chmod(temp, 0o444);
-        await assertNoSymlinkComponents(io.filesystem, target);
-        await io.filesystem.rename(temp, target);
+        await finalizeReplica(io, temp, target, localCreateClient!);
         ownsTemp = false;
         ownsSidecars = false;
         io.stdout(`Database replica saved to ${displayDestination(io, target)}.`);

--- a/src/commands/database.ts
+++ b/src/commands/database.ts
@@ -2,9 +2,15 @@ import * as readline from 'readline';
 import { requireConfigWithWorkspace } from '../utils/api';
 import { Config } from '../utils/config';
 import {
+    DatabaseClient,
+    DatabaseClientDependencies,
     DatabaseOperationError,
     DatabaseRequestDependencies,
+    DatabaseResultSet,
+    formatDatabaseTableValue,
+    normalizeDatabaseValue,
     requestDatabaseOperation,
+    withDatabaseClient,
 } from '../utils/database-data-plane';
 import { renderTable } from '../utils/table';
 
@@ -46,7 +52,20 @@ interface DatabaseUndeleteOptions {
     json?: boolean;
 }
 
-export interface DatabaseCommandDependencies extends DatabaseRequestDependencies {
+interface DatabaseSchemaOptions {
+    json?: boolean;
+}
+
+interface DatabaseQueryOptions {
+    json?: boolean;
+}
+
+interface DatabaseExecOptions {
+    yes?: boolean;
+    json?: boolean;
+}
+
+export interface DatabaseCommandDependencies extends DatabaseClientDependencies {
     stdout?: (line: string) => void;
     stderr?: (line: string) => void;
     confirm?: (message: string) => Promise<boolean | undefined>;
@@ -61,6 +80,7 @@ interface ResolvedCommandDependencies {
     isTTY: boolean;
     importDatabase: (name: string, file: string) => Promise<void>;
     post: DatabaseCommandDependencies['post'];
+    loadClient: DatabaseCommandDependencies['loadClient'];
 }
 
 function defaultConfirmation(message: string): Promise<boolean> {
@@ -97,11 +117,19 @@ function resolveDependencies(dependencies: DatabaseCommandDependencies): Resolve
         isTTY: dependencies.isTTY ?? process.stdin.isTTY === true,
         importDatabase: dependencies.importDatabase ?? unavailableImportHandoff,
         post: dependencies.post,
+        loadClient: dependencies.loadClient,
     };
 }
 
 function requestDependencies(dependencies: ResolvedCommandDependencies): DatabaseRequestDependencies {
     return { post: dependencies.post };
+}
+
+function clientDependencies(dependencies: ResolvedCommandDependencies): DatabaseClientDependencies {
+    return {
+        post: dependencies.post,
+        loadClient: dependencies.loadClient,
+    };
 }
 
 function stableDatabaseRecord(database: DatabaseRecord | null | undefined): DatabaseRecord {
@@ -180,6 +208,241 @@ function renderMutation(
 
 function writeJson(stdout: (line: string) => void, data: unknown): void {
     stdout(JSON.stringify(data, null, 2));
+}
+
+interface StableDirectResult {
+    columns: string[];
+    rows: unknown[][];
+    rowsAffected: number;
+    lastInsertRowid: unknown;
+}
+
+interface DatabaseSchemaColumn {
+    name: string;
+    type: string;
+    notnull: boolean;
+    default: unknown;
+    pk: number;
+}
+
+interface DatabaseSchemaIndex {
+    name: string;
+    sql: string | null;
+}
+
+interface DatabaseSchemaTable {
+    name: string;
+    sql: string;
+    columns: DatabaseSchemaColumn[];
+    indexes: DatabaseSchemaIndex[];
+}
+
+interface DatabaseSchemaResponse {
+    database: string;
+    tables: DatabaseSchemaTable[];
+}
+
+const TABLE_CATALOG_SQL = "SELECT name, sql FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' AND sql IS NOT NULL ORDER BY name";
+const INDEX_CATALOG_SQL = "SELECT name, tbl_name, sql FROM sqlite_master WHERE type = 'index' AND name NOT LIKE 'sqlite_%' ORDER BY name";
+
+function isDirectValue(value: unknown): boolean {
+    return value === null
+        || typeof value === 'string'
+        || (typeof value === 'number' && Number.isFinite(value))
+        || typeof value === 'bigint'
+        || value instanceof ArrayBuffer
+        || ArrayBuffer.isView(value);
+}
+
+function stableLastInsertRowid(value: unknown): string | number | bigint | null {
+    if (value === undefined || value === null) {
+        return null;
+    }
+
+    if (typeof value === 'bigint') {
+        return value;
+    }
+
+    if (typeof value === 'number' && Number.isSafeInteger(value)) {
+        return value;
+    }
+
+    if (typeof value === 'string' && /^-?\d+$/.test(value)) {
+        return value;
+    }
+
+    throw new Error('Invalid last insert row ID.');
+}
+
+function stableDirectResult(result: DatabaseResultSet): StableDirectResult {
+    if (!result || !Array.isArray(result.columns) || !Array.isArray(result.rows)) {
+        throw new Error('Invalid database result.');
+    }
+
+    if (!result.columns.every((column) => typeof column === 'string')) {
+        throw new Error('Invalid database result columns.');
+    }
+
+    const rows = result.rows.map((row) => {
+        if (
+            row === null
+            || typeof row !== 'object'
+            || !Number.isSafeInteger(row.length)
+            || row.length !== result.columns.length
+        ) {
+            throw new Error('Invalid database result row.');
+        }
+
+        const positional = Array.from({ length: row.length }, (_, index) => row[index]);
+        if (!positional.every(isDirectValue)) {
+            throw new Error('Invalid database result value.');
+        }
+
+        return positional;
+    });
+
+    if (
+        result.rowsAffected !== undefined
+        && (!Number.isSafeInteger(result.rowsAffected) || result.rowsAffected < 0)
+    ) {
+        throw new Error('Invalid affected row count.');
+    }
+
+    return {
+        columns: [...result.columns],
+        rows,
+        rowsAffected: result.rowsAffected ?? 0,
+        lastInsertRowid: stableLastInsertRowid(result.lastInsertRowid),
+    };
+}
+
+function sqliteInteger(value: unknown): number {
+    if (
+        (typeof value !== 'string' && typeof value !== 'number' && typeof value !== 'bigint')
+        || String(value).trim() === ''
+    ) {
+        throw new Error('Invalid SQLite integer.');
+    }
+
+    const parsed = Number(value);
+    if (!Number.isSafeInteger(parsed) || parsed < 0) {
+        throw new Error('Invalid SQLite integer.');
+    }
+
+    return parsed;
+}
+
+function sqliteBoolean(value: unknown): boolean {
+    const parsed = sqliteInteger(value);
+    if (parsed !== 0 && parsed !== 1) {
+        throw new Error('Invalid SQLite boolean.');
+    }
+
+    return parsed === 1;
+}
+
+function requiredString(value: unknown): string {
+    if (typeof value !== 'string') {
+        throw new Error('Invalid database metadata.');
+    }
+
+    return value;
+}
+
+function nullableString(value: unknown): string | null {
+    if (value === null || typeof value === 'string') {
+        return value;
+    }
+
+    throw new Error('Invalid database metadata.');
+}
+
+function quotePragmaIdentifier(identifier: string): string {
+    return `"${identifier.replace(/"/g, '""')}"`;
+}
+
+function normalizedRows(result: StableDirectResult): unknown[][] {
+    return result.rows.map((row) => row.map(normalizeDatabaseValue));
+}
+
+function renderDirectTable(result: StableDirectResult): string {
+    return renderTable(
+        result.columns,
+        result.rows.map((row) => row.map(formatDatabaseTableValue)),
+    ).join('\n');
+}
+
+async function readDatabaseSchema(client: DatabaseClient, database: string): Promise<DatabaseSchemaResponse> {
+    const tablesResult = stableDirectResult(await client.execute(TABLE_CATALOG_SQL));
+    const indexesResult = stableDirectResult(await client.execute(INDEX_CATALOG_SQL));
+    const indexesByTable = new Map<string, DatabaseSchemaIndex[]>();
+
+    for (const row of indexesResult.rows) {
+        const index: DatabaseSchemaIndex = {
+            name: requiredString(row[0]),
+            sql: nullableString(row[2]),
+        };
+        const tableName = requiredString(row[1]);
+        indexesByTable.set(tableName, [...(indexesByTable.get(tableName) ?? []), index]);
+    }
+
+    const tables: DatabaseSchemaTable[] = [];
+    for (const row of tablesResult.rows) {
+        const name = requiredString(row[0]);
+        const pragma = `PRAGMA table_info(${quotePragmaIdentifier(name)})`;
+        const columnsResult = stableDirectResult(await client.execute(pragma));
+        const columns = columnsResult.rows.map((column): DatabaseSchemaColumn => ({
+            name: requiredString(column[1]),
+            type: requiredString(column[2]),
+            notnull: sqliteBoolean(column[3]),
+            default: normalizeDatabaseValue(column[4]),
+            pk: sqliteInteger(column[5]),
+        }));
+
+        tables.push({
+            name,
+            sql: requiredString(row[1]),
+            columns,
+            indexes: indexesByTable.get(name) ?? [],
+        });
+    }
+
+    return { database, tables };
+}
+
+function renderSchema(schema: DatabaseSchemaResponse): string {
+    if (schema.tables.length === 0) {
+        return `Database: ${schema.database}\nNo tables.`;
+    }
+
+    const sections = [`Database: ${schema.database}`];
+    for (const table of schema.tables) {
+        sections.push(
+            `Table: ${table.name}`,
+            renderTable(
+                ['NAME', 'TYPE', 'NOT NULL', 'DEFAULT', 'PK ORDER'],
+                table.columns.map((column) => [
+                    column.name,
+                    column.type,
+                    column.notnull ? 'yes' : 'no',
+                    formatDatabaseTableValue(column.default),
+                    String(column.pk),
+                ]),
+            ).join('\n'),
+        );
+
+        if (table.indexes.length > 0) {
+            sections.push(
+                'Indexes:',
+                renderTable(
+                    ['NAME', 'SQL'],
+                    table.indexes.map((index) => [index.name, index.sql ?? 'NULL']),
+                ).join('\n'),
+            );
+        }
+    }
+
+    return sections.join('\n\n');
 }
 
 export async function databaseListWithConfig(
@@ -291,6 +554,106 @@ export async function databaseUndeleteWithConfig(
     io.stdout(renderMutation('undelete', data.database));
 }
 
+export async function databaseSchemaWithConfig(
+    name: string,
+    options: DatabaseSchemaOptions,
+    config: Config,
+    dependencies: DatabaseCommandDependencies = {},
+): Promise<void> {
+    const io = resolveDependencies(dependencies);
+    const schema = await withDatabaseClient(
+        config,
+        name,
+        'read',
+        (client) => readDatabaseSchema(client, name),
+        clientDependencies(io),
+    );
+
+    if (options.json) {
+        writeJson(io.stdout, schema);
+        return;
+    }
+
+    io.stdout(renderSchema(schema));
+}
+
+export async function databaseQueryWithConfig(
+    name: string,
+    sql: string,
+    options: DatabaseQueryOptions,
+    config: Config,
+    dependencies: DatabaseCommandDependencies = {},
+): Promise<void> {
+    const io = resolveDependencies(dependencies);
+    const result = await withDatabaseClient(
+        config,
+        name,
+        'read',
+        async (client) => stableDirectResult(await client.execute(sql)),
+        clientDependencies(io),
+    );
+
+    if (options.json) {
+        writeJson(io.stdout, {
+            columns: result.columns,
+            rows: normalizedRows(result),
+            row_count: result.rows.length,
+        });
+        return;
+    }
+
+    io.stdout(result.columns.length > 0 ? renderDirectTable(result) : 'No rows returned.');
+}
+
+export async function databaseExecWithConfig(
+    name: string,
+    sql: string,
+    options: DatabaseExecOptions,
+    config: Config,
+    dependencies: DatabaseCommandDependencies = {},
+): Promise<void> {
+    const io = resolveDependencies(dependencies);
+
+    if (!options.yes) {
+        if (options.json || !io.isTTY) {
+            throw new DatabaseOperationError(
+                'confirmation_required',
+                'Database execution requires --yes in JSON or non-interactive mode.',
+            );
+        }
+
+        if (!await io.confirm(`Execute SQL against database "${name}"?`)) {
+            io.stdout('Cancelled.');
+            return;
+        }
+    }
+
+    const result = await withDatabaseClient(
+        config,
+        name,
+        'write',
+        async (client) => stableDirectResult(await client.execute(sql)),
+        clientDependencies(io),
+    );
+
+    if (options.json) {
+        writeJson(io.stdout, {
+            columns: result.columns,
+            rows: normalizedRows(result),
+            row_count: result.rows.length,
+            rows_affected: result.rowsAffected,
+            last_insert_rowid: normalizeDatabaseValue(result.lastInsertRowid),
+        });
+        return;
+    }
+
+    const output = [`Rows affected: ${result.rowsAffected}`];
+    if (result.rows.length > 0 && result.columns.length > 0) {
+        output.push(renderDirectTable(result));
+    }
+    io.stdout(output.join('\n'));
+}
+
 export async function databaseList(
     options: DatabaseListOptions,
     dependencies: DatabaseCommandDependencies = {},
@@ -320,4 +683,30 @@ export async function databaseUndelete(
     dependencies: DatabaseCommandDependencies = {},
 ): Promise<void> {
     await databaseUndeleteWithConfig(name, options, await requireConfigWithWorkspace(), dependencies);
+}
+
+export async function databaseSchema(
+    name: string,
+    options: DatabaseSchemaOptions,
+    dependencies: DatabaseCommandDependencies = {},
+): Promise<void> {
+    await databaseSchemaWithConfig(name, options, await requireConfigWithWorkspace(), dependencies);
+}
+
+export async function databaseQuery(
+    name: string,
+    sql: string,
+    options: DatabaseQueryOptions,
+    dependencies: DatabaseCommandDependencies = {},
+): Promise<void> {
+    await databaseQueryWithConfig(name, sql, options, await requireConfigWithWorkspace(), dependencies);
+}
+
+export async function databaseExec(
+    name: string,
+    sql: string,
+    options: DatabaseExecOptions,
+    dependencies: DatabaseCommandDependencies = {},
+): Promise<void> {
+    await databaseExecWithConfig(name, sql, options, await requireConfigWithWorkspace(), dependencies);
 }

--- a/src/commands/database.ts
+++ b/src/commands/database.ts
@@ -19,6 +19,7 @@ import {
     withDatabaseClient,
 } from '../utils/database-data-plane';
 import { loadDatabaseClientBeforeMint } from '../utils/database-client-support';
+import { DatabaseSqlStatementAccumulator } from '../utils/database-sql-import';
 export { parseDatabaseImportSql } from '../utils/database-sql-import';
 import {
     bindPreparedDatabaseImport,
@@ -720,71 +721,6 @@ const WRITABLE_WARNING = 'Writable live session: writes go to the live workspace
 const WRITABLE_PROMPT = 'solidactions-db> ';
 const WRITABLE_CONTINUATION_PROMPT = '...> ';
 
-interface AccumulatedSql {
-    sql: string;
-    multiple: boolean;
-}
-
-/**
- * A deliberately small SQLite statement accumulator. Task 8 needs quoted
- * string awareness and transaction grouping; Task 9 extends this scanner for
- * comments, quoted identifiers, and trigger bodies before it is reused for
- * imports.
- */
-class SqliteStatementAccumulator {
-    private lines: string[] = [];
-
-    get pending(): boolean {
-        return this.lines.some((line) => line.trim() !== '');
-    }
-
-    push(line: string): AccumulatedSql | null {
-        if (!this.pending && line.trim() === '') return null;
-        this.lines.push(line);
-        const sql = this.lines.join('\n');
-        const segments: string[] = [];
-        let inSingleQuote = false;
-        let segmentStart = 0;
-
-        for (let index = 0; index < sql.length; index += 1) {
-            if (sql[index] === "'") {
-                if (inSingleQuote && sql[index + 1] === "'") {
-                    index += 1;
-                    continue;
-                }
-                inSingleQuote = !inSingleQuote;
-                continue;
-            }
-
-            if (!inSingleQuote && sql[index] === ';') {
-                segments.push(sql.slice(segmentStart, index + 1));
-                segmentStart = index + 1;
-            }
-        }
-
-        if (inSingleQuote || sql.slice(segmentStart).trim() !== '' || segments.length === 0) {
-            return null;
-        }
-
-        const keyword = (statement: string): string => statement
-            .trim()
-            .replace(/;$/, '')
-            .trim()
-            .split(/\s+/, 1)[0]
-            ?.toUpperCase() ?? '';
-        const explicitTransaction = keyword(segments[0]) === 'BEGIN';
-        if (explicitTransaction && !['COMMIT', 'END', 'ROLLBACK'].includes(keyword(segments[segments.length - 1]))) {
-            return null;
-        }
-
-        this.lines = [];
-        return {
-            sql,
-            multiple: explicitTransaction || segments.length > 1,
-        };
-    }
-}
-
 interface WritableInputSession {
     iterator: AsyncIterator<string>;
     prompt: (pending: boolean) => void;
@@ -1446,7 +1382,7 @@ async function databaseWritablePullWithConfig(
         await openAttachedClient(true);
         io.stdout(WRITABLE_WARNING);
         inputSession = createWritableInput(io);
-        const accumulator = new SqliteStatementAccumulator();
+        const accumulator = new DatabaseSqlStatementAccumulator();
         let sessionFailure: unknown;
         let publishAfterFailure = false;
 

--- a/src/commands/database.ts
+++ b/src/commands/database.ts
@@ -1,0 +1,323 @@
+import * as readline from 'readline';
+import { requireConfigWithWorkspace } from '../utils/api';
+import { Config } from '../utils/config';
+import {
+    DatabaseOperationError,
+    DatabaseRequestDependencies,
+    requestDatabaseOperation,
+} from '../utils/database-data-plane';
+import { renderTable } from '../utils/table';
+
+export interface DatabaseRecord {
+    name: string;
+    status: string;
+    deleted_at: string | null;
+    purge_at: string | null;
+    size_bytes: number;
+}
+
+interface DatabaseListResponse {
+    databases: DatabaseRecord[];
+    quota: {
+        used: number;
+        limit: number;
+    };
+}
+
+interface DatabaseMutationResponse {
+    database: DatabaseRecord;
+}
+
+interface DatabaseListOptions {
+    json?: boolean;
+}
+
+interface DatabaseCreateOptions {
+    from?: string;
+    json?: boolean;
+}
+
+interface DatabaseDeleteOptions {
+    yes?: boolean;
+    json?: boolean;
+}
+
+interface DatabaseUndeleteOptions {
+    json?: boolean;
+}
+
+export interface DatabaseCommandDependencies extends DatabaseRequestDependencies {
+    stdout?: (line: string) => void;
+    stderr?: (line: string) => void;
+    confirm?: (message: string) => Promise<boolean | undefined>;
+    isTTY?: boolean;
+    importDatabase?: (name: string, file: string) => Promise<void>;
+}
+
+interface ResolvedCommandDependencies {
+    stdout: (line: string) => void;
+    stderr: (line: string) => void;
+    confirm: (message: string) => Promise<boolean>;
+    isTTY: boolean;
+    importDatabase: (name: string, file: string) => Promise<void>;
+    post: DatabaseCommandDependencies['post'];
+}
+
+function defaultConfirmation(message: string): Promise<boolean> {
+    const input = readline.createInterface({ input: process.stdin, output: process.stdout });
+
+    return new Promise((resolve) => {
+        let settled = false;
+        const finish = (confirmed: boolean) => {
+            if (settled) return;
+            settled = true;
+            resolve(confirmed);
+        };
+
+        input.once('close', () => finish(false));
+        input.question(`${message} [y/N] `, (answer) => {
+            finish(/^y(?:es)?$/i.test(answer.trim()));
+            input.close();
+        });
+    });
+}
+
+async function unavailableImportHandoff(name: string, _file: string): Promise<void> {
+    throw new DatabaseOperationError(
+        'import_failed',
+        `Database "${name}" was created, but SQL import is not available yet. The database remains in place.`,
+    );
+}
+
+function resolveDependencies(dependencies: DatabaseCommandDependencies): ResolvedCommandDependencies {
+    return {
+        stdout: dependencies.stdout ?? ((line) => console.log(line)),
+        stderr: dependencies.stderr ?? ((line) => console.error(line)),
+        confirm: async (message) => (await (dependencies.confirm ?? defaultConfirmation)(message)) === true,
+        isTTY: dependencies.isTTY ?? process.stdin.isTTY === true,
+        importDatabase: dependencies.importDatabase ?? unavailableImportHandoff,
+        post: dependencies.post,
+    };
+}
+
+function requestDependencies(dependencies: ResolvedCommandDependencies): DatabaseRequestDependencies {
+    return { post: dependencies.post };
+}
+
+function stableDatabaseRecord(database: DatabaseRecord | null | undefined): DatabaseRecord {
+    if (
+        !database
+        || typeof database.name !== 'string'
+        || typeof database.status !== 'string'
+        || typeof database.size_bytes !== 'number'
+        || (database.deleted_at !== null && typeof database.deleted_at !== 'string')
+        || (database.purge_at !== null && typeof database.purge_at !== 'string')
+    ) {
+        throw new DatabaseOperationError('upstream_unavailable', 'The database response was invalid.');
+    }
+
+    return {
+        name: database.name,
+        status: database.status,
+        deleted_at: database.deleted_at,
+        purge_at: database.purge_at,
+        size_bytes: database.size_bytes,
+    };
+}
+
+function stableDatabaseResponse(data: DatabaseMutationResponse): DatabaseMutationResponse {
+    return { database: stableDatabaseRecord(data?.database) };
+}
+
+function stableListResponse(data: DatabaseListResponse): DatabaseListResponse {
+    if (
+        !data
+        || !Array.isArray(data.databases)
+        || typeof data.quota?.used !== 'number'
+        || typeof data.quota?.limit !== 'number'
+    ) {
+        throw new DatabaseOperationError('upstream_unavailable', 'The database response was invalid.');
+    }
+
+    return {
+        databases: data.databases.map(stableDatabaseRecord),
+        quota: {
+            used: data.quota.used,
+            limit: data.quota.limit,
+        },
+    };
+}
+
+function databaseRows(databases: DatabaseRecord[]): string[][] {
+    return databases.map((database) => [
+        database.name,
+        database.status,
+        String(database.size_bytes),
+        database.deleted_at ?? '-',
+        database.purge_at ?? '-',
+    ]);
+}
+
+function renderDatabaseTable(databases: DatabaseRecord[]): string {
+    return renderTable(
+        ['NAME', 'STATUS', 'SIZE (BYTES)', 'DELETED AT', 'PURGE AT'],
+        databaseRows(databases),
+    ).join('\n');
+}
+
+function renderMutation(
+    operation: 'create' | 'delete' | 'undelete',
+    database: DatabaseRecord,
+): string {
+    const verb = operation === 'create'
+        ? 'created'
+        : operation === 'delete'
+            ? 'deleted'
+            : 'restored';
+
+    return `Database "${database.name}" ${verb}.\n${renderDatabaseTable([database])}`;
+}
+
+function writeJson(stdout: (line: string) => void, data: unknown): void {
+    stdout(JSON.stringify(data, null, 2));
+}
+
+export async function databaseListWithConfig(
+    options: DatabaseListOptions,
+    config: Config,
+    dependencies: DatabaseCommandDependencies = {},
+): Promise<void> {
+    const io = resolveDependencies(dependencies);
+    const data = stableListResponse(await requestDatabaseOperation<DatabaseListResponse>(
+        config,
+        { operation: 'list' },
+        requestDependencies(io),
+    ));
+
+    if (options.json) {
+        writeJson(io.stdout, data);
+        return;
+    }
+
+    io.stdout(`${renderDatabaseTable(data.databases)}\nQuota: ${data.quota.used} / ${data.quota.limit}`);
+}
+
+export async function databaseCreateWithConfig(
+    name: string,
+    options: DatabaseCreateOptions,
+    config: Config,
+    dependencies: DatabaseCommandDependencies = {},
+): Promise<void> {
+    const io = resolveDependencies(dependencies);
+    const data = stableDatabaseResponse(await requestDatabaseOperation<DatabaseMutationResponse>(
+        config,
+        { operation: 'create', name },
+        requestDependencies(io),
+    ));
+
+    if (options.from) {
+        try {
+            await io.importDatabase(data.database.name, options.from);
+        } catch {
+            throw new DatabaseOperationError(
+                'import_failed',
+                `Database "${data.database.name}" was created, but its SQL import failed. The database remains in place.`,
+            );
+        }
+    }
+
+    if (options.json) {
+        writeJson(io.stdout, data);
+        return;
+    }
+
+    io.stdout(renderMutation('create', data.database));
+}
+
+export async function databaseDeleteWithConfig(
+    name: string,
+    options: DatabaseDeleteOptions,
+    config: Config,
+    dependencies: DatabaseCommandDependencies = {},
+): Promise<void> {
+    const io = resolveDependencies(dependencies);
+
+    if (!options.yes) {
+        if (options.json || !io.isTTY) {
+            throw new DatabaseOperationError(
+                'confirmation_required',
+                'Database deletion requires --yes in JSON or non-interactive mode.',
+            );
+        }
+
+        if (!await io.confirm(`Delete database "${name}"?`)) {
+            io.stdout('Cancelled.');
+            return;
+        }
+    }
+
+    const data = stableDatabaseResponse(await requestDatabaseOperation<DatabaseMutationResponse>(
+        config,
+        { operation: 'delete', name },
+        requestDependencies(io),
+    ));
+
+    if (options.json) {
+        writeJson(io.stdout, data);
+        return;
+    }
+
+    io.stdout(renderMutation('delete', data.database));
+}
+
+export async function databaseUndeleteWithConfig(
+    name: string,
+    options: DatabaseUndeleteOptions,
+    config: Config,
+    dependencies: DatabaseCommandDependencies = {},
+): Promise<void> {
+    const io = resolveDependencies(dependencies);
+    const data = stableDatabaseResponse(await requestDatabaseOperation<DatabaseMutationResponse>(
+        config,
+        { operation: 'undelete', name },
+        requestDependencies(io),
+    ));
+
+    if (options.json) {
+        writeJson(io.stdout, data);
+        return;
+    }
+
+    io.stdout(renderMutation('undelete', data.database));
+}
+
+export async function databaseList(
+    options: DatabaseListOptions,
+    dependencies: DatabaseCommandDependencies = {},
+): Promise<void> {
+    await databaseListWithConfig(options, await requireConfigWithWorkspace(), dependencies);
+}
+
+export async function databaseCreate(
+    name: string,
+    options: DatabaseCreateOptions,
+    dependencies: DatabaseCommandDependencies = {},
+): Promise<void> {
+    await databaseCreateWithConfig(name, options, await requireConfigWithWorkspace(), dependencies);
+}
+
+export async function databaseDelete(
+    name: string,
+    options: DatabaseDeleteOptions,
+    dependencies: DatabaseCommandDependencies = {},
+): Promise<void> {
+    await databaseDeleteWithConfig(name, options, await requireConfigWithWorkspace(), dependencies);
+}
+
+export async function databaseUndelete(
+    name: string,
+    options: DatabaseUndeleteOptions,
+    dependencies: DatabaseCommandDependencies = {},
+): Promise<void> {
+    await databaseUndeleteWithConfig(name, options, await requireConfigWithWorkspace(), dependencies);
+}

--- a/src/commands/database.ts
+++ b/src/commands/database.ts
@@ -1,4 +1,8 @@
+import fs from 'fs';
+import path from 'path';
 import * as readline from 'readline';
+import { randomUUID } from 'crypto';
+import { pathToFileURL } from 'url';
 import { requireConfigWithWorkspace } from '../utils/api';
 import { Config } from '../utils/config';
 import {
@@ -9,9 +13,12 @@ import {
     DatabaseResultSet,
     formatDatabaseTableValue,
     normalizeDatabaseValue,
+    requestDatabaseAccess,
+    requestDatabaseDumpStream,
     requestDatabaseOperation,
     withDatabaseClient,
 } from '../utils/database-data-plane';
+import { loadDatabaseClientBeforeMint } from '../utils/database-client-support';
 import { renderTable } from '../utils/table';
 
 export interface DatabaseRecord {
@@ -65,12 +72,26 @@ interface DatabaseExecOptions {
     json?: boolean;
 }
 
+interface DatabaseDumpOptions {
+    yes?: boolean;
+}
+
+interface DatabasePullOptions {
+    yes?: boolean;
+    writable?: boolean;
+}
+
+type DatabaseFileSystem = typeof fs.promises;
+
 export interface DatabaseCommandDependencies extends DatabaseClientDependencies {
     stdout?: (line: string) => void;
     stderr?: (line: string) => void;
     confirm?: (message: string) => Promise<boolean | undefined>;
     isTTY?: boolean;
     importDatabase?: (name: string, file: string) => Promise<void>;
+    cwd?: string;
+    tempPath?: (target: string) => string;
+    filesystem?: DatabaseFileSystem;
 }
 
 interface ResolvedCommandDependencies {
@@ -81,6 +102,9 @@ interface ResolvedCommandDependencies {
     importDatabase: (name: string, file: string) => Promise<void>;
     post: DatabaseCommandDependencies['post'];
     loadClient: DatabaseCommandDependencies['loadClient'];
+    cwd: string;
+    tempPath: (target: string) => string;
+    filesystem: DatabaseFileSystem;
 }
 
 function defaultConfirmation(message: string): Promise<boolean> {
@@ -118,6 +142,12 @@ function resolveDependencies(dependencies: DatabaseCommandDependencies): Resolve
         importDatabase: dependencies.importDatabase ?? unavailableImportHandoff,
         post: dependencies.post,
         loadClient: dependencies.loadClient,
+        cwd: dependencies.cwd ?? process.cwd(),
+        tempPath: dependencies.tempPath ?? ((target) => path.join(
+            path.dirname(target),
+            `.${path.basename(target)}.solidactions-${randomUUID()}.tmp`,
+        )),
+        filesystem: dependencies.filesystem ?? fs.promises,
     };
 }
 
@@ -445,6 +475,207 @@ function renderSchema(schema: DatabaseSchemaResponse): string {
     return sections.join('\n\n');
 }
 
+const INCOMPLETE_DUMP_MARKER = '-- DOWNLOAD INCOMPLETE';
+const DUMP_TAIL_BYTES = 4096;
+const PULL_ATTEMPTS = 3;
+
+function safeDatabaseStem(name: string): string {
+    return name
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '') || 'database';
+}
+
+function errorCode(error: unknown): string | undefined {
+    return error && typeof error === 'object' && typeof (error as { code?: unknown }).code === 'string'
+        ? (error as { code: string }).code
+        : undefined;
+}
+
+function freshSafeFileError(error: unknown): DatabaseOperationError {
+    if (error instanceof DatabaseOperationError) {
+        return new DatabaseOperationError(error.code, error.message, error.status);
+    }
+
+    if (errorCode(error) === 'database_client_unsupported') {
+        return new DatabaseOperationError(
+            'database_client_unsupported',
+            'Database commands are not supported on this platform.',
+        );
+    }
+
+    return new DatabaseOperationError('upstream_unavailable', 'Database file operation failed.');
+}
+
+function isMissingPath(error: unknown): boolean {
+    return errorCode(error) === 'ENOENT';
+}
+
+async function lstatIfPresent(
+    filesystem: DatabaseFileSystem,
+    candidate: string,
+): Promise<Awaited<ReturnType<DatabaseFileSystem['lstat']>> | null> {
+    try {
+        return await filesystem.lstat(candidate);
+    } catch (error) {
+        if (isMissingPath(error)) return null;
+        throw error;
+    }
+}
+
+async function assertNoSymlinkComponents(
+    filesystem: DatabaseFileSystem,
+    destination: string,
+): Promise<void> {
+    const absolute = path.resolve(destination);
+    const root = path.parse(absolute).root;
+    const relative = absolute.slice(root.length);
+    const components = relative.split(path.sep).filter(Boolean);
+    let current = root;
+
+    for (const component of components) {
+        current = path.join(current, component);
+        const stat = await lstatIfPresent(filesystem, current);
+        if (stat?.isSymbolicLink()) {
+            throw new DatabaseOperationError(
+                'unsafe_destination',
+                'Destination paths cannot contain symbolic links.',
+            );
+        }
+    }
+}
+
+async function confirmFileOverwrite(
+    target: string,
+    options: { yes?: boolean },
+    io: ResolvedCommandDependencies,
+): Promise<boolean> {
+    await assertNoSymlinkComponents(io.filesystem, target);
+    const targetStat = await lstatIfPresent(io.filesystem, target);
+    if (!targetStat) return true;
+
+    if (!targetStat.isFile()) {
+        throw new DatabaseOperationError('unsafe_destination', 'Destination must be a regular file.');
+    }
+
+    if (options.yes) return true;
+    if (!io.isTTY) {
+        throw new DatabaseOperationError(
+            'confirmation_required',
+            'Overwriting an existing database file requires --yes in non-interactive mode.',
+        );
+    }
+
+    if (!await io.confirm(`Overwrite "${target}"?`)) {
+        io.stdout('Cancelled.');
+        return false;
+    }
+
+    return true;
+}
+
+function resolveDatabaseDestination(
+    io: ResolvedCommandDependencies,
+    requested: string | undefined,
+    fallback: string,
+): string {
+    return path.resolve(io.cwd, requested ?? fallback);
+}
+
+function validatedTempPath(io: ResolvedCommandDependencies, target: string): string {
+    const temp = path.resolve(io.tempPath(target));
+    if (temp === target || path.dirname(temp) !== path.dirname(target)) {
+        throw new DatabaseOperationError(
+            'unsafe_destination',
+            'The temporary database file must be a sibling of its destination.',
+        );
+    }
+    return temp;
+}
+
+async function reserveDestinationTemp(
+    io: ResolvedCommandDependencies,
+    target: string,
+): Promise<{
+    temp: string;
+    handle: Awaited<ReturnType<DatabaseFileSystem['open']>>;
+}> {
+    const parent = path.dirname(target);
+    await assertNoSymlinkComponents(io.filesystem, target);
+    await io.filesystem.mkdir(parent, { recursive: true });
+    await assertNoSymlinkComponents(io.filesystem, target);
+
+    const temp = validatedTempPath(io, target);
+    await assertNoSymlinkComponents(io.filesystem, temp);
+    const handle = await io.filesystem.open(temp, 'wx', 0o600);
+    return { temp, handle };
+}
+
+async function removeOwnedFiles(
+    filesystem: DatabaseFileSystem,
+    paths: string[],
+): Promise<void> {
+    for (const candidate of paths) {
+        try {
+            await filesystem.unlink(candidate);
+        } catch {
+            // Cleanup is best effort and may target only paths owned by this invocation.
+        }
+    }
+}
+
+function pullSidecars(temp: string): string[] {
+    return [`${temp}-wal`, `${temp}-shm`, `${temp}-journal`];
+}
+
+async function anyPathExists(filesystem: DatabaseFileSystem, candidates: string[]): Promise<boolean> {
+    for (const candidate of candidates) {
+        if (await lstatIfPresent(filesystem, candidate)) return true;
+    }
+    return false;
+}
+
+function streamChunk(value: unknown): Buffer {
+    if (typeof value === 'string') return Buffer.from(value);
+    if (Buffer.isBuffer(value)) return value;
+    if (value instanceof ArrayBuffer) return Buffer.from(value);
+    if (ArrayBuffer.isView(value)) {
+        return Buffer.from(value.buffer, value.byteOffset, value.byteLength);
+    }
+    throw new Error('Invalid database dump stream chunk.');
+}
+
+async function writeDumpStream(
+    stream: unknown,
+    handle: Awaited<ReturnType<DatabaseFileSystem['open']>>,
+): Promise<Buffer> {
+    if (!stream || typeof (stream as { [Symbol.asyncIterator]?: unknown })[Symbol.asyncIterator] !== 'function') {
+        throw new Error('Invalid database dump stream.');
+    }
+
+    let tail = Buffer.alloc(0);
+    for await (const value of stream as AsyncIterable<unknown>) {
+        const chunk = streamChunk(value);
+        let offset = 0;
+        while (offset < chunk.byteLength) {
+            const { bytesWritten } = await handle.write(chunk, offset, chunk.byteLength - offset, null);
+            if (bytesWritten <= 0) throw new Error('Database dump write failed.');
+            offset += bytesWritten;
+        }
+
+        tail = Buffer.concat([tail, chunk]);
+        if (tail.byteLength > DUMP_TAIL_BYTES) {
+            tail = tail.subarray(tail.byteLength - DUMP_TAIL_BYTES);
+        }
+    }
+
+    return tail;
+}
+
+function displayDestination(io: ResolvedCommandDependencies, target: string): string {
+    return path.relative(io.cwd, target) || path.basename(target);
+}
+
 export async function databaseListWithConfig(
     options: DatabaseListOptions,
     config: Config,
@@ -654,6 +885,161 @@ export async function databaseExecWithConfig(
     io.stdout(output.join('\n'));
 }
 
+export async function databaseDumpWithConfig(
+    name: string,
+    file: string | undefined,
+    options: DatabaseDumpOptions,
+    config: Config,
+    dependencies: DatabaseCommandDependencies = {},
+): Promise<void> {
+    const io = resolveDependencies(dependencies);
+    const target = resolveDatabaseDestination(io, file, `${safeDatabaseStem(name)}.sql`);
+    let temp: string | undefined;
+    let handle: Awaited<ReturnType<DatabaseFileSystem['open']>> | undefined;
+    let ownsTemp = false;
+
+    try {
+        if (!await confirmFileOverwrite(target, options, io)) return;
+
+        const reservation = await reserveDestinationTemp(io, target);
+        temp = reservation.temp;
+        handle = reservation.handle;
+        ownsTemp = true;
+
+        const stream = await requestDatabaseDumpStream(config, name, requestDependencies(io));
+        const tail = await writeDumpStream(stream, handle);
+        await handle.close();
+        handle = undefined;
+
+        if (tail.includes(Buffer.from(INCOMPLETE_DUMP_MARKER))) {
+            throw new DatabaseOperationError(
+                'upstream_unavailable',
+                'The downloaded database dump is incomplete.',
+            );
+        }
+
+        await assertNoSymlinkComponents(io.filesystem, target);
+        await io.filesystem.rename(temp, target);
+        ownsTemp = false;
+        io.stdout(`Database dump saved to ${displayDestination(io, target)}.`);
+    } catch (error) {
+        if (handle) {
+            try {
+                await handle.close();
+            } catch {
+                // The public error remains stable; cleanup below owns the path.
+            }
+        }
+        if (ownsTemp && temp) await removeOwnedFiles(io.filesystem, [temp]);
+        throw freshSafeFileError(error);
+    }
+}
+
+export async function databasePullWithConfig(
+    name: string,
+    destination: string | undefined,
+    options: DatabasePullOptions,
+    config: Config,
+    dependencies: DatabaseCommandDependencies = {},
+): Promise<void> {
+    const io = resolveDependencies(dependencies);
+    if (options.writable) {
+        throw new DatabaseOperationError(
+            'database_client_unsupported',
+            'Writable database pull is not available yet.',
+        );
+    }
+
+    const target = resolveDatabaseDestination(
+        io,
+        destination,
+        path.join('.solidactions', 'databases', `${safeDatabaseStem(name)}.db`),
+    );
+    let temp: string | undefined;
+    let ownsTemp = false;
+    let ownsSidecars = false;
+
+    try {
+        if (!await confirmFileOverwrite(target, options, io)) return;
+
+        const reservation = await reserveDestinationTemp(io, target);
+        temp = reservation.temp;
+        ownsTemp = true;
+        await reservation.handle.close();
+
+        const sidecars = pullSidecars(temp);
+        if (await anyPathExists(io.filesystem, sidecars)) {
+            throw new DatabaseOperationError(
+                'upstream_unavailable',
+                'Database replica temporary files already exist.',
+            );
+        }
+        ownsSidecars = true;
+
+        let synced = false;
+        for (let attempt = 0; attempt < PULL_ATTEMPTS; attempt += 1) {
+            const { createClient, access } = await loadDatabaseClientBeforeMint(
+                () => requestDatabaseAccess(config, name, 'read', requestDependencies(io)),
+                { loadClient: io.loadClient },
+            );
+
+            let client: DatabaseClient | undefined;
+            let attemptFailed = false;
+            try {
+                client = createClient({
+                    url: pathToFileURL(temp).href,
+                    syncUrl: access.url,
+                    authToken: access.token,
+                    intMode: 'string',
+                }) as DatabaseClient;
+                if (typeof client.sync !== 'function') throw new Error('Database sync is unavailable.');
+                await client.sync();
+            } catch {
+                attemptFailed = true;
+            } finally {
+                if (client) {
+                    try {
+                        await client.close();
+                    } catch {
+                        attemptFailed = true;
+                    }
+                }
+            }
+
+            if (!attemptFailed) {
+                synced = true;
+                break;
+            }
+        }
+
+        if (!synced) {
+            throw new DatabaseOperationError('upstream_unavailable', 'Database file operation failed.');
+        }
+
+        if (await anyPathExists(io.filesystem, pullSidecars(temp))) {
+            throw new DatabaseOperationError(
+                'upstream_unavailable',
+                'Database replica could not be finalized safely.',
+            );
+        }
+
+        await io.filesystem.chmod(temp, 0o444);
+        await assertNoSymlinkComponents(io.filesystem, target);
+        await io.filesystem.rename(temp, target);
+        ownsTemp = false;
+        ownsSidecars = false;
+        io.stdout(`Database replica saved to ${displayDestination(io, target)}.`);
+    } catch (error) {
+        if (ownsTemp && temp) {
+            await removeOwnedFiles(
+                io.filesystem,
+                [temp, ...(ownsSidecars ? pullSidecars(temp) : [])],
+            );
+        }
+        throw freshSafeFileError(error);
+    }
+}
+
 export async function databaseList(
     options: DatabaseListOptions,
     dependencies: DatabaseCommandDependencies = {},
@@ -709,4 +1095,22 @@ export async function databaseExec(
     dependencies: DatabaseCommandDependencies = {},
 ): Promise<void> {
     await databaseExecWithConfig(name, sql, options, await requireConfigWithWorkspace(), dependencies);
+}
+
+export async function databaseDump(
+    name: string,
+    file: string | undefined,
+    options: DatabaseDumpOptions,
+    dependencies: DatabaseCommandDependencies = {},
+): Promise<void> {
+    await databaseDumpWithConfig(name, file, options, await requireConfigWithWorkspace(), dependencies);
+}
+
+export async function databasePull(
+    name: string,
+    destination: string | undefined,
+    options: DatabasePullOptions,
+    dependencies: DatabaseCommandDependencies = {},
+): Promise<void> {
+    await databasePullWithConfig(name, destination, options, await requireConfigWithWorkspace(), dependencies);
 }

--- a/src/commands/database.ts
+++ b/src/commands/database.ts
@@ -20,6 +20,12 @@ import {
 } from '../utils/database-data-plane';
 import { loadDatabaseClientBeforeMint } from '../utils/database-client-support';
 export { parseDatabaseImportSql } from '../utils/database-sql-import';
+import {
+    bindPreparedDatabaseImport,
+    prepareDatabaseImport,
+    prepareDatabaseImportSource,
+    runPreparedDatabaseImport,
+} from '../utils/database-sql-import-runner';
 import { renderTable } from '../utils/table';
 
 export interface DatabaseRecord {
@@ -82,6 +88,11 @@ interface DatabasePullOptions {
     writable?: boolean;
 }
 
+interface DatabaseImportOptions {
+    yes?: boolean;
+    resume?: string;
+}
+
 type DatabaseFileSystem = typeof fs.promises;
 
 export interface DatabaseCommandDependencies extends DatabaseClientDependencies {
@@ -103,7 +114,7 @@ interface ResolvedCommandDependencies {
     stderr: (line: string) => void;
     confirm: (message: string) => Promise<boolean>;
     isTTY: boolean;
-    importDatabase: (name: string, file: string) => Promise<void>;
+    importDatabase?: (name: string, file: string) => Promise<void>;
     post: DatabaseCommandDependencies['post'];
     loadClient: DatabaseCommandDependencies['loadClient'];
     cwd: string;
@@ -133,20 +144,13 @@ function defaultConfirmation(message: string): Promise<boolean> {
     });
 }
 
-async function unavailableImportHandoff(name: string, _file: string): Promise<void> {
-    throw new DatabaseOperationError(
-        'import_failed',
-        `Database "${name}" was created, but SQL import is not available yet. The database remains in place.`,
-    );
-}
-
 function resolveDependencies(dependencies: DatabaseCommandDependencies): ResolvedCommandDependencies {
     return {
         stdout: dependencies.stdout ?? ((line) => console.log(line)),
         stderr: dependencies.stderr ?? ((line) => console.error(line)),
         confirm: async (message) => (await (dependencies.confirm ?? defaultConfirmation)(message)) === true,
         isTTY: dependencies.isTTY ?? process.stdin.isTTY === true,
-        importDatabase: dependencies.importDatabase ?? unavailableImportHandoff,
+        importDatabase: dependencies.importDatabase,
         post: dependencies.post,
         loadClient: dependencies.loadClient,
         cwd: dependencies.cwd ?? process.cwd(),
@@ -1000,6 +1004,9 @@ export async function databaseCreateWithConfig(
     dependencies: DatabaseCommandDependencies = {},
 ): Promise<void> {
     const io = resolveDependencies(dependencies);
+    const preparedSource = options.from && !io.importDatabase
+        ? await prepareDatabaseImportSource(options.from, io.cwd, io.filesystem)
+        : undefined;
     const data = stableDatabaseResponse(await requestDatabaseOperation<DatabaseMutationResponse>(
         config,
         { operation: 'create', name },
@@ -1008,11 +1015,38 @@ export async function databaseCreateWithConfig(
 
     if (options.from) {
         try {
-            await io.importDatabase(data.database.name, options.from);
-        } catch {
+            if (io.importDatabase) {
+                await io.importDatabase(data.database.name, options.from);
+            } else if (preparedSource) {
+                const prepared = await bindPreparedDatabaseImport(
+                    preparedSource,
+                    data.database.name,
+                    undefined,
+                    io.cwd,
+                    io.filesystem,
+                );
+                await runPreparedDatabaseImport(
+                    prepared,
+                    config,
+                    {
+                        cwd: io.cwd,
+                        filesystem: io.filesystem,
+                        stdout: options.json ? () => undefined : io.stdout,
+                        now: io.now,
+                        post: io.post,
+                        loadClient: io.loadClient,
+                    },
+                );
+            }
+        } catch (error) {
+            const safeGuidance = error instanceof DatabaseOperationError
+                && error.code === 'import_failed'
+                && error.message.includes('Resume with:')
+                ? `\n${error.message}`
+                : '';
             throw new DatabaseOperationError(
                 'import_failed',
-                `Database "${data.database.name}" was created, but its SQL import failed. The database remains in place.`,
+                `Database "${data.database.name}" was created, but its SQL import failed. The database remains in place.${safeGuidance}`,
             );
         }
     }
@@ -1023,6 +1057,45 @@ export async function databaseCreateWithConfig(
     }
 
     io.stdout(renderMutation('create', data.database));
+}
+
+export async function databaseImportWithConfig(
+    name: string,
+    file: string,
+    options: DatabaseImportOptions,
+    config: Config,
+    dependencies: DatabaseCommandDependencies = {},
+): Promise<void> {
+    const io = resolveDependencies(dependencies);
+    const prepared = await prepareDatabaseImport(
+        name,
+        file,
+        options.resume,
+        io.cwd,
+        io.filesystem,
+    );
+
+    if (!options.yes) {
+        if (!io.isTTY) {
+            throw new DatabaseOperationError(
+                'confirmation_required',
+                'Database import requires --yes in non-interactive mode.',
+            );
+        }
+        if (!await io.confirm(`Import SQL into database "${name}"?`)) {
+            io.stdout('Cancelled.');
+            return;
+        }
+    }
+
+    await runPreparedDatabaseImport(prepared, config, {
+        cwd: io.cwd,
+        filesystem: io.filesystem,
+        stdout: io.stdout,
+        now: io.now,
+        post: io.post,
+        loadClient: io.loadClient,
+    });
 }
 
 export async function databaseDeleteWithConfig(
@@ -1724,4 +1797,13 @@ export async function databasePull(
     dependencies: DatabaseCommandDependencies = {},
 ): Promise<void> {
     await databasePullWithConfig(name, destination, options, await requireConfigWithWorkspace(), dependencies);
+}
+
+export async function databaseImport(
+    name: string,
+    file: string,
+    options: DatabaseImportOptions,
+    dependencies: DatabaseCommandDependencies = {},
+): Promise<void> {
+    await databaseImportWithConfig(name, file, options, await requireConfigWithWorkspace(), dependencies);
 }

--- a/src/commands/database.ts
+++ b/src/commands/database.ts
@@ -625,7 +625,7 @@ async function removeOwnedFiles(
 }
 
 function pullSidecars(temp: string): string[] {
-    return [`${temp}-wal`, `${temp}-shm`, `${temp}-journal`];
+    return [`${temp}-wal`, `${temp}-shm`, `${temp}-journal`, `${temp}-client_wal_index`];
 }
 
 async function anyPathExists(filesystem: DatabaseFileSystem, candidates: string[]): Promise<boolean> {
@@ -674,6 +674,31 @@ async function writeDumpStream(
 
 function displayDestination(io: ResolvedCommandDependencies, target: string): string {
     return path.relative(io.cwd, target) || path.basename(target);
+}
+
+function checkpointInteger(value: unknown): bigint {
+    if (typeof value === 'bigint' && value >= 0n) return value;
+    if (typeof value === 'number' && Number.isSafeInteger(value) && value >= 0) return BigInt(value);
+    if (typeof value === 'string' && /^\d+$/.test(value)) return BigInt(value);
+    throw new Error('Invalid database checkpoint result.');
+}
+
+function validateCheckpointResult(result: DatabaseResultSet): void {
+    if (!result || !Array.isArray(result.rows) || result.rows.length !== 1) {
+        throw new Error('Invalid database checkpoint result.');
+    }
+
+    const row = result.rows[0];
+    if (!row || !Number.isSafeInteger(row.length) || row.length < 3) {
+        throw new Error('Invalid database checkpoint result.');
+    }
+
+    const busy = checkpointInteger(row[0]);
+    const log = checkpointInteger(row[1]);
+    const checkpointed = checkpointInteger(row[2]);
+    if (busy !== 0n || checkpointed < log) {
+        throw new Error('Database checkpoint did not complete.');
+    }
 }
 
 export async function databaseListWithConfig(
@@ -978,11 +1003,13 @@ export async function databasePullWithConfig(
         ownsSidecars = true;
 
         let synced = false;
+        let localCreateClient: ((config: Record<string, unknown>) => DatabaseClient) | undefined;
         for (let attempt = 0; attempt < PULL_ATTEMPTS; attempt += 1) {
             const { createClient, access } = await loadDatabaseClientBeforeMint(
                 () => requestDatabaseAccess(config, name, 'read', requestDependencies(io)),
                 { loadClient: io.loadClient },
             );
+            localCreateClient = createClient as (config: Record<string, unknown>) => DatabaseClient;
 
             if (attempt === 0) {
                 await assertNoSymlinkComponents(io.filesystem, temp);
@@ -1011,6 +1038,8 @@ export async function databasePullWithConfig(
                     intMode: 'string',
                 }) as DatabaseClient;
             } catch {
+                const createdStat = await lstatIfPresent(io.filesystem, temp);
+                if (createdStat?.isFile() && !createdStat.isSymbolicLink()) ownsTemp = true;
                 throw new DatabaseOperationError('upstream_unavailable', 'Database file operation failed.');
             }
 
@@ -1044,12 +1073,37 @@ export async function databasePullWithConfig(
             throw new DatabaseOperationError('upstream_unavailable', 'Database file operation failed.');
         }
 
-        if (await anyPathExists(io.filesystem, pullSidecars(temp))) {
-            throw new DatabaseOperationError(
-                'upstream_unavailable',
-                'Database replica could not be finalized safely.',
-            );
+        let finalizer: DatabaseClient | undefined;
+        let checkpointResult: DatabaseResultSet | undefined;
+        let finalizationFailed = false;
+        try {
+            finalizer = localCreateClient!({
+                url: pathToFileURL(temp).href,
+                intMode: 'string',
+            });
+            checkpointResult = await finalizer.execute('PRAGMA wal_checkpoint(TRUNCATE)');
+        } catch {
+            finalizationFailed = true;
+        } finally {
+            if (finalizer) {
+                try {
+                    await finalizer.close();
+                } catch {
+                    finalizationFailed = true;
+                }
+            }
         }
+
+        if (finalizationFailed || !checkpointResult) {
+            throw new DatabaseOperationError('upstream_unavailable', 'Database file operation failed.');
+        }
+        validateCheckpointResult(checkpointResult);
+
+        await removeOwnedFiles(io.filesystem, pullSidecars(temp));
+        if (await anyPathExists(io.filesystem, pullSidecars(temp))) {
+            throw new DatabaseOperationError('upstream_unavailable', 'Database file operation failed.');
+        }
+        ownsSidecars = false;
 
         await io.filesystem.chmod(temp, 0o444);
         await assertNoSymlinkComponents(io.filesystem, target);

--- a/src/commands/device-login.ts
+++ b/src/commands/device-login.ts
@@ -16,7 +16,7 @@ const CLI_OAUTH_CLIENT_ID = '9f1b6e2a-9c1e-4b6e-8f0a-6c9f2b1e7d4c';
 
 // CLI capability scopes requested at device-code issuance — the server
 // rejects any scope not pre-registered via Passport::tokensCan().
-const CLI_SCOPES = 'env deploy runs docs';
+const CLI_SCOPES = 'env deploy runs docs databases';
 
 interface DeviceCodeResponse {
     device_code: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,8 +60,10 @@ import { workflowView } from './commands/workflow-view';
 import {
     databaseCreate,
     databaseDelete,
+    databaseDump,
     databaseExec,
     databaseList,
+    databasePull,
     databaseQuery,
     databaseSchema,
     databaseUndelete,
@@ -275,7 +277,10 @@ database
     .description('Download a database SQL dump')
     .argument('<name>', 'Database name')
     .argument('[file]', 'Destination file')
-    .option('-y, --yes', 'Overwrite without confirmation');
+    .option('-y, --yes', 'Overwrite without confirmation')
+    .action(async (name, file, options) => {
+        await databaseDump(name, file, options);
+    });
 
 database
     .command('pull')
@@ -283,7 +288,10 @@ database
     .argument('<name>', 'Database name')
     .argument('[path]', 'Destination path')
     .option('-y, --yes', 'Overwrite without confirmation')
-    .option('--writable', 'Open a foreground writable session');
+    .option('--writable', 'Open a foreground writable session')
+    .action(async (name, destination, options) => {
+        await databasePull(name, destination, options);
+    });
 
 database
     .command('import')

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,12 @@ import {
     workflowEnable,
 } from './commands/state';
 import { workflowView } from './commands/workflow-view';
+import {
+    databaseCreate,
+    databaseDelete,
+    databaseList,
+    databaseUndelete,
+} from './commands/database';
 import { setCliWorkspaceOverride } from './utils/config';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -197,27 +203,39 @@ const database = program.command('database').description('Manage workspace datab
 database
     .command('list')
     .description('List workspace databases')
-    .option('--json', 'Output as JSON');
+    .option('--json', 'Output as JSON')
+    .action(async (options) => {
+        await databaseList(options);
+    });
 
 database
     .command('create')
     .description('Create a workspace database')
     .argument('<name>', 'Database name')
     .option('--from <file.sql>', 'Import a SQL file after creation')
-    .option('--json', 'Output as JSON');
+    .option('--json', 'Output as JSON')
+    .action(async (name, options) => {
+        await databaseCreate(name, options);
+    });
 
 database
     .command('delete')
     .description('Delete a workspace database')
     .argument('<name>', 'Database name')
     .option('-y, --yes', 'Skip confirmation')
-    .option('--json', 'Output as JSON');
+    .option('--json', 'Output as JSON')
+    .action(async (name, options) => {
+        await databaseDelete(name, options);
+    });
 
 database
     .command('undelete')
     .description('Restore a deleted workspace database')
     .argument('<name>', 'Database name')
-    .option('--json', 'Output as JSON');
+    .option('--json', 'Output as JSON')
+    .action(async (name, options) => {
+        await databaseUndelete(name, options);
+    });
 
 database
     .command('schema')

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,7 @@ import {
     databaseDelete,
     databaseDump,
     databaseExec,
+    databaseImport,
     databaseList,
     databasePull,
     databaseQuery,
@@ -298,7 +299,11 @@ database
     .description('Import a SQL file into a database')
     .argument('<name>', 'Database name')
     .argument('<file.sql>', 'SQL file')
-    .option('-y, --yes', 'Skip confirmation');
+    .option('-y, --yes', 'Skip confirmation')
+    .option('--resume <checkpoint>', 'Resume from a validated import checkpoint')
+    .action(async (name, file, options) => {
+        await databaseImport(name, file, options);
+    });
 
 // =============================================================================
 // project <subcommand>

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,10 @@ import { workflowView } from './commands/workflow-view';
 import {
     databaseCreate,
     databaseDelete,
+    databaseExec,
     databaseList,
+    databaseQuery,
+    databaseSchema,
     databaseUndelete,
 } from './commands/database';
 import { setCliWorkspaceOverride } from './utils/config';
@@ -241,14 +244,20 @@ database
     .command('schema')
     .description('Show a database schema')
     .argument('<name>', 'Database name')
-    .option('--json', 'Output as JSON');
+    .option('--json', 'Output as JSON')
+    .action(async (name, options) => {
+        await databaseSchema(name, options);
+    });
 
 database
     .command('query')
     .description('Run a read-only SQL query')
     .argument('<name>', 'Database name')
     .argument('<sql>', 'SQL query')
-    .option('--json', 'Output as JSON');
+    .option('--json', 'Output as JSON')
+    .action(async (name, sql, options) => {
+        await databaseQuery(name, sql, options);
+    });
 
 database
     .command('exec')
@@ -256,7 +265,10 @@ database
     .argument('<name>', 'Database name')
     .argument('<sql>', 'SQL statement')
     .option('-y, --yes', 'Skip confirmation')
-    .option('--json', 'Output as JSON');
+    .option('--json', 'Output as JSON')
+    .action(async (name, sql, options) => {
+        await databaseExec(name, sql, options);
+    });
 
 database
     .command('dump')

--- a/src/index.ts
+++ b/src/index.ts
@@ -187,6 +187,82 @@ program
     });
 
 // =============================================================================
+// database <subcommand>
+// =============================================================================
+
+// Register the complete public surface up front so help and the generated
+// command manifest stay authoritative while handlers land in focused slices.
+const database = program.command('database').description('Manage workspace databases');
+
+database
+    .command('list')
+    .description('List workspace databases')
+    .option('--json', 'Output as JSON');
+
+database
+    .command('create')
+    .description('Create a workspace database')
+    .argument('<name>', 'Database name')
+    .option('--from <file.sql>', 'Import a SQL file after creation')
+    .option('--json', 'Output as JSON');
+
+database
+    .command('delete')
+    .description('Delete a workspace database')
+    .argument('<name>', 'Database name')
+    .option('-y, --yes', 'Skip confirmation')
+    .option('--json', 'Output as JSON');
+
+database
+    .command('undelete')
+    .description('Restore a deleted workspace database')
+    .argument('<name>', 'Database name')
+    .option('--json', 'Output as JSON');
+
+database
+    .command('schema')
+    .description('Show a database schema')
+    .argument('<name>', 'Database name')
+    .option('--json', 'Output as JSON');
+
+database
+    .command('query')
+    .description('Run a read-only SQL query')
+    .argument('<name>', 'Database name')
+    .argument('<sql>', 'SQL query')
+    .option('--json', 'Output as JSON');
+
+database
+    .command('exec')
+    .description('Execute a SQL statement')
+    .argument('<name>', 'Database name')
+    .argument('<sql>', 'SQL statement')
+    .option('-y, --yes', 'Skip confirmation')
+    .option('--json', 'Output as JSON');
+
+database
+    .command('dump')
+    .description('Download a database SQL dump')
+    .argument('<name>', 'Database name')
+    .argument('[file]', 'Destination file')
+    .option('-y, --yes', 'Overwrite without confirmation');
+
+database
+    .command('pull')
+    .description('Pull a database into a local file')
+    .argument('<name>', 'Database name')
+    .argument('[path]', 'Destination path')
+    .option('-y, --yes', 'Overwrite without confirmation')
+    .option('--writable', 'Open a foreground writable session');
+
+database
+    .command('import')
+    .description('Import a SQL file into a database')
+    .argument('<name>', 'Database name')
+    .argument('<file.sql>', 'SQL file')
+    .option('-y, --yes', 'Skip confirmation');
+
+// =============================================================================
 // project <subcommand>
 // =============================================================================
 

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -142,12 +142,43 @@ export function augmentWorkspaceForbiddenMessage(error: any): any {
     return error;
 }
 
+/**
+ * Existing device tokens predate the coarse `databases` scope. Turn the app's
+ * stable missing-ability response into a re-login instruction while preserving
+ * its original message. Other ability failures retain their existing behavior.
+ */
+export function augmentTokenMissingAbilityMessage(error: any): any {
+    const response = error?.response;
+    const requiredAbility = response?.data?.required_ability;
+    const isDatabaseAbility =
+        requiredAbility === 'databases'
+        || (typeof requiredAbility === 'string' && requiredAbility.startsWith('databases:'));
+
+    if (
+        response?.status === 403
+        && response.data?.code === 'token_missing_ability'
+        && isDatabaseAbility
+    ) {
+        const hint = 'Run `solidactions login --device` to refresh database access.';
+        const message = typeof response.data.message === 'string' && response.data.message.length > 0
+            ? response.data.message
+            : 'This session does not have database access.';
+        if (!message.includes('solidactions login --device')) {
+            response.data.message = `${message}\n\n${hint}`;
+        }
+    }
+
+    return error;
+}
+
 axios.interceptors.response.use(
     (response) => response,
     (error) => Promise.reject(
-        augmentWorkspaceForbiddenMessage(
-            augmentNotFoundMessage(
-                augmentSandboxEgressMessage(error),
+        augmentTokenMissingAbilityMessage(
+            augmentWorkspaceForbiddenMessage(
+                augmentNotFoundMessage(
+                    augmentSandboxEgressMessage(error),
+                ),
             ),
         ),
     ),

--- a/src/utils/database-client-support.ts
+++ b/src/utils/database-client-support.ts
@@ -1,0 +1,45 @@
+interface DatabaseClientModule {
+    createClient: (...args: any[]) => any;
+}
+
+interface DatabaseClientSupportDependencies {
+    loadClient?: () => Promise<DatabaseClientModule>;
+}
+
+export class DatabaseClientUnsupportedError extends Error {
+    readonly code = 'database_client_unsupported';
+
+    constructor() {
+        super('Database commands are not supported on this platform.');
+        this.name = 'DatabaseClientUnsupportedError';
+    }
+}
+
+/**
+ * Load the native-capable client module before requesting a short-lived
+ * credential. Import and binding failures are deliberately collapsed to a
+ * stable product error so low-level module paths and implementation details do
+ * not reach users. Mint failures are left untouched for the API error mapper.
+ */
+export async function loadDatabaseClientBeforeMint<T>(
+    mintAccess: () => Promise<T>,
+    dependencies: DatabaseClientSupportDependencies = {},
+): Promise<{ createClient: DatabaseClientModule['createClient']; access: T }> {
+    let clientModule: DatabaseClientModule;
+
+    try {
+        clientModule = await (dependencies.loadClient ?? (() => import('@libsql/client')))();
+        if (typeof clientModule.createClient !== 'function') {
+            throw new Error('Database client factory is unavailable.');
+        }
+    } catch {
+        throw new DatabaseClientUnsupportedError();
+    }
+
+    const access = await mintAccess();
+
+    return {
+        createClient: clientModule.createClient,
+        access,
+    };
+}

--- a/src/utils/database-data-plane.ts
+++ b/src/utils/database-data-plane.ts
@@ -25,6 +25,7 @@ interface DatabaseClientModule {
 
 export interface DatabaseClient {
     execute: (statement: string | { sql: string; args?: unknown }) => Promise<DatabaseResultSet>;
+    sync?: () => Promise<unknown>;
     close: () => void | Promise<void>;
     [key: string]: unknown;
 }
@@ -33,8 +34,8 @@ export interface DatabaseRequestDependencies {
     post?: (
         url: string,
         body: Record<string, unknown>,
-        options: { headers: Record<string, string> },
-    ) => Promise<{ data: unknown }>;
+        options: { headers: Record<string, string>; responseType?: 'stream' },
+    ) => Promise<{ data: unknown; status?: number }>;
 }
 
 export interface DatabaseClientDependencies extends DatabaseRequestDependencies {
@@ -59,7 +60,7 @@ export class DatabaseOperationError extends Error {
     }
 }
 
-function safeAppError(error: unknown): DatabaseOperationError {
+export function safeDatabaseRequestError(error: unknown): DatabaseOperationError {
     const augmented = augmentTokenMissingAbilityMessage(error);
     const response = (augmented as any)?.response;
     const status = typeof response?.status === 'number' ? response.status : undefined;
@@ -97,7 +98,34 @@ export async function requestDatabaseOperation<T>(
 
         return response.data as T;
     } catch (error) {
-        throw safeAppError(error);
+        throw safeDatabaseRequestError(error);
+    }
+}
+
+/** Request the existing server-side SQL dump as a stream. */
+export async function requestDatabaseDumpStream(
+    config: Config,
+    name: string,
+    dependencies: DatabaseRequestDependencies = {},
+): Promise<unknown> {
+    const post = dependencies.post ?? axios.post;
+
+    try {
+        const response = await post(
+            `${config.host}/api/v1/databases`,
+            { operation: 'dump', name },
+            {
+                headers: {
+                    ...getApiHeaders(config, 'application/json'),
+                    Accept: 'application/sql',
+                },
+                responseType: 'stream',
+            },
+        );
+
+        return response.data;
+    } catch (error) {
+        throw safeDatabaseRequestError(error);
     }
 }
 

--- a/src/utils/database-data-plane.ts
+++ b/src/utils/database-data-plane.ts
@@ -1,0 +1,183 @@
+import axios from 'axios';
+import { getApiHeaders } from './api';
+import { Config } from './config';
+import { loadDatabaseClientBeforeMint } from './database-client-support';
+
+export type DatabaseAccessMode = 'read' | 'write';
+
+export interface DatabaseAccess {
+    url: string;
+    token: string;
+    mode: DatabaseAccessMode;
+    expires_at: string;
+}
+
+interface DatabaseClientModule {
+    createClient: (config: Record<string, unknown>) => DatabaseClient;
+}
+
+interface DatabaseClient {
+    close: () => void | Promise<void>;
+    [key: string]: unknown;
+}
+
+interface DatabaseRequestDependencies {
+    post?: (
+        url: string,
+        body: Record<string, unknown>,
+        options: { headers: Record<string, string> },
+    ) => Promise<{ data: DatabaseAccess }>;
+}
+
+interface DatabaseClientDependencies extends DatabaseRequestDependencies {
+    loadClient?: () => Promise<DatabaseClientModule>;
+}
+
+export class DatabaseOperationError extends Error {
+    readonly code: string;
+    readonly status?: number;
+
+    constructor(code: string, message: string, status?: number) {
+        super(message);
+        this.code = code;
+        if (status !== undefined) {
+            this.status = status;
+        }
+
+        // A public command error is deliberately data-only. In particular, it
+        // must never retain an upstream stack, request, response, config, or
+        // cause that could contain either control- or data-plane credentials.
+        delete this.stack;
+    }
+}
+
+function safeAppError(error: unknown): DatabaseOperationError {
+    const response = (error as any)?.response;
+    const status = typeof response?.status === 'number' ? response.status : undefined;
+    const code = typeof response?.data?.code === 'string' && response.data.code.length > 0
+        ? response.data.code
+        : 'upstream_unavailable';
+    const message = typeof response?.data?.message === 'string' && response.data.message.length > 0
+        ? response.data.message
+        : 'Database request failed.';
+
+    return new DatabaseOperationError(code, message, status);
+}
+
+function safeDirectClientError(): DatabaseOperationError {
+    return new DatabaseOperationError('upstream_unavailable', 'Database operation failed.');
+}
+
+/**
+ * Request a short-lived direct database credential from the app control plane.
+ * Any Axios transport object is discarded at this boundary.
+ */
+export async function requestDatabaseAccess(
+    config: Config,
+    name: string,
+    mode: DatabaseAccessMode,
+    dependencies: DatabaseRequestDependencies = {},
+): Promise<DatabaseAccess> {
+    const post = dependencies.post ?? axios.post;
+
+    try {
+        const response = await post(
+            `${config.host}/api/v1/databases`,
+            { operation: 'access', name, mode },
+            { headers: getApiHeaders(config, 'application/json') },
+        );
+
+        return response.data;
+    } catch (error) {
+        throw safeAppError(error);
+    }
+}
+
+/**
+ * Run one foreground operation with an ephemeral direct client. Native support
+ * is loaded before access is minted, and the client is always closed once it
+ * exists. Direct-client details are collapsed to a credential-safe error.
+ */
+export async function withDatabaseClient<T>(
+    config: Config,
+    name: string,
+    mode: DatabaseAccessMode,
+    operation: (client: DatabaseClient) => Promise<T>,
+    dependencies: DatabaseClientDependencies = {},
+): Promise<T> {
+    const { createClient, access } = await loadDatabaseClientBeforeMint(
+        () => requestDatabaseAccess(config, name, mode, { post: dependencies.post }),
+        { loadClient: dependencies.loadClient },
+    );
+
+    let client: DatabaseClient;
+    try {
+        client = createClient({
+            url: access.url,
+            authToken: access.token,
+            intMode: 'string',
+        }) as DatabaseClient;
+    } catch {
+        throw safeDirectClientError();
+    }
+
+    let primaryFailure: DatabaseOperationError | undefined;
+    try {
+        return await operation(client);
+    } catch {
+        primaryFailure = safeDirectClientError();
+        throw primaryFailure;
+    } finally {
+        try {
+            await client.close();
+        } catch {
+            if (!primaryFailure) {
+                throw safeDirectClientError();
+            }
+        }
+    }
+}
+
+function blobBytes(value: unknown): Uint8Array | null {
+    if (ArrayBuffer.isView(value)) {
+        return new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+    }
+
+    if (value instanceof ArrayBuffer) {
+        return new Uint8Array(value);
+    }
+
+    return null;
+}
+
+/** Normalize direct-client values into the stable JSON contract. */
+export function normalizeDatabaseValue(value: unknown): unknown {
+    if (typeof value === 'bigint') {
+        return value.toString(10);
+    }
+
+    const bytes = blobBytes(value);
+    if (bytes) {
+        return { base64: Buffer.from(bytes).toString('base64') };
+    }
+
+    return value;
+}
+
+/** Render one direct-client value as a concise, implementation-neutral cell. */
+export function formatDatabaseTableValue(value: unknown): string {
+    if (value === null) {
+        return 'NULL';
+    }
+
+    if (typeof value === 'bigint') {
+        return value.toString(10);
+    }
+
+    const bytes = blobBytes(value);
+    if (bytes) {
+        return `<blob ${bytes.byteLength} bytes>`;
+    }
+
+    return String(value);
+}

--- a/src/utils/database-data-plane.ts
+++ b/src/utils/database-data-plane.ts
@@ -55,10 +55,13 @@ function safeAppError(error: unknown): DatabaseOperationError {
     const augmented = augmentTokenMissingAbilityMessage(error);
     const response = (augmented as any)?.response;
     const status = typeof response?.status === 'number' ? response.status : undefined;
-    const code = typeof response?.data?.code === 'string' && response.data.code.length > 0
+    const stableCode = typeof response?.data?.code === 'string' && response.data.code.length > 0
         ? response.data.code
-        : 'upstream_unavailable';
-    const message = typeof response?.data?.message === 'string' && response.data.message.length > 0
+        : null;
+    const code = stableCode ?? 'upstream_unavailable';
+    const message = stableCode !== null
+        && typeof response?.data?.message === 'string'
+        && response.data.message.length > 0
         ? response.data.message
         : 'Database request failed.';
 

--- a/src/utils/database-data-plane.ts
+++ b/src/utils/database-data-plane.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { getApiHeaders } from './api';
+import { augmentTokenMissingAbilityMessage, getApiHeaders } from './api';
 import { Config } from './config';
 import { loadDatabaseClientBeforeMint } from './database-client-support';
 
@@ -21,12 +21,12 @@ interface DatabaseClient {
     [key: string]: unknown;
 }
 
-interface DatabaseRequestDependencies {
+export interface DatabaseRequestDependencies {
     post?: (
         url: string,
         body: Record<string, unknown>,
         options: { headers: Record<string, string> },
-    ) => Promise<{ data: DatabaseAccess }>;
+    ) => Promise<{ data: unknown }>;
 }
 
 interface DatabaseClientDependencies extends DatabaseRequestDependencies {
@@ -52,7 +52,8 @@ export class DatabaseOperationError extends Error {
 }
 
 function safeAppError(error: unknown): DatabaseOperationError {
-    const response = (error as any)?.response;
+    const augmented = augmentTokenMissingAbilityMessage(error);
+    const response = (augmented as any)?.response;
     const status = typeof response?.status === 'number' ? response.status : undefined;
     const code = typeof response?.data?.code === 'string' && response.data.code.length > 0
         ? response.data.code
@@ -62,6 +63,30 @@ function safeAppError(error: unknown): DatabaseOperationError {
         : 'Database request failed.';
 
     return new DatabaseOperationError(code, message, status);
+}
+
+/**
+ * Call the single CLI database control-plane endpoint and discard all Axios
+ * transport state at the error boundary.
+ */
+export async function requestDatabaseOperation<T>(
+    config: Config,
+    body: Record<string, unknown>,
+    dependencies: DatabaseRequestDependencies = {},
+): Promise<T> {
+    const post = dependencies.post ?? axios.post;
+
+    try {
+        const response = await post(
+            `${config.host}/api/v1/databases`,
+            body,
+            { headers: getApiHeaders(config, 'application/json') },
+        );
+
+        return response.data as T;
+    } catch (error) {
+        throw safeAppError(error);
+    }
 }
 
 function safeDirectClientError(): DatabaseOperationError {
@@ -78,19 +103,11 @@ export async function requestDatabaseAccess(
     mode: DatabaseAccessMode,
     dependencies: DatabaseRequestDependencies = {},
 ): Promise<DatabaseAccess> {
-    const post = dependencies.post ?? axios.post;
-
-    try {
-        const response = await post(
-            `${config.host}/api/v1/databases`,
-            { operation: 'access', name, mode },
-            { headers: getApiHeaders(config, 'application/json') },
-        );
-
-        return response.data;
-    } catch (error) {
-        throw safeAppError(error);
-    }
+    return requestDatabaseOperation<DatabaseAccess>(
+        config,
+        { operation: 'access', name, mode },
+        dependencies,
+    );
 }
 
 /**

--- a/src/utils/database-data-plane.ts
+++ b/src/utils/database-data-plane.ts
@@ -32,16 +32,26 @@ export interface DatabaseClient {
 }
 
 export interface DatabaseRequestDependencies {
+    controlPlaneTimeoutMs?: number;
     post?: (
         url: string,
         body: Record<string, unknown>,
-        options: { headers: Record<string, string>; responseType?: 'stream' },
+        options: {
+            headers: Record<string, string>;
+            responseType?: 'stream';
+            signal?: AbortSignal;
+            timeout?: number;
+        },
     ) => Promise<{ data: unknown; status?: number }>;
 }
 
 export interface DatabaseClientDependencies extends DatabaseRequestDependencies {
+    dataPlaneTimeoutMs?: number;
     loadClient?: () => Promise<DatabaseClientModule>;
 }
+
+export const DEFAULT_DATABASE_CONTROL_PLANE_TIMEOUT_MS = 30_000;
+export const DEFAULT_DATABASE_DATA_PLANE_TIMEOUT_MS = 120_000;
 
 export class DatabaseOperationError extends Error {
     readonly code: string;
@@ -70,13 +80,76 @@ export function safeDatabaseRequestError(error: unknown): DatabaseOperationError
         : '';
     const stableCode = codeCandidate.length > 0 ? codeCandidate : null;
     const code = stableCode ?? 'upstream_unavailable';
-    const message = stableCode !== null
+    const appMessage = stableCode !== null
         && typeof response?.data?.message === 'string'
         && response.data.message.trim().length > 0
         ? response.data.message
         : 'Database request failed.';
+    const message = code === 'unauthenticated'
+        ? `${appMessage} Run solidactions login to authenticate again.`
+        : appMessage;
 
     return new DatabaseOperationError(code, message, status);
+}
+
+function positiveTimeout(value: number | undefined, fallback: number): number {
+    return typeof value === 'number' && Number.isFinite(value) && value > 0
+        ? value
+        : fallback;
+}
+
+class DatabaseDeadlineElapsed extends DatabaseOperationError {
+    constructor(message: string) {
+        super('upstream_unavailable', message);
+    }
+}
+
+async function requestWithDeadline<T>(
+    operation: (signal: AbortSignal, timeoutMs: number) => Promise<T>,
+    timeoutMs: number,
+): Promise<T> {
+    const controller = new AbortController();
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const deadline = new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => {
+            controller.abort();
+            reject(new DatabaseDeadlineElapsed('Database request timed out.'));
+        }, timeoutMs);
+    });
+
+    try {
+        return await Promise.race([operation(controller.signal, timeoutMs), deadline]);
+    } finally {
+        if (timer) clearTimeout(timer);
+    }
+}
+
+/**
+ * Bound a Hrana operation and actively invoke its cancellation/close hook when
+ * the deadline expires. Callers can inject a shorter timeout per command.
+ */
+export async function runDatabaseClientOperationWithDeadline<T>(
+    operation: () => Promise<T>,
+    onTimeout: (() => void | Promise<void>) | undefined,
+    timeoutMs = DEFAULT_DATABASE_DATA_PLANE_TIMEOUT_MS,
+): Promise<T> {
+    const boundedTimeout = positiveTimeout(timeoutMs, DEFAULT_DATABASE_DATA_PLANE_TIMEOUT_MS);
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const deadline = new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => {
+            try {
+                void Promise.resolve(onTimeout?.()).catch(() => undefined);
+            } finally {
+                reject(new DatabaseDeadlineElapsed('Database operation timed out.'));
+            }
+        }, boundedTimeout);
+    });
+
+    try {
+        return await Promise.race([Promise.resolve().then(operation), deadline]);
+    } finally {
+        if (timer) clearTimeout(timer);
+    }
 }
 
 /**
@@ -89,12 +162,23 @@ export async function requestDatabaseOperation<T>(
     dependencies: DatabaseRequestDependencies = {},
 ): Promise<T> {
     const post = dependencies.post ?? axios.post;
+    const timeoutMs = positiveTimeout(
+        dependencies.controlPlaneTimeoutMs,
+        DEFAULT_DATABASE_CONTROL_PLANE_TIMEOUT_MS,
+    );
 
     try {
-        const response = await post(
-            `${config.host}/api/v1/databases`,
-            body,
-            { headers: getApiHeaders(config, 'application/json') },
+        const response = await requestWithDeadline(
+            (signal, timeout) => post(
+                `${config.host}/api/v1/databases`,
+                body,
+                {
+                    headers: getApiHeaders(config, 'application/json'),
+                    signal,
+                    timeout,
+                },
+            ),
+            timeoutMs,
         );
 
         return response.data as T;
@@ -110,18 +194,27 @@ export async function requestDatabaseDumpStream(
     dependencies: DatabaseRequestDependencies = {},
 ): Promise<unknown> {
     const post = dependencies.post ?? axios.post;
+    const timeoutMs = positiveTimeout(
+        dependencies.controlPlaneTimeoutMs,
+        DEFAULT_DATABASE_CONTROL_PLANE_TIMEOUT_MS,
+    );
 
     try {
-        const response = await post(
-            `${config.host}/api/v1/databases`,
-            { operation: 'dump', name },
-            {
-                headers: {
-                    ...getApiHeaders(config, 'application/json'),
-                    Accept: 'application/sql',
+        const response = await requestWithDeadline(
+            (signal, timeout) => post(
+                `${config.host}/api/v1/databases`,
+                { operation: 'dump', name },
+                {
+                    headers: {
+                        ...getApiHeaders(config, 'application/json'),
+                        Accept: 'application/sql',
+                    },
+                    responseType: 'stream',
+                    signal,
+                    timeout,
                 },
-                responseType: 'stream',
-            },
+            ),
+            timeoutMs,
         );
 
         return response.data;
@@ -164,7 +257,10 @@ export async function withDatabaseClient<T>(
     dependencies: DatabaseClientDependencies = {},
 ): Promise<T> {
     const { createClient, access } = await loadDatabaseClientBeforeMint(
-        () => requestDatabaseAccess(config, name, mode, { post: dependencies.post }),
+        () => requestDatabaseAccess(config, name, mode, {
+            post: dependencies.post,
+            controlPlaneTimeoutMs: dependencies.controlPlaneTimeoutMs,
+        }),
         { loadClient: dependencies.loadClient },
     );
 
@@ -179,15 +275,34 @@ export async function withDatabaseClient<T>(
         throw safeDirectClientError();
     }
 
+    const dataPlaneTimeoutMs = positiveTimeout(
+        dependencies.dataPlaneTimeoutMs,
+        DEFAULT_DATABASE_DATA_PLANE_TIMEOUT_MS,
+    );
+    let closePromise: Promise<void> | undefined;
+    const closeClient = (): Promise<void> => {
+        closePromise ??= runDatabaseClientOperationWithDeadline(
+            async () => { await client.close(); },
+            undefined,
+            dataPlaneTimeoutMs,
+        );
+        return closePromise;
+    };
     let primaryFailure: DatabaseOperationError | undefined;
     try {
-        return await operation(client);
-    } catch {
-        primaryFailure = safeDirectClientError();
+        return await runDatabaseClientOperationWithDeadline(
+            () => operation(client),
+            closeClient,
+            dataPlaneTimeoutMs,
+        );
+    } catch (error) {
+        primaryFailure = error instanceof DatabaseDeadlineElapsed
+            ? new DatabaseOperationError(error.code, error.message, error.status)
+            : safeDirectClientError();
         throw primaryFailure;
     } finally {
         try {
-            await client.close();
+            await closeClient();
         } catch {
             if (!primaryFailure) {
                 throw safeDirectClientError();

--- a/src/utils/database-data-plane.ts
+++ b/src/utils/database-data-plane.ts
@@ -25,6 +25,7 @@ interface DatabaseClientModule {
 
 export interface DatabaseClient {
     execute: (statement: string | { sql: string; args?: unknown }) => Promise<DatabaseResultSet>;
+    executeMultiple?: (sql: string) => Promise<void>;
     sync?: () => Promise<unknown>;
     close: () => void | Promise<void>;
     [key: string]: unknown;

--- a/src/utils/database-data-plane.ts
+++ b/src/utils/database-data-plane.ts
@@ -12,11 +12,19 @@ export interface DatabaseAccess {
     expires_at: string;
 }
 
+export interface DatabaseResultSet {
+    columns: Array<string>;
+    rows: Array<ArrayLike<unknown>>;
+    rowsAffected?: number;
+    lastInsertRowid?: unknown;
+}
+
 interface DatabaseClientModule {
     createClient: (config: Record<string, unknown>) => DatabaseClient;
 }
 
-interface DatabaseClient {
+export interface DatabaseClient {
+    execute: (statement: string | { sql: string; args?: unknown }) => Promise<DatabaseResultSet>;
     close: () => void | Promise<void>;
     [key: string]: unknown;
 }
@@ -29,7 +37,7 @@ export interface DatabaseRequestDependencies {
     ) => Promise<{ data: unknown }>;
 }
 
-interface DatabaseClientDependencies extends DatabaseRequestDependencies {
+export interface DatabaseClientDependencies extends DatabaseRequestDependencies {
     loadClient?: () => Promise<DatabaseClientModule>;
 }
 

--- a/src/utils/database-data-plane.ts
+++ b/src/utils/database-data-plane.ts
@@ -55,13 +55,14 @@ function safeAppError(error: unknown): DatabaseOperationError {
     const augmented = augmentTokenMissingAbilityMessage(error);
     const response = (augmented as any)?.response;
     const status = typeof response?.status === 'number' ? response.status : undefined;
-    const stableCode = typeof response?.data?.code === 'string' && response.data.code.length > 0
-        ? response.data.code
-        : null;
+    const codeCandidate = typeof response?.data?.code === 'string'
+        ? response.data.code.trim()
+        : '';
+    const stableCode = codeCandidate.length > 0 ? codeCandidate : null;
     const code = stableCode ?? 'upstream_unavailable';
     const message = stableCode !== null
         && typeof response?.data?.message === 'string'
-        && response.data.message.length > 0
+        && response.data.message.trim().length > 0
         ? response.data.message
         : 'Database request failed.';
 

--- a/src/utils/database-sql-import-runner.ts
+++ b/src/utils/database-sql-import-runner.ts
@@ -1,0 +1,584 @@
+import { createHash, randomUUID } from 'crypto';
+import fs from 'fs';
+import path from 'path';
+import { Config } from './config';
+import { loadDatabaseClientBeforeMint } from './database-client-support';
+import {
+    DatabaseClient,
+    DatabaseClientDependencies,
+    DatabaseOperationError,
+    requestDatabaseAccess,
+} from './database-data-plane';
+import {
+    DatabaseSqlImportGroup,
+    parseDatabaseImportSql,
+} from './database-sql-import';
+
+const CHECKPOINT_VERSION = 1;
+const MAX_BATCH_GROUPS = 100;
+const MAX_BATCH_BYTES = 512 * 1024;
+const RENEWAL_WINDOW_MS = 30_000;
+
+type ImportFileSystem = typeof fs.promises;
+
+interface ImportCheckpoint {
+    version: 1;
+    database: string;
+    source: {
+        sha256: string;
+        sizeBytes: number;
+    };
+    lastCompletedBatch: number;
+    nextStatement: number;
+    completedSourceBytes: number;
+}
+
+export interface PreparedDatabaseImportSource {
+    file: string;
+    source: Buffer;
+    sha256: string;
+    sizeBytes: number;
+    groups: DatabaseSqlImportGroup[];
+}
+
+export interface PreparedDatabaseImport extends PreparedDatabaseImportSource {
+    database: string;
+    checkpointPath: string;
+    checkpoint: ImportCheckpoint | null;
+}
+
+export interface DatabaseImportRunnerDependencies extends DatabaseClientDependencies {
+    cwd: string;
+    filesystem: ImportFileSystem;
+    stdout: (line: string) => void;
+    now: () => number;
+}
+
+function importFailure(message = 'Database import failed.'): DatabaseOperationError {
+    return new DatabaseOperationError('import_failed', message);
+}
+
+function safeStem(database: string): string {
+    return database
+        .normalize('NFKD')
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '')
+        .slice(0, 80) || 'database';
+}
+
+function resumeLine(database: string, file: string, checkpoint: string): string {
+    return `Resume with: solidactions database import ${JSON.stringify(database)} ${JSON.stringify(file)} --resume ${JSON.stringify(checkpoint)} --yes`;
+}
+
+function checkpointPath(cwd: string, database: string, sha256: string, sizeBytes: number): string {
+    return path.join(
+        cwd,
+        '.solidactions',
+        'imports',
+        `${safeStem(database)}-${sha256}-${sizeBytes}.json`,
+    );
+}
+
+async function lstatMaybe(filesystem: ImportFileSystem, target: string): Promise<fs.Stats | null> {
+    try {
+        return await filesystem.lstat(target);
+    } catch (error) {
+        if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') return null;
+        throw importFailure('The import checkpoint path could not be validated.');
+    }
+}
+
+async function assertSafeAncestors(filesystem: ImportFileSystem, target: string): Promise<void> {
+    const absolute = path.resolve(target);
+    const parent = path.dirname(absolute);
+    const root = path.parse(parent).root;
+    const parts = parent.slice(root.length).split(path.sep).filter(Boolean);
+    let current = root;
+
+    for (const part of parts) {
+        current = path.join(current, part);
+        const stat = await lstatMaybe(filesystem, current);
+        if (!stat) return;
+        if (stat.isSymbolicLink() || !stat.isDirectory()) {
+            throw importFailure('The import checkpoint path is unsafe.');
+        }
+    }
+}
+
+async function assertRegularCheckpoint(
+    filesystem: ImportFileSystem,
+    target: string,
+): Promise<fs.Stats> {
+    await assertSafeAncestors(filesystem, target);
+    const stat = await lstatMaybe(filesystem, target);
+    if (!stat || stat.isSymbolicLink() || !stat.isFile()) {
+        throw importFailure('The import checkpoint must be a regular non-symlink file.');
+    }
+    return stat;
+}
+
+function checkpointBoundary(groups: DatabaseSqlImportGroup[], nextStatement: number): number | null {
+    if (!Number.isInteger(nextStatement) || nextStatement < 0 || nextStatement > groups.length) return null;
+    return nextStatement === 0 ? 0 : groups[nextStatement - 1].endByte;
+}
+
+function deterministicBatchCount(
+    groups: DatabaseSqlImportGroup[],
+    nextStatement: number,
+): number | null {
+    if (nextStatement === 0) return 0;
+    let cursor = 0;
+    let count = 0;
+    while (cursor < groups.length) {
+        const batch = nextBatch(groups, cursor);
+        cursor = batch.nextStatement;
+        count += 1;
+        if (cursor === nextStatement) return count;
+        if (cursor > nextStatement) return null;
+    }
+    return null;
+}
+
+function validateCheckpoint(
+    value: unknown,
+    database: string,
+    sha256: string,
+    sizeBytes: number,
+    groups: DatabaseSqlImportGroup[],
+): ImportCheckpoint {
+    const checkpoint = value as Record<string, unknown> | null;
+    const source = checkpoint?.source as Record<string, unknown> | null;
+    const nextStatement = checkpoint?.nextStatement;
+    const completedSourceBytes = checkpoint?.completedSourceBytes;
+    const expectedBoundary = typeof nextStatement === 'number'
+        ? checkpointBoundary(groups, nextStatement)
+        : null;
+    const expectedBatchCount = typeof nextStatement === 'number'
+        ? deterministicBatchCount(groups, nextStatement)
+        : null;
+
+    if (
+        checkpoint?.version !== CHECKPOINT_VERSION
+        || checkpoint.database !== database
+        || source?.sha256 !== sha256
+        || source.sizeBytes !== sizeBytes
+        || typeof checkpoint.lastCompletedBatch !== 'number'
+        || !Number.isInteger(checkpoint.lastCompletedBatch)
+        || checkpoint.lastCompletedBatch !== expectedBatchCount
+        || typeof nextStatement !== 'number'
+        || expectedBoundary === null
+        || completedSourceBytes !== expectedBoundary
+    ) {
+        throw importFailure('The import checkpoint does not match this database and SQL source.');
+    }
+
+    return {
+        version: 1,
+        database,
+        source: { sha256, sizeBytes },
+        lastCompletedBatch: checkpoint.lastCompletedBatch,
+        nextStatement,
+        completedSourceBytes,
+    };
+}
+
+async function readCheckpoint(
+    filesystem: ImportFileSystem,
+    target: string,
+    database: string,
+    sha256: string,
+    sizeBytes: number,
+    groups: DatabaseSqlImportGroup[],
+): Promise<ImportCheckpoint> {
+    await assertRegularCheckpoint(filesystem, target);
+    let value: unknown;
+    try {
+        value = JSON.parse(await filesystem.readFile(target, 'utf8'));
+    } catch {
+        throw importFailure('The import checkpoint is corrupt.');
+    }
+    return validateCheckpoint(value, database, sha256, sizeBytes, groups);
+}
+
+export async function prepareDatabaseImportSource(
+    file: string,
+    cwd: string,
+    filesystem: ImportFileSystem,
+): Promise<PreparedDatabaseImportSource> {
+    const sourcePath = path.isAbsolute(file) ? file : path.resolve(cwd, file);
+    let source: Buffer;
+    try {
+        source = Buffer.from(await filesystem.readFile(sourcePath));
+    } catch {
+        throw importFailure('The SQL import source could not be read.');
+    }
+
+    let groups: DatabaseSqlImportGroup[];
+    try {
+        groups = parseDatabaseImportSql(source).groups;
+    } catch (error) {
+        if (error instanceof DatabaseOperationError) throw importFailure(error.message);
+        throw importFailure('The SQL import source is invalid.');
+    }
+    if (groups.length === 0) throw importFailure('The SQL import source contains no statements.');
+
+    const sha256 = createHash('sha256').update(source).digest('hex');
+    const sizeBytes = source.length;
+    return { file, source, sha256, sizeBytes, groups };
+}
+
+export async function bindPreparedDatabaseImport(
+    prepared: PreparedDatabaseImportSource,
+    database: string,
+    resume: string | undefined,
+    cwd: string,
+    filesystem: ImportFileSystem,
+): Promise<PreparedDatabaseImport> {
+    const { file, source, sha256, sizeBytes, groups } = prepared;
+    const deterministic = checkpointPath(cwd, database, sha256, sizeBytes);
+    await assertSafeAncestors(filesystem, deterministic);
+    const deterministicStat = await lstatMaybe(filesystem, deterministic);
+    if (deterministicStat && (deterministicStat.isSymbolicLink() || !deterministicStat.isFile())) {
+        throw importFailure('The import checkpoint path is unsafe.');
+    }
+
+    if (resume) {
+        const supplied = path.isAbsolute(resume) ? resume : path.resolve(cwd, resume);
+        if (deterministicStat && path.resolve(deterministic) !== path.resolve(supplied)) {
+            throw importFailure('A different import checkpoint already exists for this SQL source.');
+        }
+        const checkpoint = await readCheckpoint(
+            filesystem,
+            supplied,
+            database,
+            sha256,
+            sizeBytes,
+            groups,
+        );
+        return {
+            database,
+            file,
+            source,
+            sha256,
+            sizeBytes,
+            groups,
+            checkpointPath: supplied,
+            checkpoint,
+        };
+    }
+
+    if (deterministicStat) {
+        await readCheckpoint(filesystem, deterministic, database, sha256, sizeBytes, groups);
+        throw importFailure(
+            `A matching import checkpoint already exists.\n${resumeLine(database, file, deterministic)}`,
+        );
+    }
+
+    return {
+        database,
+        file,
+        source,
+        sha256,
+        sizeBytes,
+        groups,
+        checkpointPath: deterministic,
+        checkpoint: null,
+    };
+}
+
+export async function prepareDatabaseImport(
+    database: string,
+    file: string,
+    resume: string | undefined,
+    cwd: string,
+    filesystem: ImportFileSystem,
+): Promise<PreparedDatabaseImport> {
+    const prepared = await prepareDatabaseImportSource(file, cwd, filesystem);
+    return bindPreparedDatabaseImport(prepared, database, resume, cwd, filesystem);
+}
+
+async function ensureSafeDirectory(filesystem: ImportFileSystem, directory: string): Promise<void> {
+    const absolute = path.resolve(directory);
+    const root = path.parse(absolute).root;
+    const parts = absolute.slice(root.length).split(path.sep).filter(Boolean);
+    let current = root;
+
+    for (const part of parts) {
+        current = path.join(current, part);
+        let stat = await lstatMaybe(filesystem, current);
+        if (!stat) {
+            try {
+                await filesystem.mkdir(current, { mode: 0o700 });
+            } catch (error) {
+                if ((error as NodeJS.ErrnoException)?.code !== 'EEXIST') {
+                    throw importFailure('The import checkpoint directory could not be created.');
+                }
+            }
+            stat = await lstatMaybe(filesystem, current);
+        }
+        if (!stat || stat.isSymbolicLink() || !stat.isDirectory()) {
+            throw importFailure('The import checkpoint path is unsafe.');
+        }
+    }
+}
+
+async function publishCheckpoint(
+    filesystem: ImportFileSystem,
+    target: string,
+    checkpoint: ImportCheckpoint,
+    allowExisting: boolean,
+): Promise<void> {
+    const directory = path.dirname(target);
+    await ensureSafeDirectory(filesystem, directory);
+    await assertSafeAncestors(filesystem, target);
+
+    const existing = await lstatMaybe(filesystem, target);
+    if (
+        (existing && (existing.isSymbolicLink() || !existing.isFile()))
+        || (existing && !allowExisting)
+    ) {
+        throw importFailure('The import checkpoint path is unsafe.');
+    }
+
+    const temp = path.join(directory, `.${path.basename(target)}.${randomUUID()}.tmp`);
+    let handle: Awaited<ReturnType<ImportFileSystem['open']>> | undefined;
+    let ownsTemp = false;
+    try {
+        handle = await filesystem.open(temp, 'wx', 0o600);
+        ownsTemp = true;
+        await handle.writeFile(`${JSON.stringify(checkpoint)}\n`, 'utf8');
+        await handle.sync();
+        await handle.close();
+        handle = undefined;
+
+        await assertSafeAncestors(filesystem, target);
+        const finalExisting = await lstatMaybe(filesystem, target);
+        if (
+            (finalExisting && (finalExisting.isSymbolicLink() || !finalExisting.isFile()))
+            || (finalExisting && !allowExisting)
+        ) {
+            throw importFailure('The import checkpoint path is unsafe.');
+        }
+        const tempStat = await lstatMaybe(filesystem, temp);
+        if (!tempStat || tempStat.isSymbolicLink() || !tempStat.isFile()) {
+            throw importFailure('The import checkpoint temporary file is unsafe.');
+        }
+        await filesystem.rename(temp, target);
+        ownsTemp = false;
+    } catch {
+        if (handle) {
+            try {
+                await handle.close();
+            } catch {
+                // The public failure below remains credential- and path-safe.
+            }
+        }
+        if (ownsTemp) {
+            try {
+                await filesystem.unlink(temp);
+            } catch {
+                // Cleanup is scoped to the exclusively created sibling.
+            }
+        }
+        throw importFailure('The committed batch could not be checkpointed safely.');
+    }
+}
+
+async function removeCheckpoint(filesystem: ImportFileSystem, target: string): Promise<void> {
+    await assertRegularCheckpoint(filesystem, target);
+    try {
+        await filesystem.unlink(target);
+    } catch {
+        throw importFailure('The completed import checkpoint could not be removed safely.');
+    }
+}
+
+interface ImportBatch {
+    groups: DatabaseSqlImportGroup[];
+    nextStatement: number;
+}
+
+function nextBatch(groups: DatabaseSqlImportGroup[], start: number): ImportBatch {
+    const selected: DatabaseSqlImportGroup[] = [];
+    let bytes = 0;
+    let index = start;
+    while (index < groups.length && selected.length < MAX_BATCH_GROUPS) {
+        const groupBytes = Buffer.byteLength(groups[index].sql, 'utf8');
+        if (selected.length > 0 && bytes + groupBytes > MAX_BATCH_BYTES) break;
+        selected.push(groups[index]);
+        bytes += groupBytes;
+        index += 1;
+        if (groupBytes > MAX_BATCH_BYTES) break;
+    }
+    return { groups: selected, nextStatement: index };
+}
+
+function batchSql(groups: DatabaseSqlImportGroup[]): string {
+    return [
+        'PRAGMA foreign_keys=OFF;',
+        'BEGIN IMMEDIATE;',
+        ...groups.map((group) => group.sql),
+        'COMMIT;',
+        'PRAGMA foreign_keys=ON;',
+    ].join('\n');
+}
+
+function validateAccess(access: unknown, now: number): { url: string; token: string; expiresAt: number } {
+    const value = access as Record<string, unknown> | null;
+    const url = typeof value?.url === 'string' ? value.url.trim() : '';
+    const token = typeof value?.token === 'string' ? value.token.trim() : '';
+    const expiresAt = typeof value?.expires_at === 'string' ? Date.parse(value.expires_at) : Number.NaN;
+    if (
+        value?.mode !== 'write'
+        || url === ''
+        || token === ''
+        || !Number.isFinite(now)
+        || !Number.isFinite(expiresAt)
+        || expiresAt <= now + RENEWAL_WINDOW_MS
+    ) {
+        throw importFailure('Database import access was invalid.');
+    }
+    return { url, token, expiresAt };
+}
+
+async function acquireClient(
+    prepared: PreparedDatabaseImport,
+    config: Config,
+    dependencies: DatabaseImportRunnerDependencies,
+): Promise<{ client: DatabaseClient; expiresAt: number }> {
+    let loaded: Awaited<ReturnType<typeof loadDatabaseClientBeforeMint>>;
+    try {
+        loaded = await loadDatabaseClientBeforeMint(
+            () => requestDatabaseAccess(config, prepared.database, 'write', { post: dependencies.post }),
+            { loadClient: dependencies.loadClient },
+        );
+    } catch {
+        throw importFailure('Database import access could not be renewed.');
+    }
+
+    const access = validateAccess(loaded.access, dependencies.now());
+    let client: DatabaseClient;
+    try {
+        client = loaded.createClient({
+            url: access.url,
+            authToken: access.token,
+            intMode: 'string',
+        }) as DatabaseClient;
+    } catch {
+        throw importFailure('Database import client could not be created.');
+    }
+
+    if (typeof client.executeMultiple !== 'function') {
+        try {
+            await client.close();
+        } catch {
+            // The unsupported client error below is the only public detail.
+        }
+        throw importFailure('Database import requires atomic multi-statement execution support.');
+    }
+    return { client, expiresAt: access.expiresAt };
+}
+
+async function closeClient(client: DatabaseClient | undefined): Promise<void> {
+    if (!client) return;
+    try {
+        await client.close();
+    } catch {
+        throw importFailure('Database import client cleanup failed.');
+    }
+}
+
+export async function runPreparedDatabaseImport(
+    prepared: PreparedDatabaseImport,
+    config: Config,
+    dependencies: DatabaseImportRunnerDependencies,
+): Promise<void> {
+    let nextStatement = prepared.checkpoint?.nextStatement ?? 0;
+    let completedBatches = prepared.checkpoint?.lastCompletedBatch ?? 0;
+    let completedSourceBytes = prepared.checkpoint?.completedSourceBytes ?? 0;
+    let checkpointPublished = prepared.checkpoint !== null;
+    let suppressResume = false;
+    let client: DatabaseClient | undefined;
+    let expiresAt = 0;
+    let failure: DatabaseOperationError | undefined;
+
+    try {
+        while (nextStatement < prepared.groups.length) {
+            if (!client || dependencies.now() >= expiresAt - RENEWAL_WINDOW_MS) {
+                await closeClient(client);
+                client = undefined;
+                const acquired = await acquireClient(prepared, config, dependencies);
+                client = acquired.client;
+                expiresAt = acquired.expiresAt;
+            }
+
+            const batch = nextBatch(prepared.groups, nextStatement);
+            try {
+                await client.executeMultiple!(batchSql(batch.groups));
+            } catch {
+                throw importFailure('A database import batch failed.');
+            }
+
+            const boundary = prepared.groups[batch.nextStatement - 1].endByte;
+            const checkpoint: ImportCheckpoint = {
+                version: 1,
+                database: prepared.database,
+                source: {
+                    sha256: prepared.sha256,
+                    sizeBytes: prepared.sizeBytes,
+                },
+                lastCompletedBatch: completedBatches + 1,
+                nextStatement: batch.nextStatement,
+                completedSourceBytes: boundary,
+            };
+            try {
+                await publishCheckpoint(
+                    dependencies.filesystem,
+                    prepared.checkpointPath,
+                    checkpoint,
+                    checkpointPublished,
+                );
+            } catch {
+                suppressResume = true;
+                throw importFailure('A committed database import batch could not be checkpointed safely.');
+            }
+
+            checkpointPublished = true;
+            completedBatches += 1;
+            nextStatement = batch.nextStatement;
+            completedSourceBytes = boundary;
+            dependencies.stdout(`Imported checkpoint: ${nextStatement} statements, ${boundary} source bytes.`);
+        }
+    } catch {
+        failure = importFailure('Database import failed.');
+    }
+
+    try {
+        await closeClient(client);
+        client = undefined;
+    } catch {
+        if (!failure) failure = importFailure('Database import client cleanup failed.');
+    }
+
+    if (!failure) {
+        try {
+            await removeCheckpoint(dependencies.filesystem, prepared.checkpointPath);
+            checkpointPublished = false;
+        } catch {
+            suppressResume = true;
+            failure = importFailure('The completed import could not remove its checkpoint safely.');
+        }
+    }
+
+    if (failure) {
+        const guidance = checkpointPublished && !suppressResume
+            ? `\nLast completed position: batch ${completedBatches}, ${nextStatement} statements, ${completedSourceBytes} source bytes.\n${resumeLine(prepared.database, prepared.file, prepared.checkpointPath)}`
+            : '';
+        throw importFailure(`${failure.message}${guidance}`);
+    }
+
+    dependencies.stdout(
+        `Imported ${prepared.groups.length} statements (${prepared.sizeBytes} source bytes) into database "${prepared.database}".`,
+    );
+}

--- a/src/utils/database-sql-import-runner.ts
+++ b/src/utils/database-sql-import-runner.ts
@@ -453,7 +453,8 @@ async function acquireClient(
             () => requestDatabaseAccess(config, prepared.database, 'write', { post: dependencies.post }),
             { loadClient: dependencies.loadClient },
         );
-    } catch {
+    } catch (error) {
+        if (error instanceof DatabaseOperationError) throw error;
         throw importFailure('Database import access could not be renewed.');
     }
 
@@ -516,7 +517,8 @@ export async function runPreparedDatabaseImport(
             const batch = nextBatch(prepared.groups, nextStatement);
             try {
                 await client.executeMultiple!(batchSql(batch.groups));
-            } catch {
+            } catch (error) {
+                if (error instanceof DatabaseOperationError) throw error;
                 throw importFailure('A database import batch failed.');
             }
 
@@ -552,8 +554,10 @@ export async function runPreparedDatabaseImport(
                 `Imported checkpoint: ${nextStatement} statements, committed source progress: ${boundary} source bytes.`,
             );
         }
-    } catch {
-        failure = importFailure('Database import failed.');
+    } catch (error) {
+        failure = error instanceof DatabaseOperationError
+            ? error
+            : importFailure('Database import failed.');
     }
 
     try {
@@ -574,10 +578,13 @@ export async function runPreparedDatabaseImport(
     }
 
     if (failure) {
-        const guidance = checkpointPublished && !suppressResume
+        const policyRefusal = failure.code === 'read_only_mode'
+            || failure.code === 'plan_denied'
+            || failure.status === 429;
+        const guidance = checkpointPublished && !suppressResume && !policyRefusal
             ? `\nLast completed position: batch ${completedBatches}, ${nextStatement} statements, ${completedSourceBytes} source bytes.\n${resumeLine(prepared.database, prepared.file, prepared.checkpointPath)}`
             : '';
-        throw importFailure(`${failure.message}${guidance}`);
+        throw new DatabaseOperationError(failure.code, `${failure.message}${guidance}`, failure.status);
     }
 
     dependencies.stdout(

--- a/src/utils/database-sql-import-runner.ts
+++ b/src/utils/database-sql-import-runner.ts
@@ -7,7 +7,9 @@ import {
     DatabaseClient,
     DatabaseClientDependencies,
     DatabaseOperationError,
+    DEFAULT_DATABASE_DATA_PLANE_TIMEOUT_MS,
     requestDatabaseAccess,
+    runDatabaseClientOperationWithDeadline,
 } from './database-data-plane';
 import {
     DatabaseSqlImportGroup,
@@ -450,7 +452,10 @@ async function acquireClient(
     let loaded: Awaited<ReturnType<typeof loadDatabaseClientBeforeMint>>;
     try {
         loaded = await loadDatabaseClientBeforeMint(
-            () => requestDatabaseAccess(config, prepared.database, 'write', { post: dependencies.post }),
+            () => requestDatabaseAccess(config, prepared.database, 'write', {
+                post: dependencies.post,
+                controlPlaneTimeoutMs: dependencies.controlPlaneTimeoutMs,
+            }),
             { loadClient: dependencies.loadClient },
         );
     } catch (error) {
@@ -472,7 +477,11 @@ async function acquireClient(
 
     if (typeof client.executeMultiple !== 'function') {
         try {
-            await client.close();
+            await runDatabaseClientOperationWithDeadline(
+                async () => { await client.close(); },
+                undefined,
+                dependencies.dataPlaneTimeoutMs ?? DEFAULT_DATABASE_DATA_PLANE_TIMEOUT_MS,
+            );
         } catch {
             // The unsupported client error below is the only public detail.
         }
@@ -481,10 +490,17 @@ async function acquireClient(
     return { client, expiresAt: access.expiresAt };
 }
 
-async function closeClient(client: DatabaseClient | undefined): Promise<void> {
+async function closeClient(
+    client: DatabaseClient | undefined,
+    timeoutMs = DEFAULT_DATABASE_DATA_PLANE_TIMEOUT_MS,
+): Promise<void> {
     if (!client) return;
     try {
-        await client.close();
+        await runDatabaseClientOperationWithDeadline(
+            async () => { await client.close(); },
+            undefined,
+            timeoutMs,
+        );
     } catch {
         throw importFailure('Database import client cleanup failed.');
     }
@@ -501,14 +517,20 @@ export async function runPreparedDatabaseImport(
     let checkpointPublished = prepared.checkpoint !== null;
     let suppressResume = false;
     let client: DatabaseClient | undefined;
+    let clientClosePromise: Promise<void> | undefined;
     let expiresAt = 0;
     let failure: DatabaseOperationError | undefined;
+    const closeCurrentClient = (): Promise<void> => {
+        clientClosePromise ??= closeClient(client, dependencies.dataPlaneTimeoutMs);
+        return clientClosePromise;
+    };
 
     try {
         while (nextStatement < prepared.groups.length) {
             if (!client || dependencies.now() >= expiresAt - RENEWAL_WINDOW_MS) {
-                await closeClient(client);
+                await closeCurrentClient();
                 client = undefined;
+                clientClosePromise = undefined;
                 const acquired = await acquireClient(prepared, config, dependencies);
                 client = acquired.client;
                 expiresAt = acquired.expiresAt;
@@ -516,7 +538,11 @@ export async function runPreparedDatabaseImport(
 
             const batch = nextBatch(prepared.groups, nextStatement);
             try {
-                await client.executeMultiple!(batchSql(batch.groups));
+                await runDatabaseClientOperationWithDeadline(
+                    () => client!.executeMultiple!(batchSql(batch.groups)),
+                    closeCurrentClient,
+                    dependencies.dataPlaneTimeoutMs ?? DEFAULT_DATABASE_DATA_PLANE_TIMEOUT_MS,
+                );
             } catch (error) {
                 if (error instanceof DatabaseOperationError) throw error;
                 throw importFailure('A database import batch failed.');
@@ -561,8 +587,9 @@ export async function runPreparedDatabaseImport(
     }
 
     try {
-        await closeClient(client);
+        await closeCurrentClient();
         client = undefined;
+        clientClosePromise = undefined;
     } catch {
         if (!failure) failure = importFailure('Database import client cleanup failed.');
     }

--- a/src/utils/database-sql-import-runner.ts
+++ b/src/utils/database-sql-import-runner.ts
@@ -548,7 +548,9 @@ export async function runPreparedDatabaseImport(
             completedBatches += 1;
             nextStatement = batch.nextStatement;
             completedSourceBytes = boundary;
-            dependencies.stdout(`Imported checkpoint: ${nextStatement} statements, ${boundary} source bytes.`);
+            dependencies.stdout(
+                `Imported checkpoint: ${nextStatement} statements, committed source progress: ${boundary} source bytes.`,
+            );
         }
     } catch {
         failure = importFailure('Database import failed.');
@@ -579,6 +581,6 @@ export async function runPreparedDatabaseImport(
     }
 
     dependencies.stdout(
-        `Imported ${prepared.groups.length} statements (${prepared.sizeBytes} source bytes) into database "${prepared.database}".`,
+        `Imported ${prepared.groups.length} statements (${prepared.sizeBytes} total source bytes) into database "${prepared.database}".`,
     );
 }

--- a/src/utils/database-sql-import.ts
+++ b/src/utils/database-sql-import.ts
@@ -45,17 +45,18 @@ function decodeSource(source: Buffer | string): { text: string; byteBase: number
         && source[0] === 0xef
         && source[1] === 0xbb
         && source[2] === 0xbf;
+    let text: string;
     try {
         // TextDecoder consumes the first UTF-8 BOM. A second BOM remains in
         // the decoded text and is deliberately not normalized away.
-        const text = new TextDecoder('utf-8', { fatal: true }).decode(source);
-        if (hasBom && text.startsWith('\uFEFF')) {
-            throw importError('The SQL import source has more than one leading UTF-8 BOM.');
-        }
-        return { text, byteBase: hasBom ? 3 : 0 };
+        text = new TextDecoder('utf-8', { fatal: true }).decode(source);
     } catch {
         throw importError('The SQL import source is not valid UTF-8.');
     }
+    if (hasBom && text.startsWith('\uFEFF')) {
+        throw importError('The SQL import source has more than one leading UTF-8 BOM.');
+    }
+    return { text, byteBase: hasBom ? 3 : 0 };
 }
 
 function codePointWidth(text: string, index: number): number {
@@ -276,6 +277,57 @@ function scanDatabaseSqlGroupsWithTokens(text: string, byteBase = 0): ScannedGro
  */
 export function scanDatabaseSqlGroups(text: string, byteBase = 0): DatabaseSqlImportGroup[] {
     return scanDatabaseSqlGroupsWithTokens(text, byteBase).map(({ tokens: _tokens, ...group }) => group);
+}
+
+export interface AccumulatedDatabaseSql {
+    sql: string;
+    multiple: boolean;
+}
+
+/**
+ * Incrementally frame complete SQLite input using the same quote, comment,
+ * identifier, and trigger grammar as SQL imports.
+ */
+export class DatabaseSqlStatementAccumulator {
+    private lines: string[] = [];
+
+    get pending(): boolean {
+        return this.lines.some((line) => line.trim() !== '');
+    }
+
+    push(line: string): AccumulatedDatabaseSql | null {
+        if (!this.pending && line.trim() === '') return null;
+        this.lines.push(line);
+        const sql = this.lines.join('\n');
+        let groups: ScannedGroup[];
+
+        try {
+            groups = scanDatabaseSqlGroupsWithTokens(sql);
+        } catch (error) {
+            if (
+                error instanceof DatabaseOperationError
+                && /^(?:Unterminated|Incomplete) SQL\b/.test(error.message)
+            ) {
+                return null;
+            }
+            throw error;
+        }
+
+        if (groups.length === 0) return null;
+
+        const first = sqlWithoutLeadingComments(groups[0].sql);
+        const last = sqlWithoutLeadingComments(groups[groups.length - 1].sql);
+        const explicitTransaction = /^BEGIN(?:\s+TRANSACTION)?\s*;$/i.test(first);
+        if (explicitTransaction && !/^(?:COMMIT|END|ROLLBACK)\s*;$/i.test(last)) {
+            return null;
+        }
+
+        this.lines = [];
+        return {
+            sql,
+            multiple: explicitTransaction || groups.length > 1,
+        };
+    }
 }
 
 type GroupKind =

--- a/src/utils/database-sql-import.ts
+++ b/src/utils/database-sql-import.ts
@@ -1,0 +1,393 @@
+import { DatabaseOperationError } from './database-data-plane';
+
+const MAX_IMPORT_GROUP_BYTES = 8 * 1024 * 1024;
+const INCOMPLETE_DOWNLOAD_MARKER = /(?:^|\n)[\t ]*--[\t ]+DOWNLOAD INCOMPLETE\b/;
+
+export interface DatabaseSqlImportGroup {
+    sql: string;
+    startByte: number;
+    endByte: number;
+    startLine: number;
+    endLine: number;
+}
+
+export interface ParsedDatabaseImportSql {
+    groups: DatabaseSqlImportGroup[];
+    foreignKeysOff: boolean;
+}
+
+interface SqlToken {
+    value: string;
+    line: number;
+}
+
+interface ScannedGroup extends DatabaseSqlImportGroup {
+    tokens: SqlToken[];
+}
+
+function importError(message: string): DatabaseOperationError {
+    return new DatabaseOperationError('import_failed', message);
+}
+
+function decodeSource(source: Buffer | string): { text: string; byteBase: number } {
+    if (typeof source === 'string') {
+        if (source.startsWith('\uFEFF')) {
+            const text = source.slice(1);
+            if (text.startsWith('\uFEFF')) {
+                throw importError('The SQL import source has more than one leading UTF-8 BOM.');
+            }
+            return { text, byteBase: 3 };
+        }
+        return { text: source, byteBase: 0 };
+    }
+
+    const hasBom = source.length >= 3
+        && source[0] === 0xef
+        && source[1] === 0xbb
+        && source[2] === 0xbf;
+    try {
+        // TextDecoder consumes the first UTF-8 BOM. A second BOM remains in
+        // the decoded text and is deliberately not normalized away.
+        const text = new TextDecoder('utf-8', { fatal: true }).decode(source);
+        if (hasBom && text.startsWith('\uFEFF')) {
+            throw importError('The SQL import source has more than one leading UTF-8 BOM.');
+        }
+        return { text, byteBase: hasBom ? 3 : 0 };
+    } catch {
+        throw importError('The SQL import source is not valid UTF-8.');
+    }
+}
+
+function codePointWidth(text: string, index: number): number {
+    const point = text.codePointAt(index);
+    return point !== undefined && point > 0xffff ? 2 : 1;
+}
+
+function byteOffsets(text: string, byteBase: number): Uint32Array {
+    const offsets = new Uint32Array(text.length + 1);
+    let bytes = byteBase;
+    let index = 0;
+
+    while (index < text.length) {
+        offsets[index] = bytes;
+        const width = codePointWidth(text, index);
+        if (width === 2) offsets[index + 1] = bytes;
+        bytes += Buffer.byteLength(text.slice(index, index + width), 'utf8');
+        index += width;
+        offsets[index] = bytes;
+    }
+
+    return offsets;
+}
+
+function isWhitespace(character: string): boolean {
+    return /\s/u.test(character);
+}
+
+function isIdentifierStart(character: string): boolean {
+    return /[A-Za-z_]/.test(character);
+}
+
+function isIdentifierPart(character: string): boolean {
+    return /[A-Za-z0-9_$]/.test(character);
+}
+
+function isTriggerDeclaration(tokens: SqlToken[]): boolean {
+    if (tokens[0]?.value !== 'CREATE') return false;
+    if (tokens[1]?.value === 'TRIGGER') return true;
+    return ['TEMP', 'TEMPORARY'].includes(tokens[1]?.value)
+        && tokens[2]?.value === 'TRIGGER';
+}
+
+function scanDatabaseSqlGroupsWithTokens(text: string, byteBase = 0): ScannedGroup[] {
+    const offsets = byteOffsets(text, byteBase);
+    const groups: ScannedGroup[] = [];
+    let index = 0;
+    let line = 1;
+    let groupStart = -1;
+    let groupStartLine = 1;
+    let hasSql = false;
+    let tokens: SqlToken[] = [];
+    let trigger = false;
+    let triggerBeginDepth = 0;
+    let triggerCaseDepth = 0;
+    let triggerEnded = false;
+
+    const advance = () => {
+        if (text[index] === '\n') line += 1;
+        index += codePointWidth(text, index);
+    };
+
+    const startGroup = () => {
+        if (groupStart < 0) {
+            groupStart = index;
+            groupStartLine = line;
+        }
+    };
+
+    const resetGroup = () => {
+        groupStart = -1;
+        groupStartLine = line;
+        hasSql = false;
+        tokens = [];
+        trigger = false;
+        triggerBeginDepth = 0;
+        triggerCaseDepth = 0;
+        triggerEnded = false;
+    };
+
+    const finishGroup = (endIndex: number, endLine: number) => {
+        const startByte = offsets[groupStart];
+        const endByte = offsets[endIndex];
+        if (endByte - startByte > MAX_IMPORT_GROUP_BYTES) {
+            throw importError(`SQL statement at line ${groupStartLine} exceeds the 8 MiB import limit.`);
+        }
+
+        groups.push({
+            sql: text.slice(groupStart, endIndex),
+            startByte,
+            endByte,
+            startLine: groupStartLine,
+            endLine,
+            tokens,
+        });
+        resetGroup();
+    };
+
+    const scanQuoted = (closing: string, doubledEscape: boolean) => {
+        const quoteLine = line;
+        advance();
+        while (index < text.length) {
+            if (text[index] === closing) {
+                if (doubledEscape && text[index + 1] === closing) {
+                    advance();
+                    advance();
+                    continue;
+                }
+                advance();
+                return;
+            }
+            advance();
+        }
+        throw importError(`Unterminated SQL quote at line ${quoteLine}.`);
+    };
+
+    while (index < text.length) {
+        const character = text[index];
+
+        if (isWhitespace(character)) {
+            advance();
+            continue;
+        }
+
+        if (character === '-' && text[index + 1] === '-') {
+            startGroup();
+            advance();
+            advance();
+            while (index < text.length && text[index] !== '\n') advance();
+            continue;
+        }
+
+        if (character === '/' && text[index + 1] === '*') {
+            const commentLine = line;
+            startGroup();
+            advance();
+            advance();
+            let closed = false;
+            while (index < text.length) {
+                if (text[index] === '*' && text[index + 1] === '/') {
+                    advance();
+                    advance();
+                    closed = true;
+                    break;
+                }
+                advance();
+            }
+            if (!closed) throw importError(`Unterminated SQL comment at line ${commentLine}.`);
+            continue;
+        }
+
+        startGroup();
+        hasSql = true;
+
+        if (character === '\'' || character === '"' || character === '`') {
+            scanQuoted(character, true);
+            continue;
+        }
+
+        if (character === '[') {
+            scanQuoted(']', true);
+            continue;
+        }
+
+        if (isIdentifierStart(character)) {
+            const tokenLine = line;
+            const tokenStart = index;
+            while (index < text.length && isIdentifierPart(text[index])) advance();
+            const value = text.slice(tokenStart, index).toUpperCase();
+            tokens.push({ value, line: tokenLine });
+
+            if (!trigger && isTriggerDeclaration(tokens)) trigger = true;
+            if (trigger) {
+                if (triggerBeginDepth === 0 && !triggerEnded && value === 'BEGIN') {
+                    triggerBeginDepth = 1;
+                } else if (triggerBeginDepth > 0 && !triggerEnded) {
+                    if (value === 'CASE') {
+                        triggerCaseDepth += 1;
+                    } else if (value === 'BEGIN' && triggerCaseDepth === 0) {
+                        triggerBeginDepth += 1;
+                    } else if (value === 'END') {
+                        if (triggerCaseDepth > 0) {
+                            triggerCaseDepth -= 1;
+                        } else {
+                            triggerBeginDepth -= 1;
+                            if (triggerBeginDepth === 0) triggerEnded = true;
+                        }
+                    }
+                }
+            }
+            continue;
+        }
+
+        if (character === ';') {
+            const endLine = line;
+            advance();
+            if (!trigger || triggerEnded) finishGroup(index, endLine);
+            continue;
+        }
+
+        advance();
+    }
+
+    if (hasSql) {
+        if (trigger) {
+            throw importError(`Incomplete SQL trigger at line ${groupStartLine}.`);
+        }
+        throw importError(`Incomplete SQL statement at line ${groupStartLine}; a complete boundary could not be proven.`);
+    }
+
+    return groups;
+}
+
+/**
+ * Scan complete SQLite statement groups without interpreting transaction or
+ * PRAGMA policy. Import normalization builds on this scanner, while the
+ * foreground SQL session can reuse the same quote/comment/trigger boundaries.
+ */
+export function scanDatabaseSqlGroups(text: string, byteBase = 0): DatabaseSqlImportGroup[] {
+    return scanDatabaseSqlGroupsWithTokens(text, byteBase).map(({ tokens: _tokens, ...group }) => group);
+}
+
+type GroupKind =
+    | 'ordinary'
+    | 'foreign-keys-off'
+    | 'foreign-keys-on'
+    | 'begin'
+    | 'commit'
+    | 'pragma'
+    | 'transaction';
+
+function sqlWithoutLeadingComments(sql: string): string {
+    let index = 0;
+    while (index < sql.length) {
+        while (index < sql.length && isWhitespace(sql[index])) index += codePointWidth(sql, index);
+        if (sql[index] === '-' && sql[index + 1] === '-') {
+            index += 2;
+            while (index < sql.length && sql[index] !== '\n') index += codePointWidth(sql, index);
+            continue;
+        }
+        if (sql[index] === '/' && sql[index + 1] === '*') {
+            const close = sql.indexOf('*/', index + 2);
+            index = close < 0 ? sql.length : close + 2;
+            continue;
+        }
+        break;
+    }
+    return sql.slice(index).trim();
+}
+
+function classifyGroup(group: ScannedGroup): GroupKind {
+    const values = group.tokens.map((token) => token.value);
+    const first = values[0] ?? '';
+    const semanticSql = sqlWithoutLeadingComments(group.sql);
+
+    if (first === 'PRAGMA') {
+        if (/^PRAGMA\s+foreign_keys\s*=\s*OFF\s*;$/i.test(semanticSql)) {
+            return 'foreign-keys-off';
+        }
+        if (/^PRAGMA\s+foreign_keys\s*=\s*ON\s*;$/i.test(semanticSql)) {
+            return 'foreign-keys-on';
+        }
+        return 'pragma';
+    }
+
+    if (/^BEGIN(?:\s+TRANSACTION)?\s*;$/i.test(semanticSql)) {
+        return 'begin';
+    }
+    if (/^COMMIT\s*;$/i.test(semanticSql)) return 'commit';
+    if (['BEGIN', 'END', 'COMMIT', 'ROLLBACK', 'SAVEPOINT', 'RELEASE'].includes(first)) {
+        return 'transaction';
+    }
+
+    return 'ordinary';
+}
+
+function rejectDisallowedGroup(group: ScannedGroup, kind: GroupKind): void {
+    const first = group.tokens[0];
+    const line = first?.line ?? group.startLine;
+
+    if (kind === 'pragma' || kind === 'foreign-keys-off' || kind === 'foreign-keys-on') {
+        const name = group.tokens[1]?.value.toLowerCase() ?? 'unknown';
+        throw importError(`Unsupported PRAGMA ${name} at line ${line}.`);
+    }
+
+    if (kind === 'begin' || kind === 'commit' || kind === 'transaction') {
+        const control = first?.value ?? 'TRANSACTION';
+        throw importError(`Unsupported top-level ${control} at line ${line}.`);
+    }
+}
+
+export function parseDatabaseImportSql(source: Buffer | string): ParsedDatabaseImportSql {
+    const decoded = decodeSource(source);
+    if (INCOMPLETE_DOWNLOAD_MARKER.test(decoded.text.replace(/\r\n/g, '\n'))) {
+        throw importError('The SQL import source contains an incomplete download marker.');
+    }
+
+    const scanned = scanDatabaseSqlGroupsWithTokens(decoded.text, decoded.byteBase);
+    if (scanned.length === 0) return { groups: [], foreignKeysOff: false };
+
+    const kinds = scanned.map(classifyGroup);
+    let first = 0;
+    let last = scanned.length;
+    let foreignKeysOff = false;
+
+    if (kinds[first] === 'foreign-keys-off') {
+        foreignKeysOff = true;
+        first += 1;
+    }
+
+    const hasCanonicalBegin = kinds[first] === 'begin';
+    if (hasCanonicalBegin) first += 1;
+
+    if (kinds[last - 1] === 'foreign-keys-on') last -= 1;
+    const hasCanonicalCommit = kinds[last - 1] === 'commit';
+    if (hasCanonicalCommit) last -= 1;
+
+    const canonicalEnvelope = hasCanonicalBegin && hasCanonicalCommit;
+    if (!canonicalEnvelope) {
+        for (let index = 0; index < scanned.length; index += 1) {
+            rejectDisallowedGroup(scanned[index], kinds[index]);
+        }
+    }
+
+    const inner = canonicalEnvelope ? scanned.slice(first, last) : scanned;
+    const innerKinds = canonicalEnvelope ? kinds.slice(first, last) : kinds;
+    for (let index = 0; index < inner.length; index += 1) {
+        rejectDisallowedGroup(inner[index], innerKinds[index]);
+    }
+
+    return {
+        foreignKeysOff: canonicalEnvelope && foreignKeysOff,
+        groups: inner.map(({ tokens: _tokens, ...group }) => group),
+    };
+}

--- a/src/utils/examples-ref.ts
+++ b/src/utils/examples-ref.ts
@@ -26,7 +26,9 @@
  * SDK, replace this with a derivation the way sdk-version.ts does.
  *
  * Currently: solidactions-examples PR #29 head @ 8a47ced4 "docs: add database
- * CLI guidance". The PR is pending owner merge; #1146's PM-directed delivery
- * override explicitly approved pinning this immutable, green PR-head commit.
+ * CLI guidance". Pinning this immutable PR-head commit is a temporary build-time necessity
+ * while the coordinated wave is pending merge; no delivery override
+ * was granted. Before any CLI release, repin EXAMPLES_REF to the
+ * merged mainline SHA and verify that exact ref during the release ritual.
  */
 export const EXAMPLES_REF = '8a47ced4a248fe57543efd91471b57fa49b4c26d';

--- a/src/utils/examples-ref.ts
+++ b/src/utils/examples-ref.ts
@@ -25,7 +25,8 @@
  * users. If solidactions-examples ever starts publishing tags in step with the
  * SDK, replace this with a derivation the way sdk-version.ts does.
  *
- * Currently: solidactions-examples main @ 3ca5fd4 "docs: publish examples and AI
- * skill guidance (#23)".
+ * Currently: solidactions-examples PR #29 head @ 8a47ced4 "docs: add database
+ * CLI guidance". The PR is pending owner merge; #1146's PM-directed delivery
+ * override explicitly approved pinning this immutable, green PR-head commit.
  */
-export const EXAMPLES_REF = '3ca5fd4d3107659b27889775791f6691cf173303';
+export const EXAMPLES_REF = '8a47ced4a248fe57543efd91471b57fa49b4c26d';

--- a/src/utils/skills.ts
+++ b/src/utils/skills.ts
@@ -14,7 +14,7 @@ export const SOLIDACTIONS_SKILL_NAMES = [
 
 const EXAMPLES_OWNER = 'SolidActions';
 const EXAMPLES_REPO = 'solidactions-examples';
-const SKILLS_PATH_PREFIX = 'skills';
+const SKILLS_PATH_PREFIX = 'content/skills';
 
 export type AiHelperTarget = 'CLAUDE.md' | 'AGENTS.md';
 

--- a/tests/command-manifest-artifact.test.ts
+++ b/tests/command-manifest-artifact.test.ts
@@ -4,6 +4,7 @@
 import { describe, expect, it } from 'vitest';
 import path from 'path';
 import fs from 'fs';
+import { execFileSync } from 'child_process';
 import { buildCommandManifest } from '../src/utils/command-manifest';
 
 const DIST = path.resolve(__dirname, '../dist');
@@ -37,5 +38,16 @@ describe('command-manifest.json build artifact', () => {
     it('ships inside dist/, which is the only published directory', () => {
         expect(pkg.files).toContain('dist');
         expect(path.relative(DIST, MANIFEST_PATH)).toBe('command-manifest.json');
+    });
+
+    it('is present in the npm pack file list', () => {
+        const packed = JSON.parse(execFileSync(
+            'npm',
+            ['pack', '--dry-run', '--json', '--ignore-scripts'],
+            { cwd: path.resolve(__dirname, '..'), encoding: 'utf8' },
+        ));
+        const files = packed.flatMap((artifact: any) => artifact.files.map((file: any) => file.path));
+
+        expect(files).toContain('dist/command-manifest.json');
     });
 });

--- a/tests/database-client-support.test.ts
+++ b/tests/database-client-support.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import path from 'path';
+import { pathToFileURL } from 'url';
+
+async function loadSupportModule(): Promise<Record<string, unknown>> {
+    const moduleUrl = pathToFileURL(path.resolve(__dirname, '../src/utils/database-client-support.ts')).href;
+    return import(moduleUrl);
+}
+
+describe('native database client support gate', () => {
+    it('loads native support before requesting a short-lived credential', async () => {
+        const support = await loadSupportModule();
+        const loadDatabaseClientBeforeMint = support.loadDatabaseClientBeforeMint;
+
+        expect(loadDatabaseClientBeforeMint).toBeTypeOf('function');
+        if (typeof loadDatabaseClientBeforeMint !== 'function') return;
+
+        const events: string[] = [];
+        const createClient = () => ({ close: () => undefined });
+        const result = await (loadDatabaseClientBeforeMint as Function)(
+            async () => {
+                events.push('mint');
+                return { url: 'libsql://database.example', token: 'ephemeral-token' };
+            },
+            {
+                loadClient: async () => {
+                    events.push('load');
+                    return { createClient };
+                },
+            },
+        );
+
+        expect(events).toEqual(['load', 'mint']);
+        expect(result.createClient).toBe(createClient);
+        expect(result.access).toEqual({ url: 'libsql://database.example', token: 'ephemeral-token' });
+    });
+
+    it('maps a native load failure to a stable product error without minting', async () => {
+        const support = await loadSupportModule();
+        const loadDatabaseClientBeforeMint = support.loadDatabaseClientBeforeMint;
+
+        expect(loadDatabaseClientBeforeMint).toBeTypeOf('function');
+        if (typeof loadDatabaseClientBeforeMint !== 'function') return;
+
+        let mintCount = 0;
+        let caught: any;
+        try {
+            await (loadDatabaseClientBeforeMint as Function)(
+                async () => {
+                    mintCount++;
+                    return { token: 'must-not-be-minted' };
+                },
+                {
+                    loadClient: async () => {
+                        throw new Error('NATIVE_BINDING_SENTINEL libsql vendor detail');
+                    },
+                },
+            );
+        } catch (error) {
+            caught = error;
+        }
+
+        expect(mintCount).toBe(0);
+        expect(caught).toMatchObject({ code: 'database_client_unsupported' });
+        expect(String(caught?.message).trim().length).toBeGreaterThan(0);
+        expect(String(caught?.message)).not.toMatch(/NATIVE_BINDING_SENTINEL|libsql|turso/i);
+    });
+});

--- a/tests/database-command-contract.test.ts
+++ b/tests/database-command-contract.test.ts
@@ -18,10 +18,10 @@ const COMMANDS = [
     { verb: 'exec', args: [['name', true], ['sql', true]], options: ['--yes', '--json'] },
     { verb: 'dump', args: [['name', true], ['file', false]], options: ['--yes'] },
     { verb: 'pull', args: [['name', true], ['path', false]], options: ['--yes', '--writable'] },
-    { verb: 'import', args: [['name', true], ['file.sql', true]], options: ['--yes'] },
+    { verb: 'import', args: [['name', true], ['file.sql', true]], options: ['--yes', '--resume'] },
 ] as const;
 
-const CRITICAL_OPTIONS = ['--json', '--from', '--yes', '--writable'];
+const CRITICAL_OPTIONS = ['--json', '--from', '--yes', '--writable', '--resume'];
 
 function loadProgram(): any {
     expect(fs.existsSync(CLI_BINARY)).toBe(true); // CLI not built — run `npm run build` first
@@ -69,6 +69,9 @@ describe('database command tree', () => {
 
             const from = command.options.find((option: any) => option.long === '--from');
             if (expectedOptions.includes('--from')) expect(from?.required).toBe(true);
+
+            const resume = command.options.find((option: any) => option.long === '--resume');
+            if (expectedOptions.includes('--resume')) expect(resume?.required).toBe(true);
         }
     });
 });

--- a/tests/database-command-contract.test.ts
+++ b/tests/database-command-contract.test.ts
@@ -1,0 +1,110 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+import { buildCommandManifest } from '../src/utils/command-manifest';
+
+const DIST = path.resolve(__dirname, '../dist');
+const CLI_BINARY = path.join(DIST, 'index.js');
+const MANIFEST_PATH = path.join(DIST, 'command-manifest.json');
+const pkg = require('../package.json');
+
+const COMMANDS = [
+    { verb: 'list', args: [], options: ['--json'] },
+    { verb: 'create', args: [['name', true]], options: ['--from', '--json'] },
+    { verb: 'delete', args: [['name', true]], options: ['--yes', '--json'] },
+    { verb: 'undelete', args: [['name', true]], options: ['--json'] },
+    { verb: 'schema', args: [['name', true]], options: ['--json'] },
+    { verb: 'query', args: [['name', true], ['sql', true]], options: ['--json'] },
+    { verb: 'exec', args: [['name', true], ['sql', true]], options: ['--yes', '--json'] },
+    { verb: 'dump', args: [['name', true], ['file', false]], options: ['--yes'] },
+    { verb: 'pull', args: [['name', true], ['path', false]], options: ['--yes', '--writable'] },
+    { verb: 'import', args: [['name', true], ['file.sql', true]], options: ['--yes'] },
+] as const;
+
+const CRITICAL_OPTIONS = ['--json', '--from', '--yes', '--writable'];
+
+function loadProgram(): any {
+    expect(fs.existsSync(CLI_BINARY)).toBe(true); // CLI not built — run `npm run build` first
+    return require(CLI_BINARY).program;
+}
+
+describe('database command tree', () => {
+    it('exports the singular noun with exactly the ten public v1 verbs', () => {
+        const program = loadProgram();
+        const nouns = program.commands.map((command: any) => command.name());
+        const database = program.commands.find((command: any) => command.name() === 'database');
+
+        expect(nouns).toContain('database');
+        expect(nouns).not.toContain('databases');
+        expect(database).toBeDefined();
+        expect(database.commands.map((command: any) => command.name())).toEqual(
+            COMMANDS.map(({ verb }) => verb),
+        );
+    });
+
+    it('declares the required/optional arguments and critical option matrix', () => {
+        const program = loadProgram();
+        const database = program.commands.find((command: any) => command.name() === 'database');
+
+        expect(database).toBeDefined();
+        if (!database) return;
+
+        for (const expected of COMMANDS) {
+            const command = database.commands.find((candidate: any) => candidate.name() === expected.verb);
+            expect(command, `database ${expected.verb}`).toBeDefined();
+            if (!command) continue;
+
+            expect(command.registeredArguments.map((argument: any) => [argument.name(), argument.required])).toEqual(
+                expected.args,
+            );
+
+            const declaredCriticalOptions = command.options
+                .map((option: any) => option.long)
+                .filter((option: string) => CRITICAL_OPTIONS.includes(option));
+            expect(declaredCriticalOptions).toEqual(expected.options);
+
+            const expectedOptions: readonly string[] = expected.options;
+            const yes = command.options.find((option: any) => option.long === '--yes');
+            if (expectedOptions.includes('--yes')) expect(yes?.short).toBe('-y');
+
+            const from = command.options.find((option: any) => option.long === '--from');
+            if (expectedOptions.includes('--from')) expect(from?.required).toBe(true);
+        }
+    });
+});
+
+describe('database command manifest', () => {
+    it('walks the complete database contract from the exported tree', () => {
+        const manifest = buildCommandManifest(loadProgram(), pkg.version);
+        const databaseCommands = manifest.commands.filter(
+            (command) => command.path[0] === 'database' && command.path.length === 2 && command.name !== 'help',
+        );
+
+        expect(manifest.commands.some((command) => command.path.join(' ') === 'database')).toBe(true);
+        expect(manifest.commands.some((command) => command.path[0] === 'databases')).toBe(false);
+        expect(databaseCommands.map((command) => command.name)).toEqual(COMMANDS.map(({ verb }) => verb));
+
+        for (const expected of COMMANDS) {
+            const command = databaseCommands.find((candidate) => candidate.name === expected.verb)!;
+            expect(command.arguments.map((argument) => [argument.name, argument.required])).toEqual(expected.args);
+            expect(
+                command.options
+                    .map((option) => option.long)
+                    .filter((option): option is string => option !== null && CRITICAL_OPTIONS.includes(option)),
+            ).toEqual(expected.options);
+        }
+    });
+
+    it('emits the same complete database contract in the build artifact', () => {
+        expect(fs.existsSync(MANIFEST_PATH)).toBe(true); // CLI not built — run `npm run build` first
+        const onDisk = JSON.parse(fs.readFileSync(MANIFEST_PATH, 'utf8'));
+        const fresh = JSON.parse(JSON.stringify(buildCommandManifest(loadProgram(), pkg.version)));
+
+        expect(onDisk).toEqual(fresh);
+        expect(
+            onDisk.commands
+                .filter((command: any) => command.path[0] === 'database' && command.path.length === 2 && command.name !== 'help')
+                .map((command: any) => command.name),
+        ).toEqual(COMMANDS.map(({ verb }) => verb));
+    });
+});

--- a/tests/database-data-plane.test.ts
+++ b/tests/database-data-plane.test.ts
@@ -285,6 +285,87 @@ describe('database direct-client lifecycle', () => {
         expect(close).toHaveBeenCalledOnce();
     });
 
+    it('maps a close-only rejection to a safe generic error without leaking cleanup details', async () => {
+        const withDatabaseClient = await requireExport('withDatabaseClient');
+        const stdout = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+        const stderr = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+        const close = vi.fn(async () => {
+            throw new Error(`close failed for ${ACCESS.url} using ${ACCESS.token}`);
+        });
+        let caught: any;
+        let renderedOutput = '';
+
+        try {
+            await withDatabaseClient(
+                APP_CONFIG,
+                'analytics',
+                'read',
+                async () => 'operation-completed',
+                dependencies({
+                    loadClient: async () => ({ createClient: () => ({ close }) }),
+                }),
+            );
+        } catch (error) {
+            caught = error;
+        } finally {
+            renderedOutput = [
+                ...stdout.mock.calls.flat(),
+                ...stderr.mock.calls.flat(),
+            ].map(String).join('\n');
+            stdout.mockRestore();
+            stderr.mockRestore();
+        }
+
+        expect(close).toHaveBeenCalledOnce();
+        expect({ code: caught?.code, message: caught?.message }).toEqual({
+            code: 'upstream_unavailable',
+            message: 'Database operation failed.',
+        });
+
+        const serializedFailure = JSON.stringify(caught);
+        for (const sentinel of [ACCESS.url, 'physical-db.sentinel.invalid', ACCESS.token]) {
+            expect(renderedOutput).not.toContain(sentinel);
+            expect(String(caught)).not.toContain(sentinel);
+            expect(serializedFailure).not.toContain(sentinel);
+        }
+    });
+
+    it('keeps the primary safe operation failure when close also throws', async () => {
+        const withDatabaseClient = await requireExport('withDatabaseClient');
+        const close = vi.fn(async () => {
+            throw new Error(`CLOSE_FAILURE_SENTINEL ${ACCESS.url} ${ACCESS.token}`);
+        });
+        let caught: any;
+
+        try {
+            await withDatabaseClient(
+                APP_CONFIG,
+                'analytics',
+                'read',
+                async () => {
+                    throw new Error(`PRIMARY_FAILURE_SENTINEL ${ACCESS.url} ${ACCESS.token}`);
+                },
+                dependencies({
+                    loadClient: async () => ({ createClient: () => ({ close }) }),
+                }),
+            );
+        } catch (error) {
+            caught = error;
+        }
+
+        expect(close).toHaveBeenCalledOnce();
+        expect({ code: caught?.code, message: caught?.message }).toEqual({
+            code: 'upstream_unavailable',
+            message: 'Database operation failed.',
+        });
+
+        const renderedFailure = `${String(caught)}\n${JSON.stringify(caught)}`;
+        expect(renderedFailure).not.toContain('PRIMARY_FAILURE_SENTINEL');
+        expect(renderedFailure).not.toContain('CLOSE_FAILURE_SENTINEL');
+        expect(renderedFailure).not.toContain(ACCESS.url);
+        expect(renderedFailure).not.toContain(ACCESS.token);
+    });
+
     it.each(['connect', 'query', 'sync'])('closes the client after a %s failure', async (phase) => {
         const withDatabaseClient = await requireExport('withDatabaseClient');
         const close = vi.fn();
@@ -318,6 +399,22 @@ describe('database result normalization', () => {
         expect(formatDatabaseTableValue(blob)).toBe('<blob 3 bytes>');
         expect(normalizeDatabaseValue(null)).toBeNull();
         expect(formatDatabaseTableValue(null)).toBe('NULL');
+    });
+
+    it('normalizes Buffer and offset views without encoding unrelated backing bytes', async () => {
+        const normalizeDatabaseValue = await requireExport('normalizeDatabaseValue');
+        const formatDatabaseTableValue = await requireExport('formatDatabaseTableValue');
+        const buffer = Buffer.from([0x00, 0xff, 0x10]);
+        const backing = new Uint8Array([0xaa, 0xbb, 0xcc, 0xdd, 0xee]);
+        const dataView = new DataView(backing.buffer, 1, 3);
+        const slicedView = new Uint8Array(backing.buffer, 2, 2);
+
+        expect(normalizeDatabaseValue(buffer)).toEqual({ base64: 'AP8Q' });
+        expect(formatDatabaseTableValue(buffer)).toBe('<blob 3 bytes>');
+        expect(normalizeDatabaseValue(dataView)).toEqual({ base64: 'u8zd' });
+        expect(formatDatabaseTableValue(dataView)).toBe('<blob 3 bytes>');
+        expect(normalizeDatabaseValue(slicedView)).toEqual({ base64: 'zN0=' });
+        expect(formatDatabaseTableValue(slicedView)).toBe('<blob 2 bytes>');
     });
 });
 

--- a/tests/database-data-plane.test.ts
+++ b/tests/database-data-plane.test.ts
@@ -160,6 +160,7 @@ describe('database access control-plane request', () => {
         proxyError.response = {
             status: 502,
             data: {
+                code: '   ',
                 message: rawMessage,
                 body: rawMessage,
             },

--- a/tests/database-data-plane.test.ts
+++ b/tests/database-data-plane.test.ts
@@ -1,0 +1,299 @@
+import path from 'path';
+import { pathToFileURL } from 'url';
+import { describe, expect, it, vi } from 'vitest';
+
+interface DatabaseAccess {
+    url: string;
+    token: string;
+    mode: 'read' | 'write';
+    expires_at: string;
+}
+
+interface DatabaseConfig {
+    host: string;
+    apiKey: string;
+    workspaceId: string;
+}
+
+interface ClientDependencies {
+    loadClient: () => Promise<{ createClient: (config: Record<string, unknown>) => any }>;
+    post: (
+        url: string,
+        body: Record<string, unknown>,
+        options: { headers: Record<string, string> },
+    ) => Promise<{ data: DatabaseAccess }>;
+}
+
+const APP_CONFIG: DatabaseConfig = {
+    host: 'https://app.example.test',
+    apiKey: 'pat-control-plane-only',
+    workspaceId: 'workspace-1146',
+};
+
+const ACCESS: DatabaseAccess = {
+    url: 'libsql://physical-db.sentinel.invalid?connection=full-url-sentinel',
+    token: 'ephemeral-database-token-sentinel',
+    mode: 'read',
+    expires_at: '2026-08-07T12:10:00Z',
+};
+
+async function loadDataPlane(): Promise<Record<string, unknown>> {
+    const moduleUrl = pathToFileURL(path.resolve(__dirname, '../src/utils/database-data-plane.ts')).href;
+
+    try {
+        return await import(moduleUrl) as Record<string, unknown>;
+    } catch {
+        return {};
+    }
+}
+
+async function requireExport(name: string): Promise<Function> {
+    const module = await loadDataPlane();
+    expect(module[name], `${name} export`).toBeTypeOf('function');
+    return module[name] as Function;
+}
+
+function dependencies(overrides: Partial<ClientDependencies> = {}): ClientDependencies {
+    return {
+        loadClient: async () => ({
+            createClient: () => ({ close: () => undefined }),
+        }),
+        post: async () => ({ data: ACCESS }),
+        ...overrides,
+    };
+}
+
+describe('database access control-plane request', () => {
+    it('POSTs access intent with the selected workspace and bearer headers', async () => {
+        const requestDatabaseAccess = await requireExport('requestDatabaseAccess');
+        const calls: unknown[][] = [];
+
+        const access = await requestDatabaseAccess(APP_CONFIG, 'analytics', 'write', {
+            post: async (...args: unknown[]) => {
+                calls.push(args);
+                return { data: { ...ACCESS, mode: 'write' } };
+            },
+        });
+
+        expect(calls).toEqual([[
+            'https://app.example.test/api/v1/databases',
+            { operation: 'access', name: 'analytics', mode: 'write' },
+            {
+                headers: {
+                    Accept: 'application/json',
+                    Authorization: 'Bearer pat-control-plane-only',
+                    'Content-Type': 'application/json',
+                    'X-Workspace-Id': 'workspace-1146',
+                },
+            },
+        ]]);
+        expect(access).toEqual({ ...ACCESS, mode: 'write' });
+    });
+
+    it('retains stable product codes and messages returned by the app', async () => {
+        const requestDatabaseAccess = await requireExport('requestDatabaseAccess');
+        const appError: any = new Error('Request failed with status 409');
+        appError.response = {
+            status: 409,
+            data: {
+                code: 'read_only_mode',
+                message: 'Database writes are temporarily unavailable for this workspace.',
+            },
+        };
+
+        let caught: any;
+        try {
+            await requestDatabaseAccess(APP_CONFIG, 'analytics', 'write', {
+                post: async () => { throw appError; },
+            });
+        } catch (error) {
+            caught = error;
+        }
+
+        expect(caught).toMatchObject({
+            code: 'read_only_mode',
+            message: 'Database writes are temporarily unavailable for this workspace.',
+        });
+    });
+});
+
+describe('database direct-client lifecycle', () => {
+    it('loads native support before minting and uses an in-memory string-int client', async () => {
+        const withDatabaseClient = await requireExport('withDatabaseClient');
+        const events: string[] = [];
+        const clientConfigs: Array<Record<string, unknown>> = [];
+        const appConfigBefore = JSON.stringify(APP_CONFIG);
+        const client = {
+            close: () => events.push('close'),
+        };
+
+        const result = await withDatabaseClient(
+            APP_CONFIG,
+            'analytics',
+            'read',
+            async (receivedClient: unknown) => {
+                events.push('use');
+                expect(receivedClient).toBe(client);
+                return { rows: 1 };
+            },
+            dependencies({
+                loadClient: async () => {
+                    events.push('load');
+                    return {
+                        createClient: (config) => {
+                            events.push('create');
+                            clientConfigs.push(config);
+                            return client;
+                        },
+                    };
+                },
+                post: async () => {
+                    events.push('mint');
+                    return { data: ACCESS };
+                },
+            }),
+        );
+
+        expect(events).toEqual(['load', 'mint', 'create', 'use', 'close']);
+        expect(clientConfigs).toEqual([{
+            url: ACCESS.url,
+            authToken: ACCESS.token,
+            intMode: 'string',
+        }]);
+        expect(result).toEqual({ rows: 1 });
+        expect(result).not.toHaveProperty('token');
+        expect(JSON.stringify(APP_CONFIG)).toBe(appConfigBefore);
+        expect(JSON.stringify(APP_CONFIG)).not.toContain(ACCESS.token);
+    });
+
+    it('does not mint when the dynamic native-client gate fails', async () => {
+        const withDatabaseClient = await requireExport('withDatabaseClient');
+        let mintCount = 0;
+
+        await expect(withDatabaseClient(
+            APP_CONFIG,
+            'analytics',
+            'read',
+            async () => undefined,
+            dependencies({
+                loadClient: async () => {
+                    throw new Error('native binding path sentinel');
+                },
+                post: async () => {
+                    mintCount++;
+                    return { data: ACCESS };
+                },
+            }),
+        )).rejects.toMatchObject({ code: 'database_client_unsupported' });
+
+        expect(mintCount).toBe(0);
+    });
+
+    it('closes the client in finally after success', async () => {
+        const withDatabaseClient = await requireExport('withDatabaseClient');
+        const close = vi.fn();
+
+        await withDatabaseClient(
+            APP_CONFIG,
+            'analytics',
+            'read',
+            async () => 'ok',
+            dependencies({
+                loadClient: async () => ({ createClient: () => ({ close }) }),
+            }),
+        );
+
+        expect(close).toHaveBeenCalledOnce();
+    });
+
+    it.each(['connect', 'query', 'sync'])('closes the client after a %s failure', async (phase) => {
+        const withDatabaseClient = await requireExport('withDatabaseClient');
+        const close = vi.fn();
+
+        await expect(withDatabaseClient(
+            APP_CONFIG,
+            'analytics',
+            'read',
+            async () => {
+                throw new Error(`${phase} failed`);
+            },
+            dependencies({
+                loadClient: async () => ({ createClient: () => ({ close }) }),
+            }),
+        )).rejects.toBeDefined();
+
+        expect(close).toHaveBeenCalledOnce();
+    });
+});
+
+describe('database result normalization', () => {
+    it('keeps integers exact and renders blobs without implementation-specific objects', async () => {
+        const normalizeDatabaseValue = await requireExport('normalizeDatabaseValue');
+        const formatDatabaseTableValue = await requireExport('formatDatabaseTableValue');
+        const integer = 9_223_372_036_854_775_807n;
+        const blob = new Uint8Array([0x00, 0xff, 0x10]).buffer;
+
+        expect(normalizeDatabaseValue(integer)).toBe('9223372036854775807');
+        expect(normalizeDatabaseValue(blob)).toEqual({ base64: 'AP8Q' });
+        expect(formatDatabaseTableValue(integer)).toBe('9223372036854775807');
+        expect(formatDatabaseTableValue(blob)).toBe('<blob 3 bytes>');
+        expect(normalizeDatabaseValue(null)).toBeNull();
+        expect(formatDatabaseTableValue(null)).toBe('NULL');
+    });
+});
+
+describe('database direct-client error boundary', () => {
+    it.each(['connect', 'query', 'sync'])(
+        'scrubs physical host, connection URL, and token from %s failures and public output',
+        async (phase) => {
+            const withDatabaseClient = await requireExport('withDatabaseClient');
+            const stdout = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+            const stderr = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+            let caught: any;
+            let renderedOutput = '';
+
+            try {
+                await withDatabaseClient(
+                    APP_CONFIG,
+                    'analytics',
+                    'read',
+                    async () => {
+                        throw new Error(
+                            `${phase} failed for ${ACCESS.url} on physical-db.sentinel.invalid using ${ACCESS.token}`,
+                        );
+                    },
+                    dependencies(),
+                );
+            } catch (error) {
+                caught = error;
+            } finally {
+                renderedOutput = [
+                    ...stdout.mock.calls.flat(),
+                    ...stderr.mock.calls.flat(),
+                ].map(String).join('\n');
+                stdout.mockRestore();
+                stderr.mockRestore();
+            }
+
+            const publicFailure = {
+                code: caught?.code,
+                message: caught?.message,
+            };
+            const serializedFailure = JSON.stringify(publicFailure);
+            const forbidden = [ACCESS.url, 'physical-db.sentinel.invalid', ACCESS.token];
+
+            expect(caught).toBeDefined();
+            expect(publicFailure).toMatchInlineSnapshot(`
+              {
+                "code": "upstream_unavailable",
+                "message": "Database operation failed.",
+              }
+            `);
+            for (const sentinel of forbidden) {
+                expect(renderedOutput).not.toContain(sentinel);
+                expect(String(caught)).not.toContain(sentinel);
+                expect(serializedFailure).not.toContain(sentinel);
+            }
+        },
+    );
+});

--- a/tests/database-data-plane.test.ts
+++ b/tests/database-data-plane.test.ts
@@ -85,9 +85,37 @@ describe('database access control-plane request', () => {
                     'Content-Type': 'application/json',
                     'X-Workspace-Id': 'workspace-1146',
                 },
+                signal: expect.any(AbortSignal),
+                timeout: 30_000,
             },
         ]]);
         expect(access).toEqual({ ...ACCESS, mode: 'write' });
+    });
+
+    it('aborts a stalled control-plane request at the configured deadline', async () => {
+        const requestDatabaseAccess = await requireExport('requestDatabaseAccess');
+        let observedSignal: AbortSignal | undefined;
+        let observedTimeout: number | undefined;
+
+        const outcome = requestDatabaseAccess(APP_CONFIG, 'analytics', 'read', {
+            controlPlaneTimeoutMs: 10,
+            post: async (_url: string, _body: Record<string, unknown>, options: any) => {
+                observedSignal = options.signal;
+                observedTimeout = options.timeout;
+                return new Promise((_resolve, reject) => {
+                    options.signal.addEventListener('abort', () => {
+                        reject(new Error(`CONTROL_TIMEOUT_SENTINEL ${APP_CONFIG.apiKey}`));
+                    }, { once: true });
+                });
+            },
+        });
+
+        await expect(outcome).rejects.toMatchObject({
+            code: 'upstream_unavailable',
+            message: 'Database request failed.',
+        });
+        expect(observedTimeout).toBe(10);
+        expect(observedSignal?.aborted).toBe(true);
     });
 
     it('retains stable product codes and messages returned by the app', async () => {
@@ -453,6 +481,31 @@ describe('database direct-client lifecycle', () => {
         )).rejects.toBeDefined();
 
         expect(close).toHaveBeenCalledOnce();
+    });
+
+    it('closes the client to cancel a stalled data operation at the configured deadline', async () => {
+        const withDatabaseClient = await requireExport('withDatabaseClient');
+        const events: string[] = [];
+
+        await expect(withDatabaseClient(
+            APP_CONFIG,
+            'analytics',
+            'read',
+            async () => new Promise(() => undefined),
+            dependencies({
+                dataPlaneTimeoutMs: 10,
+                loadClient: async () => ({
+                    createClient: () => ({
+                        close: async () => events.push('close'),
+                    }),
+                }),
+            } as any),
+        )).rejects.toMatchObject({
+            code: 'upstream_unavailable',
+            message: 'Database operation timed out.',
+        });
+
+        expect(events).toEqual(['close']);
     });
 });
 

--- a/tests/database-data-plane.test.ts
+++ b/tests/database-data-plane.test.ts
@@ -140,6 +140,75 @@ describe('database access control-plane request', () => {
         expect(publicFailure).not.toContain(APP_CONFIG.apiKey);
         expect(publicFailure).not.toContain('CONTROL_REQUEST_SENTINEL');
     });
+
+    it('discards an unstructured 502 proxy body instead of trusting its raw message', async () => {
+        const requestDatabaseAccess = await requireExport('requestDatabaseAccess');
+        const DatabaseOperationError = await requireExport('DatabaseOperationError');
+        const rawMessage = [
+            'RAW_PROXY_BODY_SENTINEL',
+            'Turso provider failure',
+            'physical-db.sentinel.invalid',
+            ACCESS.url,
+            APP_CONFIG.apiKey,
+        ].join(' ');
+        const proxyError: any = new Error(rawMessage);
+        proxyError.config = {
+            url: `${APP_CONFIG.host}/api/v1/databases`,
+            headers: { Authorization: `Bearer ${APP_CONFIG.apiKey}` },
+        };
+        proxyError.request = { raw: rawMessage };
+        proxyError.response = {
+            status: 502,
+            data: {
+                message: rawMessage,
+                body: rawMessage,
+            },
+            config: proxyError.config,
+            request: proxyError.request,
+        };
+        const stdout = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+        const stderr = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+        let caught: any;
+        let renderedOutput = '';
+
+        try {
+            await requestDatabaseAccess(APP_CONFIG, 'analytics', 'read', {
+                post: async () => { throw proxyError; },
+            });
+        } catch (error) {
+            caught = error;
+        } finally {
+            renderedOutput = [
+                ...stdout.mock.calls.flat(),
+                ...stderr.mock.calls.flat(),
+            ].map(String).join('\n');
+            stdout.mockRestore();
+            stderr.mockRestore();
+        }
+
+        expect(caught).not.toBe(proxyError);
+        expect(caught).toBeInstanceOf(DatabaseOperationError as any);
+        expect(caught).toMatchObject({
+            code: 'upstream_unavailable',
+            message: 'Database request failed.',
+            status: 502,
+        });
+        expect(caught).not.toHaveProperty('config');
+        expect(caught).not.toHaveProperty('request');
+        expect(caught).not.toHaveProperty('response');
+        expect(caught).not.toHaveProperty('cause');
+
+        const renderedFailure = `${String(caught)}\n${JSON.stringify(caught)}\n${renderedOutput}`;
+        for (const sentinel of [
+            'RAW_PROXY_BODY_SENTINEL',
+            'Turso',
+            'physical-db.sentinel.invalid',
+            ACCESS.url,
+            APP_CONFIG.apiKey,
+        ]) {
+            expect(renderedFailure).not.toContain(sentinel);
+        }
+    });
 });
 
 describe('database direct-client lifecycle', () => {

--- a/tests/database-data-plane.test.ts
+++ b/tests/database-data-plane.test.ts
@@ -93,12 +93,27 @@ describe('database access control-plane request', () => {
     it('retains stable product codes and messages returned by the app', async () => {
         const requestDatabaseAccess = await requireExport('requestDatabaseAccess');
         const appError: any = new Error('Request failed with status 409');
+        appError.config = {
+            url: `${APP_CONFIG.host}/api/v1/databases`,
+            method: 'post',
+            headers: {
+                Authorization: `Bearer ${APP_CONFIG.apiKey}`,
+                'X-Request-Metadata': 'CONTROL_REQUEST_SENTINEL',
+            },
+        };
+        appError.request = {
+            socket: 'CONTROL_REQUEST_SENTINEL',
+            authorization: `Bearer ${APP_CONFIG.apiKey}`,
+        };
+        appError.cause = new Error(`transport cause contained ${APP_CONFIG.apiKey}`);
         appError.response = {
             status: 409,
             data: {
                 code: 'read_only_mode',
                 message: 'Database writes are temporarily unavailable for this workspace.',
             },
+            config: appError.config,
+            request: appError.request,
         };
 
         let caught: any;
@@ -113,7 +128,17 @@ describe('database access control-plane request', () => {
         expect(caught).toMatchObject({
             code: 'read_only_mode',
             message: 'Database writes are temporarily unavailable for this workspace.',
+            status: 409,
         });
+        expect(caught).not.toHaveProperty('config');
+        expect(caught).not.toHaveProperty('request');
+        expect(caught).not.toHaveProperty('response');
+        expect(caught).not.toHaveProperty('cause');
+
+        const publicFailure = JSON.stringify(caught);
+        expect(String(caught)).not.toContain(APP_CONFIG.apiKey);
+        expect(publicFailure).not.toContain(APP_CONFIG.apiKey);
+        expect(publicFailure).not.toContain('CONTROL_REQUEST_SENTINEL');
     });
 });
 
@@ -187,6 +212,60 @@ describe('database direct-client lifecycle', () => {
         )).rejects.toMatchObject({ code: 'database_client_unsupported' });
 
         expect(mintCount).toBe(0);
+    });
+
+    it('scrubs a direct-client constructor failure after mint without claiming a close', async () => {
+        const withDatabaseClient = await requireExport('withDatabaseClient');
+        const stdout = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+        const stderr = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+        const events: string[] = [];
+        let caught: any;
+        let renderedOutput = '';
+
+        try {
+            await withDatabaseClient(
+                APP_CONFIG,
+                'analytics',
+                'read',
+                async () => undefined,
+                dependencies({
+                    loadClient: async () => ({
+                        createClient: () => {
+                            events.push('create');
+                            throw new Error(
+                                `connect failed for ${ACCESS.url} on physical-db.sentinel.invalid using ${ACCESS.token}`,
+                            );
+                        },
+                    }),
+                    post: async () => {
+                        events.push('mint');
+                        return { data: ACCESS };
+                    },
+                }),
+            );
+        } catch (error) {
+            caught = error;
+        } finally {
+            renderedOutput = [
+                ...stdout.mock.calls.flat(),
+                ...stderr.mock.calls.flat(),
+            ].map(String).join('\n');
+            stdout.mockRestore();
+            stderr.mockRestore();
+        }
+
+        expect(events).toEqual(['mint', 'create']);
+        expect({ code: caught?.code, message: caught?.message }).toEqual({
+            code: 'upstream_unavailable',
+            message: 'Database operation failed.',
+        });
+
+        const serializedFailure = JSON.stringify(caught);
+        for (const sentinel of [ACCESS.url, 'physical-db.sentinel.invalid', ACCESS.token]) {
+            expect(renderedOutput).not.toContain(sentinel);
+            expect(String(caught)).not.toContain(sentinel);
+            expect(serializedFailure).not.toContain(sentinel);
+        }
     });
 
     it('closes the client in finally after success', async () => {

--- a/tests/database-device-auth-contract.test.ts
+++ b/tests/database-device-auth-contract.test.ts
@@ -1,0 +1,78 @@
+import axios, { AxiosResponse, InternalAxiosRequestConfig } from 'axios';
+import { describe, expect, it } from 'vitest';
+import { requestDeviceCode } from '../src/commands/device-login';
+
+describe('database device-token compatibility', () => {
+    it('requests the coarse databases scope during device authorization', async () => {
+        const originalAdapter = axios.defaults.adapter;
+        let requestBody: Record<string, unknown> | undefined;
+        axios.defaults.adapter = async (config: InternalAxiosRequestConfig): Promise<AxiosResponse> => {
+            requestBody = JSON.parse(String(config.data));
+            return {
+                status: 200,
+                statusText: 'OK',
+                headers: {},
+                config,
+                data: {
+                    device_code: 'device-code',
+                    user_code: 'USER-CODE',
+                    verification_uri: 'https://example.test/device',
+                    expires_in: 600,
+                    interval: 5,
+                },
+            };
+        };
+
+        try {
+            await requestDeviceCode('https://app.solidactions.com');
+        } finally {
+            axios.defaults.adapter = originalAdapter;
+        }
+
+        expect(String(requestBody?.scope).split(/\s+/).sort()).toEqual(
+            ['databases', 'deploy', 'docs', 'env', 'runs'],
+        );
+    });
+
+    it('exports a reusable stale-token hint for database ability failures', async () => {
+        const api = await import('../src/utils/api') as Record<string, unknown>;
+        const augment = api.augmentTokenMissingAbilityMessage;
+
+        expect(augment).toBeTypeOf('function');
+        if (typeof augment !== 'function') return;
+
+        const error: any = {
+            response: {
+                status: 403,
+                data: {
+                    code: 'token_missing_ability',
+                    message: "This API key does not have the 'databases' ability.",
+                    required_ability: 'databases',
+                },
+            },
+        };
+        const result = (augment as (error: any) => any)(error);
+
+        expect(result.response.data.message).toContain("does not have the 'databases' ability");
+        expect(result.response.data.message).toContain('solidactions login --device');
+
+        const unrelated: any = {
+            response: { status: 403, data: { code: 'forbidden', message: 'Access denied.' } },
+        };
+        expect((augment as (error: any) => any)(unrelated)).toBe(unrelated);
+        expect(unrelated.response.data.message).toBe('Access denied.');
+
+        const otherAbility: any = {
+            response: {
+                status: 403,
+                data: {
+                    code: 'token_missing_ability',
+                    message: "This API key does not have the 'env' ability.",
+                    required_ability: 'env',
+                },
+            },
+        };
+        expect((augment as (error: any) => any)(otherAbility)).toBe(otherAbility);
+        expect(otherAbility.response.data.message).not.toContain('solidactions login --device');
+    });
+});

--- a/tests/database-direct-command-actions.test.ts
+++ b/tests/database-direct-command-actions.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const handlers = vi.hoisted(() => ({
+    schema: vi.fn(async () => undefined),
+    query: vi.fn(async () => undefined),
+    exec: vi.fn(async () => undefined),
+}));
+
+vi.mock('../src/commands/database', async (importOriginal) => ({
+    ...await importOriginal<typeof import('../src/commands/database')>(),
+    databaseSchema: handlers.schema,
+    databaseQuery: handlers.query,
+    databaseExec: handlers.exec,
+}));
+
+import { program } from '../src/index';
+
+function databaseAction(verb: string): Function {
+    const database = program.commands.find((command) => command.name() === 'database');
+    const command = database?.commands.find((candidate) => candidate.name() === verb);
+    expect(command, `database ${verb}`).toBeDefined();
+    expect((command as any)?._actionHandler, `database ${verb} action`).toBeTypeOf('function');
+    return (command as any)._actionHandler as Function;
+}
+
+describe('database direct command registration', () => {
+    it('dispatches schema arguments and options to its command handler', async () => {
+        const options = { json: true };
+
+        await databaseAction('schema')('Analytics', options);
+
+        expect(handlers.schema).toHaveBeenCalledOnce();
+        expect(handlers.schema).toHaveBeenCalledWith('Analytics', options);
+    });
+
+    it('dispatches query arguments and options to its command handler', async () => {
+        const options = { json: true };
+
+        await databaseAction('query')('Analytics', 'SELECT 1', options);
+
+        expect(handlers.query).toHaveBeenCalledOnce();
+        expect(handlers.query).toHaveBeenCalledWith('Analytics', 'SELECT 1', options);
+    });
+
+    it('dispatches exec arguments and options to its command handler', async () => {
+        const options = { yes: true, json: true };
+
+        await databaseAction('exec')('Analytics', 'DELETE FROM events', options);
+
+        expect(handlers.exec).toHaveBeenCalledOnce();
+        expect(handlers.exec).toHaveBeenCalledWith('Analytics', 'DELETE FROM events', options);
+    });
+});

--- a/tests/database-direct-command-actions.test.ts
+++ b/tests/database-direct-command-actions.test.ts
@@ -15,19 +15,19 @@ vi.mock('../src/commands/database', async (importOriginal) => ({
 
 import { program } from '../src/index';
 
-function databaseAction(verb: string): Function {
+function databaseCommand(verb: string): any {
     const database = program.commands.find((command) => command.name() === 'database');
     const command = database?.commands.find((candidate) => candidate.name() === verb);
     expect(command, `database ${verb}`).toBeDefined();
     expect((command as any)?._actionHandler, `database ${verb} action`).toBeTypeOf('function');
-    return (command as any)._actionHandler as Function;
+    return command;
 }
 
 describe('database direct command registration', () => {
     it('dispatches schema arguments and options to its command handler', async () => {
         const options = { json: true };
 
-        await databaseAction('schema')('Analytics', options);
+        await databaseCommand('schema').parseAsync(['Analytics', '--json'], { from: 'user' });
 
         expect(handlers.schema).toHaveBeenCalledOnce();
         expect(handlers.schema).toHaveBeenCalledWith('Analytics', options);
@@ -36,7 +36,7 @@ describe('database direct command registration', () => {
     it('dispatches query arguments and options to its command handler', async () => {
         const options = { json: true };
 
-        await databaseAction('query')('Analytics', 'SELECT 1', options);
+        await databaseCommand('query').parseAsync(['Analytics', 'SELECT 1', '--json'], { from: 'user' });
 
         expect(handlers.query).toHaveBeenCalledOnce();
         expect(handlers.query).toHaveBeenCalledWith('Analytics', 'SELECT 1', options);
@@ -45,7 +45,10 @@ describe('database direct command registration', () => {
     it('dispatches exec arguments and options to its command handler', async () => {
         const options = { yes: true, json: true };
 
-        await databaseAction('exec')('Analytics', 'DELETE FROM events', options);
+        await databaseCommand('exec').parseAsync(
+            ['Analytics', 'DELETE FROM events', '--yes', '--json'],
+            { from: 'user' },
+        );
 
         expect(handlers.exec).toHaveBeenCalledOnce();
         expect(handlers.exec).toHaveBeenCalledWith('Analytics', 'DELETE FROM events', options);

--- a/tests/database-direct-commands.test.ts
+++ b/tests/database-direct-commands.test.ts
@@ -425,6 +425,35 @@ describe('database exec direct action', () => {
 });
 
 describe('database direct command error boundary', () => {
+    it('rejects malformed result metadata through the safe boundary before writing output', async () => {
+        const databaseExecWithConfig = await requireExport('databaseExecWithConfig');
+        const test = directHarness(async () => ({
+            columns: [],
+            rows: [],
+            rowsAffected: 0,
+            lastInsertRowid: {
+                raw: `MALFORMED_RESULT_SENTINEL ${ACCESS.url} ${ACCESS.token}`,
+            },
+        }));
+
+        await expect(databaseExecWithConfig(
+            'Analytics',
+            'DELETE FROM events',
+            { yes: true, json: true },
+            CONFIG,
+            test.dependencies,
+        )).rejects.toMatchObject({
+            code: 'upstream_unavailable',
+            message: 'Database operation failed.',
+        });
+
+        expect(test.stdout).toEqual([]);
+        expect(test.stderr).toEqual([]);
+        expect(test.close).toHaveBeenCalledOnce();
+        expect(JSON.stringify({ stdout: test.stdout, stderr: test.stderr })).not.toContain('MALFORMED_RESULT_SENTINEL');
+        expect(JSON.stringify({ stdout: test.stdout, stderr: test.stderr })).not.toContain(ACCESS.token);
+    });
+
     it.each([
         ['databaseSchemaWithConfig', ['Analytics', { json: true }]],
         ['databaseQueryWithConfig', ['Analytics', 'SELECT * FROM events', { json: true }]],

--- a/tests/database-direct-commands.test.ts
+++ b/tests/database-direct-commands.test.ts
@@ -1,0 +1,415 @@
+import path from 'path';
+import { pathToFileURL } from 'url';
+import { describe, expect, it, vi } from 'vitest';
+
+interface Config {
+    host: string;
+    apiKey: string;
+    workspaceId: string;
+}
+
+interface PostCall {
+    url: string;
+    body: Record<string, unknown>;
+    options: { headers: Record<string, string> };
+}
+
+const CONFIG: Config = {
+    host: 'https://app.example.test',
+    apiKey: 'control-plane-pat',
+    workspaceId: 'workspace-1146',
+};
+
+const ACCESS = {
+    url: 'libsql://physical-db.sentinel.invalid?connection=full-url-sentinel',
+    token: 'ephemeral-database-token-sentinel',
+    mode: 'read' as const,
+    expires_at: '2026-08-07T12:10:00Z',
+};
+
+async function loadDatabaseCommands(): Promise<Record<string, unknown>> {
+    const moduleUrl = pathToFileURL(path.resolve(__dirname, '../src/commands/database.ts')).href;
+
+    try {
+        return await import(moduleUrl) as Record<string, unknown>;
+    } catch {
+        return {};
+    }
+}
+
+async function requireExport(name: string): Promise<Function> {
+    const module = await loadDatabaseCommands();
+    expect(module[name], `${name} export`).toBeTypeOf('function');
+    return module[name] as Function;
+}
+
+function directHarness(
+    execute: (statement: unknown) => Promise<unknown>,
+    options: { isTTY?: boolean; confirmation?: boolean | undefined } = {},
+) {
+    const events: string[] = [];
+    const posts: PostCall[] = [];
+    const clientConfigs: Array<Record<string, unknown>> = [];
+    const statements: unknown[] = [];
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const confirm = vi.fn(async () => Object.prototype.hasOwnProperty.call(options, 'confirmation')
+        ? options.confirmation
+        : true);
+    const close = vi.fn(async () => {
+        events.push('close');
+    });
+
+    const client = {
+        execute: async (statement: unknown) => {
+            events.push('execute');
+            statements.push(statement);
+            return execute(statement);
+        },
+        close,
+    };
+
+    const dependencies = {
+        loadClient: async () => {
+            events.push('load');
+            return {
+                createClient: (config: Record<string, unknown>) => {
+                    events.push('create');
+                    clientConfigs.push(config);
+                    return client;
+                },
+            };
+        },
+        post: async (
+            url: string,
+            body: Record<string, unknown>,
+            postOptions: { headers: Record<string, string> },
+        ) => {
+            events.push('mint');
+            posts.push({ url, body, options: postOptions });
+            return {
+                data: {
+                    ...ACCESS,
+                    mode: body.mode,
+                },
+            };
+        },
+        stdout: (line: string) => stdout.push(line),
+        stderr: (line: string) => stderr.push(line),
+        confirm,
+        isTTY: options.isTTY ?? true,
+    };
+
+    return {
+        events,
+        posts,
+        clientConfigs,
+        statements,
+        stdout,
+        stderr,
+        confirm,
+        close,
+        dependencies,
+    };
+}
+
+function statementSql(statement: unknown): string {
+    if (typeof statement === 'string') return statement;
+    if (statement && typeof statement === 'object' && typeof (statement as any).sql === 'string') {
+        return (statement as any).sql;
+    }
+    return '';
+}
+
+function expectSingleAccessPost(test: ReturnType<typeof directHarness>, mode: 'read' | 'write'): void {
+    expect(test.posts).toEqual([{
+        url: 'https://app.example.test/api/v1/databases',
+        body: { operation: 'access', name: 'Analytics', mode },
+        options: {
+            headers: {
+                Accept: 'application/json',
+                Authorization: 'Bearer control-plane-pat',
+                'Content-Type': 'application/json',
+                'X-Workspace-Id': 'workspace-1146',
+            },
+        },
+    }]);
+}
+
+function expectEphemeralClient(test: ReturnType<typeof directHarness>): void {
+    expect(test.clientConfigs).toEqual([{
+        url: ACCESS.url,
+        authToken: ACCESS.token,
+        intMode: 'string',
+    }]);
+    expect(test.close).toHaveBeenCalledOnce();
+    expect(test.events[0]).toBe('load');
+    expect(test.events.indexOf('load')).toBeLessThan(test.events.indexOf('mint'));
+}
+
+describe('database schema direct action', () => {
+    it('mints once for read access and returns catalog, safely quoted PRAGMA metadata, and numeric PK order', async () => {
+        const databaseSchemaWithConfig = await requireExport('databaseSchemaWithConfig');
+        const tableName = 'odd"table';
+        const tableSql = 'CREATE TABLE "odd""table" (tenant_id INTEGER, item_id INTEGER, body BLOB, PRIMARY KEY (tenant_id, item_id))';
+        const indexSql = 'CREATE INDEX idx_odd_body ON "odd""table" (body)';
+        const test = directHarness(async (statement) => {
+            const sql = statementSql(statement);
+            if (/type\s*=\s*'table'/i.test(sql)) {
+                return { columns: ['name', 'sql'], rows: [[tableName, tableSql]] };
+            }
+            if (/type\s*=\s*'index'/i.test(sql)) {
+                return { columns: ['name', 'tbl_name', 'sql'], rows: [['idx_odd_body', tableName, indexSql]] };
+            }
+            if (sql === 'PRAGMA table_info("odd""table")') {
+                return {
+                    columns: ['cid', 'name', 'type', 'notnull', 'dflt_value', 'pk'],
+                    rows: [
+                        ['0', 'tenant_id', 'INTEGER', '1', null, '1'],
+                        ['1', 'item_id', 'INTEGER', '1', null, '2'],
+                        ['2', 'body', 'BLOB', '0', "x'00ff'", '0'],
+                    ],
+                };
+            }
+            throw new Error(`Unexpected direct SQL: ${sql}`);
+        });
+
+        await databaseSchemaWithConfig('Analytics', { json: true }, CONFIG, test.dependencies);
+
+        expectSingleAccessPost(test, 'read');
+        expectEphemeralClient(test);
+        expect(test.statements.map(statementSql)).toEqual(expect.arrayContaining([
+            expect.stringMatching(/sqlite_master.*type\s*=\s*'table'/i),
+            expect.stringMatching(/sqlite_master.*type\s*=\s*'index'/i),
+            'PRAGMA table_info("odd""table")',
+        ]));
+        expect(JSON.stringify(test.posts)).not.toContain('sqlite_master');
+        expect(JSON.stringify(test.posts)).not.toContain('PRAGMA');
+        expect(JSON.parse(test.stdout.join('\n'))).toEqual({
+            database: 'Analytics',
+            tables: [{
+                name: tableName,
+                sql: tableSql,
+                columns: [
+                    { name: 'tenant_id', type: 'INTEGER', notnull: true, default: null, pk: 1 },
+                    { name: 'item_id', type: 'INTEGER', notnull: true, default: null, pk: 2 },
+                    { name: 'body', type: 'BLOB', notnull: false, default: "x'00ff'", pk: 0 },
+                ],
+                indexes: [{ name: 'idx_odd_body', sql: indexSql }],
+            }],
+        });
+        expect(test.stderr).toEqual([]);
+    });
+});
+
+describe('database query direct action', () => {
+    it('fails the native support gate before requesting read access', async () => {
+        const databaseQueryWithConfig = await requireExport('databaseQueryWithConfig');
+        const test = directHarness(async () => ({ columns: [], rows: [] }));
+        test.dependencies.loadClient = async () => {
+            test.events.push('load');
+            throw new Error('NATIVE_BINDING_FAILURE_SENTINEL');
+        };
+
+        await expect(databaseQueryWithConfig(
+            'Analytics',
+            'SELECT 1',
+            { json: true },
+            CONFIG,
+            test.dependencies,
+        )).rejects.toMatchObject({ code: 'database_client_unsupported' });
+
+        expect(test.events).toEqual(['load']);
+        expect(test.posts).toEqual([]);
+        expect(test.clientConfigs).toEqual([]);
+        expect(test.stdout).toEqual([]);
+        expect(test.stderr).toEqual([]);
+    });
+
+    it('uses one read credential, preserves positional duplicate columns, and normalizes JSON cells', async () => {
+        const databaseQueryWithConfig = await requireExport('databaseQueryWithConfig');
+        const sql = 'SELECT 7 AS duplicate, 8 AS duplicate, big_value, payload, nullable FROM metrics';
+        const test = directHarness(async () => ({
+            columns: ['duplicate', 'duplicate', 'big_value', 'payload', 'nullable'],
+            rows: [[7n, 8n, 9_223_372_036_854_775_807n, new Uint8Array([0x00, 0xff, 0x10]), null]],
+        }));
+
+        await databaseQueryWithConfig('Analytics', sql, { json: true }, CONFIG, test.dependencies);
+
+        expectSingleAccessPost(test, 'read');
+        expectEphemeralClient(test);
+        expect(test.statements).toEqual([sql]);
+        expect(JSON.stringify(test.posts)).not.toContain(sql);
+        expect(JSON.parse(test.stdout.join('\n'))).toEqual({
+            columns: ['duplicate', 'duplicate', 'big_value', 'payload', 'nullable'],
+            rows: [['7', '8', '9223372036854775807', { base64: 'AP8Q' }, null]],
+            row_count: 1,
+        });
+        expect(test.stderr).toEqual([]);
+    });
+
+    it('renders the same positional result as a human table with stable bigint, blob, and null cells', async () => {
+        const databaseQueryWithConfig = await requireExport('databaseQueryWithConfig');
+        const test = directHarness(async () => ({
+            columns: ['id', 'payload', 'nullable'],
+            rows: [[9_223_372_036_854_775_807n, new Uint8Array([0x00, 0xff, 0x10]), null]],
+        }));
+
+        await databaseQueryWithConfig('Analytics', 'SELECT id, payload, nullable FROM metrics', {}, CONFIG, test.dependencies);
+
+        const output = test.stdout.join('\n');
+        expect(output).toMatch(/id/i);
+        expect(output).toMatch(/payload/i);
+        expect(output).toContain('9223372036854775807');
+        expect(output).toContain('<blob 3 bytes>');
+        expect(output).toContain('NULL');
+        expect(test.stderr).toEqual([]);
+    });
+
+    it('sends even obvious write SQL through a read-authorized direct client, leaving authorization to the server', async () => {
+        const databaseQueryWithConfig = await requireExport('databaseQueryWithConfig');
+        const sql = 'DELETE FROM events WHERE id = 42';
+        const test = directHarness(async () => ({ columns: [], rows: [] }));
+
+        await databaseQueryWithConfig('Analytics', sql, { json: true }, CONFIG, test.dependencies);
+
+        expectSingleAccessPost(test, 'read');
+        expect(test.statements).toEqual([sql]);
+        expect(JSON.stringify(test.posts)).not.toContain(sql);
+    });
+});
+
+describe('database exec direct action', () => {
+    it('uses one write credential and returns affected counts plus positional returned rows as JSON', async () => {
+        const databaseExecWithConfig = await requireExport('databaseExecWithConfig');
+        const sql = 'INSERT INTO events (body) VALUES (\'hello\') RETURNING id, body';
+        const test = directHarness(async () => ({
+            columns: ['id', 'body'],
+            rows: [[9_223_372_036_854_775_807n, 'hello']],
+            rowsAffected: 1,
+            lastInsertRowid: 9_223_372_036_854_775_807n,
+        }));
+
+        await databaseExecWithConfig('Analytics', sql, { yes: true, json: true }, CONFIG, test.dependencies);
+
+        expect(test.confirm).not.toHaveBeenCalled();
+        expectSingleAccessPost(test, 'write');
+        expectEphemeralClient(test);
+        expect(test.statements).toEqual([sql]);
+        expect(JSON.stringify(test.posts)).not.toContain(sql);
+        expect(JSON.parse(test.stdout.join('\n'))).toEqual({
+            columns: ['id', 'body'],
+            rows: [['9223372036854775807', 'hello']],
+            row_count: 1,
+            rows_affected: 1,
+            last_insert_rowid: '9223372036854775807',
+        });
+        expect(test.stderr).toEqual([]);
+    });
+
+    it('confirms in a TTY before minting, then reports affected count and returned rows in human output', async () => {
+        const databaseExecWithConfig = await requireExport('databaseExecWithConfig');
+        const test = directHarness(async () => ({
+            columns: ['id'],
+            rows: [[12n]],
+            rowsAffected: 1,
+            lastInsertRowid: 12n,
+        }));
+
+        await databaseExecWithConfig('Analytics', 'UPDATE events SET seen = 1 RETURNING id', {}, CONFIG, test.dependencies);
+
+        expect(test.confirm).toHaveBeenCalledOnce();
+        expect(test.confirm.mock.calls[0][0]).toMatch(/Analytics/);
+        expect(test.events.indexOf('mint')).toBeGreaterThan(test.events.indexOf('load'));
+        const output = test.stdout.join('\n');
+        expect(output).toMatch(/1\s+row.*affected|rows affected.*1/i);
+        expect(output).toContain('id');
+        expect(output).toContain('12');
+        expect(test.stderr).toEqual([]);
+    });
+
+    it.each([
+        ['decline', false],
+        ['EOF', undefined],
+    ])('treats interactive %s as cancellation before native load, mint, or client creation', async (_label, answer) => {
+        const databaseExecWithConfig = await requireExport('databaseExecWithConfig');
+        const test = directHarness(async () => ({ columns: [], rows: [] }), { confirmation: answer });
+
+        await databaseExecWithConfig('Analytics', 'DROP TABLE events', {}, CONFIG, test.dependencies);
+
+        expect(test.confirm).toHaveBeenCalledOnce();
+        expect(test.events).toEqual([]);
+        expect(test.posts).toEqual([]);
+        expect(test.clientConfigs).toEqual([]);
+        expect(test.statements).toEqual([]);
+        expect(test.stdout.join('\n')).toMatch(/cancelled/i);
+        expect(test.stderr).toEqual([]);
+    });
+
+    it.each([
+        ['JSON', { json: true }, true],
+        ['non-interactive', {}, false],
+    ])('requires --yes in %s mode without prompting, loading, minting, or creating a client', async (_label, options, isTTY) => {
+        const databaseExecWithConfig = await requireExport('databaseExecWithConfig');
+        const test = directHarness(async () => ({ columns: [], rows: [] }), { isTTY });
+
+        await expect(databaseExecWithConfig('Analytics', 'DROP TABLE events', options, CONFIG, test.dependencies))
+            .rejects.toMatchObject({ code: 'confirmation_required' });
+
+        expect(test.confirm).not.toHaveBeenCalled();
+        expect(test.events).toEqual([]);
+        expect(test.posts).toEqual([]);
+        expect(test.clientConfigs).toEqual([]);
+        expect(test.statements).toEqual([]);
+        expect(test.stdout).toEqual([]);
+        expect(test.stderr).toEqual([]);
+    });
+});
+
+describe('database direct command error boundary', () => {
+    it.each([
+        ['databaseSchemaWithConfig', ['Analytics', { json: true }]],
+        ['databaseQueryWithConfig', ['Analytics', 'SELECT * FROM events', { json: true }]],
+        ['databaseExecWithConfig', ['Analytics', 'DELETE FROM events', { yes: true, json: true }]],
+    ])('scrubs direct failures from %s output, errors, and snapshots', async (exportName, argumentsBeforeConfig) => {
+        const handler = await requireExport(exportName);
+        const failure = [
+            'DIRECT_FAILURE_SENTINEL',
+            ACCESS.url,
+            'physical-db.sentinel.invalid',
+            ACCESS.token,
+        ].join(' ');
+        const test = directHarness(async () => {
+            throw new Error(failure);
+        });
+
+        let caught: any;
+        try {
+            await handler(...argumentsBeforeConfig, CONFIG, test.dependencies);
+        } catch (error) {
+            caught = error;
+        }
+
+        const publicSurface = {
+            error: { code: caught?.code, message: caught?.message },
+            stdout: test.stdout,
+            stderr: test.stderr,
+        };
+        expect(publicSurface).toMatchInlineSnapshot(`
+          {
+            "error": {
+              "code": "upstream_unavailable",
+              "message": "Database operation failed.",
+            },
+            "stderr": [],
+            "stdout": [],
+          }
+        `);
+        expect(test.close).toHaveBeenCalledOnce();
+
+        const rendered = `${String(caught)}\n${JSON.stringify(caught)}\n${JSON.stringify(publicSurface)}`;
+        for (const sentinel of ['DIRECT_FAILURE_SENTINEL', ACCESS.url, 'physical-db.sentinel.invalid', ACCESS.token]) {
+            expect(rendered).not.toContain(sentinel);
+        }
+    });
+});

--- a/tests/database-direct-commands.test.ts
+++ b/tests/database-direct-commands.test.ts
@@ -135,6 +135,8 @@ function expectSingleAccessPost(test: ReturnType<typeof directHarness>, mode: 'r
                 'Content-Type': 'application/json',
                 'X-Workspace-Id': 'workspace-1146',
             },
+            signal: expect.any(AbortSignal),
+            timeout: 30_000,
         },
     }]);
 }

--- a/tests/database-direct-commands.test.ts
+++ b/tests/database-direct-commands.test.ts
@@ -53,9 +53,12 @@ function directHarness(
     const statements: unknown[] = [];
     const stdout: string[] = [];
     const stderr: string[] = [];
-    const confirm = vi.fn(async () => Object.prototype.hasOwnProperty.call(options, 'confirmation')
-        ? options.confirmation
-        : true);
+    const confirm = vi.fn(async () => {
+        events.push('confirm');
+        return Object.prototype.hasOwnProperty.call(options, 'confirmation')
+            ? options.confirmation
+            : true;
+    });
     const close = vi.fn(async () => {
         events.push('close');
     });
@@ -200,6 +203,61 @@ describe('database schema direct action', () => {
         });
         expect(test.stderr).toEqual([]);
     });
+
+    it('renders logical tables, column details, composite PK order, and indexes safely for humans', async () => {
+        const databaseSchemaWithConfig = await requireExport('databaseSchemaWithConfig');
+        const test = directHarness(async (statement) => {
+            const sql = statementSql(statement);
+            if (/type\s*=\s*'table'/i.test(sql)) {
+                return {
+                    columns: ['name', 'sql'],
+                    rows: [['memberships', 'CREATE TABLE memberships (account_id INTEGER, region TEXT DEFAULT \'us\', PRIMARY KEY (account_id, region))']],
+                };
+            }
+            if (/type\s*=\s*'index'/i.test(sql)) {
+                return {
+                    columns: ['name', 'tbl_name', 'sql'],
+                    rows: [['idx_memberships_region', 'memberships', 'CREATE INDEX idx_memberships_region ON memberships(region)']],
+                };
+            }
+            if (sql === 'PRAGMA table_info("memberships")') {
+                return {
+                    columns: ['cid', 'name', 'type', 'notnull', 'dflt_value', 'pk'],
+                    rows: [
+                        ['0', 'account_id', 'INTEGER', '1', null, '1'],
+                        ['1', 'region', 'TEXT', '0', "'us'", '2'],
+                    ],
+                };
+            }
+            throw new Error(`Unexpected direct SQL: ${sql}`);
+        });
+
+        await databaseSchemaWithConfig('Analytics', {}, CONFIG, test.dependencies);
+
+        const output = test.stdout.join('\n');
+        expect(output).toContain('Analytics');
+        expect(output).toContain('memberships');
+        expect(output).toContain('account_id');
+        expect(output).toContain('INTEGER');
+        expect(output).toContain('region');
+        expect(output).toContain('TEXT');
+        expect(output).toMatch(/not.?null/i);
+        expect(output).toMatch(/default/i);
+        expect(output).toContain("'us'");
+        expect(output).toMatch(/pk|primary.?key/i);
+        expect(output).toMatch(/(?:^|\D)1(?:\D|$)/);
+        expect(output).toMatch(/(?:^|\D)2(?:\D|$)/);
+        expect(output).toContain('idx_memberships_region');
+        expect(() => JSON.parse(output)).toThrow();
+        expect(output).not.toMatch(/\u001b\[/);
+        expect(output).not.toContain(CONFIG.apiKey);
+        expect(output).not.toContain(ACCESS.token);
+        expect(output).not.toContain(ACCESS.url);
+        expect(output).not.toContain('physical-db.sentinel.invalid');
+        expect(test.stderr).toEqual([]);
+        expectSingleAccessPost(test, 'read');
+        expectEphemeralClient(test);
+    });
 });
 
 describe('database query direct action', () => {
@@ -320,7 +378,7 @@ describe('database exec direct action', () => {
 
         expect(test.confirm).toHaveBeenCalledOnce();
         expect(test.confirm.mock.calls[0][0]).toMatch(/Analytics/);
-        expect(test.events.indexOf('mint')).toBeGreaterThan(test.events.indexOf('load'));
+        expect(test.events).toEqual(['confirm', 'load', 'mint', 'create', 'execute', 'close']);
         const output = test.stdout.join('\n');
         expect(output).toMatch(/1\s+row.*affected|rows affected.*1/i);
         expect(output).toContain('id');
@@ -338,7 +396,7 @@ describe('database exec direct action', () => {
         await databaseExecWithConfig('Analytics', 'DROP TABLE events', {}, CONFIG, test.dependencies);
 
         expect(test.confirm).toHaveBeenCalledOnce();
-        expect(test.events).toEqual([]);
+        expect(test.events).toEqual(['confirm']);
         expect(test.posts).toEqual([]);
         expect(test.clientConfigs).toEqual([]);
         expect(test.statements).toEqual([]);

--- a/tests/database-dump-command.test.ts
+++ b/tests/database-dump-command.test.ts
@@ -1,0 +1,256 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { pathToFileURL } from 'url';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+interface Config {
+    host: string;
+    apiKey: string;
+    workspaceId: string;
+}
+
+const CONFIG: Config = {
+    host: 'https://app.example.test',
+    apiKey: 'control-plane-pat-sentinel',
+    workspaceId: 'workspace-1146',
+};
+
+const roots: string[] = [];
+
+afterEach(() => {
+    for (const root of roots.splice(0)) {
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+});
+
+async function requireDump(): Promise<Function> {
+    const url = pathToFileURL(path.resolve(__dirname, '../src/commands/database.ts')).href;
+    let module: Record<string, unknown> = {};
+    try {
+        module = await import(url) as Record<string, unknown>;
+    } catch {
+        // The first TDD slice intentionally lands before the production export.
+    }
+    expect(module.databaseDumpWithConfig, 'databaseDumpWithConfig export').toBeTypeOf('function');
+    return module.databaseDumpWithConfig as Function;
+}
+
+function tempRoot(): string {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'sa-database-dump-'));
+    roots.push(root);
+    return root;
+}
+
+function chunks(...values: string[]): AsyncIterable<Buffer> {
+    return (async function* stream() {
+        for (const value of values) yield Buffer.from(value);
+    })();
+}
+
+function failingChunks(secret: string): AsyncIterable<Buffer> {
+    return (async function* stream() {
+        yield Buffer.from('CREATE TABLE preserved (id INTEGER);\n');
+        throw new Error(`stream exploded ${secret}`);
+    })();
+}
+
+function dumpHarness(root: string, data: unknown = chunks('SELECT 1;\n')) {
+    const posts: Array<{ url: string; body: Record<string, unknown>; options: Record<string, unknown> }> = [];
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const confirm = vi.fn(async () => true as boolean | undefined);
+    const dependencies = {
+        cwd: root,
+        tempPath: (target: string) => path.join(path.dirname(target), `.${path.basename(target)}.solidactions-task7.tmp`),
+        post: async (url: string, body: Record<string, unknown>, options: Record<string, unknown>) => {
+            posts.push({ url, body, options });
+            return { status: 200, data };
+        },
+        stdout: (line: string) => stdout.push(line),
+        stderr: (line: string) => stderr.push(line),
+        confirm,
+        isTTY: true,
+    };
+
+    return { posts, stdout, stderr, confirm, dependencies };
+}
+
+function expectDumpPost(post: { url: string; body: Record<string, unknown>; options: Record<string, unknown> }, name: string): void {
+    expect(post.url).toBe('https://app.example.test/api/v1/databases');
+    expect(post.body).toEqual({ operation: 'dump', name });
+    expect(post.options).toMatchObject({
+        responseType: 'stream',
+        headers: {
+            Accept: expect.stringMatching(/sql|octet-stream/i),
+            Authorization: 'Bearer control-plane-pat-sentinel',
+            'Content-Type': 'application/json',
+            'X-Workspace-Id': 'workspace-1146',
+        },
+    });
+}
+
+describe('database dump atomic file contract', () => {
+    it.each([
+        { name: '../../', expected: 'database.sql' },
+        { name: '../../Customer Data/2026', expected: 'customer-data-2026.sql' },
+        { name: '/tmp/Root DB', expected: 'tmp-root-db.sql' },
+    ])('keeps the safe default for $name inside cwd as $expected', async ({ name, expected }) => {
+        const databaseDumpWithConfig = await requireDump();
+        const root = tempRoot();
+        const test = dumpHarness(root, chunks('-- complete\n'));
+
+        await databaseDumpWithConfig(name, undefined, {}, CONFIG, test.dependencies);
+
+        const target = path.join(root, expected);
+        expect(fs.readFileSync(target, 'utf8')).toBe('-- complete\n');
+        expect(path.dirname(target)).toBe(root);
+        expect(test.posts).toHaveLength(1);
+        expectDumpPost(test.posts[0], name);
+        expect(test.stdout.join('\n')).toContain(expected);
+        expect(test.stderr).toEqual([]);
+    });
+
+    it('streams to an exclusively-created sibling temp and renames only after the stream closes', async () => {
+        const databaseDumpWithConfig = await requireDump();
+        const root = tempRoot();
+        const target = path.join(root, 'chosen.sql');
+        const events: string[] = [];
+        const realPromises = fs.promises;
+        const data = (async function* stream() {
+            try {
+                yield Buffer.from('CREATE TABLE events (id INTEGER);\n');
+                yield Buffer.from('INSERT INTO events VALUES (1);\n');
+            } finally {
+                events.push('stream-close');
+            }
+        })();
+        const test = dumpHarness(root, data);
+        const open = vi.fn(async (file: fs.PathLike, flags: fs.OpenMode, mode?: fs.Mode) => {
+            events.push(`open:${String(flags)}`);
+            return realPromises.open(file, flags, mode);
+        });
+        const rename = vi.fn(async (from: fs.PathLike, to: fs.PathLike) => {
+            events.push('rename');
+            return realPromises.rename(from, to);
+        });
+        test.dependencies = {
+            ...test.dependencies,
+            filesystem: { ...realPromises, open, rename },
+        } as any;
+
+        await databaseDumpWithConfig('Analytics', target, {}, CONFIG, test.dependencies);
+
+        expect(open).toHaveBeenCalled();
+        expect(open.mock.calls[0][1]).toBe('wx');
+        expect(rename).toHaveBeenCalledOnce();
+        expect(events.indexOf('stream-close')).toBeLessThan(events.indexOf('rename'));
+        expect(fs.readFileSync(target, 'utf8')).toContain('INSERT INTO events VALUES (1)');
+        expect(fs.readdirSync(root)).toEqual(['chosen.sql']);
+    });
+
+    it.each([
+        { label: 'non-TTY', isTTY: false, answer: true },
+        { label: 'decline', isTTY: true, answer: false },
+        { label: 'EOF', isTTY: true, answer: undefined },
+    ])('$label refuses an existing target before any request or write', async ({ isTTY, answer }) => {
+        const databaseDumpWithConfig = await requireDump();
+        const root = tempRoot();
+        const target = path.join(root, 'existing.sql');
+        fs.writeFileSync(target, 'OLD DUMP');
+        const test = dumpHarness(root);
+        test.dependencies.isTTY = isTTY;
+        test.dependencies.confirm = vi.fn(async () => answer);
+
+        const outcome = databaseDumpWithConfig('Analytics', target, {}, CONFIG, test.dependencies);
+        if (isTTY) await outcome;
+        else await expect(outcome).rejects.toMatchObject({ code: 'confirmation_required' });
+
+        expect(test.posts).toEqual([]);
+        expect(fs.readFileSync(target, 'utf8')).toBe('OLD DUMP');
+        expect(fs.readdirSync(root)).toEqual(['existing.sql']);
+    });
+
+    it('refuses a destination symlink before prompting or requesting, even with --yes', async () => {
+        const databaseDumpWithConfig = await requireDump();
+        const root = tempRoot();
+        const outside = path.join(root, 'outside.sql');
+        const target = path.join(root, 'linked.sql');
+        fs.writeFileSync(outside, 'DO NOT REPLACE');
+        fs.symlinkSync(outside, target);
+        const test = dumpHarness(root);
+
+        await expect(databaseDumpWithConfig('Analytics', target, { yes: true }, CONFIG, test.dependencies))
+            .rejects.toThrow(/symbolic link/i);
+
+        expect(test.posts).toEqual([]);
+        expect(test.confirm).not.toHaveBeenCalled();
+        expect(fs.readFileSync(outside, 'utf8')).toBe('DO NOT REPLACE');
+        expect(fs.lstatSync(target).isSymbolicLink()).toBe(true);
+    });
+
+    it.each([
+        {
+            label: 'stream failure',
+            stream: failingChunks('RAW_STREAM_TOKEN_AND_HOST_SENTINEL'),
+        },
+        {
+            label: 'incomplete marker split across chunks',
+            stream: chunks('SELECT 1;\n-- DOWNLOAD ', 'INCOMPLETE\n'),
+        },
+    ])('$label preserves the old target and removes only its own temp', async ({ stream }) => {
+        const databaseDumpWithConfig = await requireDump();
+        const root = tempRoot();
+        const target = path.join(root, 'existing.sql');
+        const ownTemp = path.join(root, '.existing.sql.solidactions-task7.tmp');
+        const unrelated = path.join(root, '.other.sql.solidactions-someone-else.tmp');
+        fs.writeFileSync(target, 'OLD DUMP');
+        fs.writeFileSync(unrelated, 'NOT OUR FILE');
+        const test = dumpHarness(root, stream);
+
+        let caught: any;
+        try {
+            await databaseDumpWithConfig('Analytics', target, { yes: true }, CONFIG, test.dependencies);
+        } catch (error) {
+            caught = error;
+        }
+
+        expect(caught).toBeDefined();
+        expect(String(caught?.message)).toMatch(/failed|incomplete/i);
+        expect(JSON.stringify(caught)).not.toContain('RAW_STREAM_TOKEN_AND_HOST_SENTINEL');
+        expect(String(caught?.stack ?? '')).not.toContain('RAW_STREAM_TOKEN_AND_HOST_SENTINEL');
+        expect(String(caught?.message)).not.toContain(CONFIG.apiKey);
+        expect(fs.readFileSync(target, 'utf8')).toBe('OLD DUMP');
+        expect(fs.existsSync(ownTemp)).toBe(false);
+        expect(fs.readFileSync(unrelated, 'utf8')).toBe('NOT OUR FILE');
+    });
+
+    it('scrubs HTTP response bodies and credentials while preserving an existing target', async () => {
+        const databaseDumpWithConfig = await requireDump();
+        const root = tempRoot();
+        const target = path.join(root, 'existing.sql');
+        fs.writeFileSync(target, 'OLD DUMP');
+        const test = dumpHarness(root);
+        test.dependencies.post = async () => {
+            throw {
+                message: `request failed ${CONFIG.apiKey}`,
+                response: { data: 'RAW_UPSTREAM_BODY_SENTINEL' },
+                config: { headers: { Authorization: `Bearer ${CONFIG.apiKey}` } },
+            };
+        };
+
+        let caught: any;
+        try {
+            await databaseDumpWithConfig('Analytics', target, { yes: true }, CONFIG, test.dependencies);
+        } catch (error) {
+            caught = error;
+        }
+
+        expect(caught).toMatchObject({ code: 'upstream_unavailable' });
+        const publicError = `${caught?.message ?? ''} ${caught?.stack ?? ''} ${JSON.stringify(caught)}`;
+        expect(publicError).not.toContain(CONFIG.apiKey);
+        expect(publicError).not.toContain('RAW_UPSTREAM_BODY_SENTINEL');
+        expect(fs.readFileSync(target, 'utf8')).toBe('OLD DUMP');
+        expect(fs.readdirSync(root)).toEqual(['existing.sql']);
+    });
+});

--- a/tests/database-dump-command.test.ts
+++ b/tests/database-dump-command.test.ts
@@ -189,6 +189,46 @@ describe('database dump atomic file contract', () => {
         expect(fs.lstatSync(target).isSymbolicLink()).toBe(true);
     });
 
+    it('refuses a symlinked destination parent before requesting or creating files', async () => {
+        const databaseDumpWithConfig = await requireDump();
+        const root = tempRoot();
+        const outside = path.join(root, 'outside');
+        const linkedParent = path.join(root, 'backups');
+        fs.mkdirSync(outside);
+        fs.writeFileSync(path.join(outside, 'analytics.sql'), 'OUTSIDE DUMP');
+        fs.symlinkSync(outside, linkedParent, 'dir');
+        const test = dumpHarness(root);
+
+        await expect(databaseDumpWithConfig(
+            'Analytics',
+            path.join(linkedParent, 'analytics.sql'),
+            { yes: true },
+            CONFIG,
+            test.dependencies,
+        )).rejects.toThrow(/symbolic link/i);
+
+        expect(test.posts).toEqual([]);
+        expect(test.confirm).not.toHaveBeenCalled();
+        expect(fs.readFileSync(path.join(outside, 'analytics.sql'), 'utf8')).toBe('OUTSIDE DUMP');
+        expect(fs.readdirSync(outside)).toEqual(['analytics.sql']);
+    });
+
+    it('reserves its deterministic sibling temp exclusively without posting or removing a collision', async () => {
+        const databaseDumpWithConfig = await requireDump();
+        const root = tempRoot();
+        const target = path.join(root, 'analytics.sql');
+        const temp = path.join(root, '.analytics.sql.solidactions-task7.tmp');
+        fs.writeFileSync(temp, 'PRE-EXISTING TEMP OWNED BY SOMEONE ELSE');
+        const test = dumpHarness(root);
+
+        await expect(databaseDumpWithConfig('Analytics', target, {}, CONFIG, test.dependencies))
+            .rejects.toThrow(/temporary|already exists|failed/i);
+
+        expect(test.posts).toEqual([]);
+        expect(fs.existsSync(target)).toBe(false);
+        expect(fs.readFileSync(temp, 'utf8')).toBe('PRE-EXISTING TEMP OWNED BY SOMEONE ELSE');
+    });
+
     it.each([
         {
             label: 'stream failure',
@@ -252,5 +292,37 @@ describe('database dump atomic file contract', () => {
         expect(publicError).not.toContain('RAW_UPSTREAM_BODY_SENTINEL');
         expect(fs.readFileSync(target, 'utf8')).toBe('OLD DUMP');
         expect(fs.readdirSync(root)).toEqual(['existing.sql']);
+    });
+
+    it('rolls back only its own temp when final rename fails and scrubs filesystem details', async () => {
+        const databaseDumpWithConfig = await requireDump();
+        const root = tempRoot();
+        const target = path.join(root, 'existing.sql');
+        const ownTemp = path.join(root, '.existing.sql.solidactions-task7.tmp');
+        const unrelated = path.join(root, '.unrelated.solidactions-other.tmp');
+        fs.writeFileSync(target, 'OLD DUMP');
+        fs.writeFileSync(unrelated, 'NOT OUR FILE');
+        const test = dumpHarness(root, chunks('COMPLETE NEW DUMP'));
+        test.dependencies.filesystem = {
+            ...fs.promises,
+            rename: async () => {
+                throw new Error(`rename leaked ${CONFIG.apiKey} RAW_RENAME_PATH_SENTINEL`);
+            },
+        } as any;
+
+        let caught: any;
+        try {
+            await databaseDumpWithConfig('Analytics', target, { yes: true }, CONFIG, test.dependencies);
+        } catch (error) {
+            caught = error;
+        }
+
+        expect(caught).toMatchObject({ code: 'upstream_unavailable' });
+        const publicError = `${caught?.message ?? ''} ${caught?.stack ?? ''} ${JSON.stringify(caught)}`;
+        expect(publicError).not.toContain(CONFIG.apiKey);
+        expect(publicError).not.toContain('RAW_RENAME_PATH_SENTINEL');
+        expect(fs.readFileSync(target, 'utf8')).toBe('OLD DUMP');
+        expect(fs.existsSync(ownTemp)).toBe(false);
+        expect(fs.readFileSync(unrelated, 'utf8')).toBe('NOT OUR FILE');
     });
 });

--- a/tests/database-dump-command.test.ts
+++ b/tests/database-dump-command.test.ts
@@ -134,9 +134,13 @@ describe('database dump atomic file contract', () => {
             events.push('rename');
             return realPromises.rename(from, to);
         });
+        const chmod = vi.fn(async (file: fs.PathLike, mode: fs.Mode) => {
+            events.push(`chmod:${Number(mode).toString(8)}`);
+            return realPromises.chmod(file, mode);
+        });
         test.dependencies = {
             ...test.dependencies,
-            filesystem: { ...realPromises, open, rename },
+            filesystem: { ...realPromises, open, rename, chmod },
         } as any;
 
         await databaseDumpWithConfig('Analytics', target, {}, CONFIG, test.dependencies);
@@ -145,7 +149,10 @@ describe('database dump atomic file contract', () => {
         expect(open.mock.calls[0][1]).toBe('wx');
         expect(rename).toHaveBeenCalledOnce();
         expect(events.indexOf('stream-close')).toBeLessThan(events.indexOf('rename'));
+        expect(chmod).toHaveBeenCalledWith(target, 0o444);
+        expect(events.indexOf('rename')).toBeLessThan(events.indexOf('chmod:444'));
         expect(fs.readFileSync(target, 'utf8')).toContain('INSERT INTO events VALUES (1)');
+        expect(fs.statSync(target).mode & 0o777).toBe(0o444);
         expect(fs.readdirSync(root)).toEqual(['chosen.sql']);
     });
 

--- a/tests/database-file-command-actions.test.ts
+++ b/tests/database-file-command-actions.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const handlers = vi.hoisted(() => ({
+    dump: vi.fn(async () => undefined),
+    pull: vi.fn(async () => undefined),
+}));
+
+vi.mock('../src/commands/database', async (importOriginal) => ({
+    ...await importOriginal<typeof import('../src/commands/database')>(),
+    databaseDump: handlers.dump,
+    databasePull: handlers.pull,
+}));
+
+import { program } from '../src/index';
+
+function databaseCommand(verb: string): any {
+    const database = program.commands.find((command) => command.name() === 'database');
+    const command = database?.commands.find((candidate) => candidate.name() === verb);
+    expect(command, `database ${verb}`).toBeDefined();
+    expect((command as any)?._actionHandler, `database ${verb} action`).toBeTypeOf('function');
+    return command;
+}
+
+describe('database file command registration', () => {
+    it('dispatches dump name, optional destination, and overwrite option', async () => {
+        await databaseCommand('dump').parseAsync(
+            ['../../Customer Data', './backups/customer.sql', '--yes'],
+            { from: 'user' },
+        );
+
+        expect(handlers.dump).toHaveBeenCalledOnce();
+        expect(handlers.dump).toHaveBeenCalledWith(
+            '../../Customer Data',
+            './backups/customer.sql',
+            { yes: true },
+        );
+    });
+
+    it('dispatches pull name, optional destination, and pull options', async () => {
+        await databaseCommand('pull').parseAsync(
+            ['Analytics', './replicas/analytics.db', '--yes', '--writable'],
+            { from: 'user' },
+        );
+
+        expect(handlers.pull).toHaveBeenCalledOnce();
+        expect(handlers.pull).toHaveBeenCalledWith(
+            'Analytics',
+            './replicas/analytics.db',
+            { yes: true, writable: true },
+        );
+    });
+});

--- a/tests/database-import-command.test.ts
+++ b/tests/database-import-command.test.ts
@@ -176,6 +176,8 @@ function expectWriteAccess(test: ReturnType<typeof importHarness>): void {
                     'Content-Type': 'application/json',
                     'X-Workspace-Id': 'workspace-1146',
                 },
+                signal: expect.any(AbortSignal),
+                timeout: 30_000,
             },
         });
     }

--- a/tests/database-import-command.test.ts
+++ b/tests/database-import-command.test.ts
@@ -534,7 +534,7 @@ describe('database import preflight and execution', () => {
         expect(checkpoints).toHaveLength(1);
         const checkpoint = JSON.parse(fs.readFileSync(checkpoints[0], 'utf8'));
         expect(checkpoint).toMatchObject({ lastCompletedBatch: 1, nextStatement: 100 });
-        expect(report(caught, test).split('\n')).toContain(resumeLine('Analytics', source, checkpoints[0]));
+        expect(report(caught, test)).not.toContain('Resume with:');
         expectNoSecrets(report(caught, test));
         expectNoSecrets(checkpoint);
     });
@@ -1014,7 +1014,7 @@ describe('database import resume validation', () => {
         expect(test.stdout.join('\n')).toContain(String(fs.statSync(source).size));
     });
 
-    it('reports the exact last completed resume position before guidance when access fails pre-execution', async () => {
+    it('preserves a valid checkpoint without resume guidance when policy denies access pre-execution', async () => {
         const databaseImportWithConfig = await requireImport();
         const root = tempRoot();
         const statements = Array.from({ length: 101 }, (_, index) => `INSERT INTO t VALUES (${index});`);
@@ -1048,11 +1048,12 @@ describe('database import resume validation', () => {
             caught = error;
         }
 
-        const lines = report(caught, test).split('\n');
-        const position = `Last completed position: batch 1, 100 statements, ${completedSourceBytes} source bytes.`;
-        const guidance = resumeLine('Analytics', source, checkpoint);
-        expect(lines).toContain(position);
-        expect(lines.indexOf(position)).toBeLessThan(lines.indexOf(guidance));
+        expect(caught).toMatchObject({
+            code: 'read_only_mode',
+            message: 'Database writes are disabled.',
+            status: 403,
+        });
+        expect(report(caught, test)).not.toContain('Resume with:');
         expect(test.executions).toEqual([]);
         expect(test.clients).toEqual([]);
         expect(fs.readFileSync(checkpoint)).toEqual(before);

--- a/tests/database-import-command.test.ts
+++ b/tests/database-import-command.test.ts
@@ -43,9 +43,9 @@ function tempRoot(): string {
     return root;
 }
 
-function sourceFile(root: string, sql: string, name = 'seed.sql'): string {
+function sourceFile(root: string, sql: string | Buffer, name = 'seed.sql'): string {
     const file = path.join(root, name);
-    fs.writeFileSync(file, sql, { encoding: 'utf8', mode: 0o600 });
+    fs.writeFileSync(file, sql, { mode: 0o600 });
     return file;
 }
 
@@ -220,6 +220,10 @@ function report(error: unknown, test: ReturnType<typeof importHarness>): string 
     return [value?.code, value?.message, ...test.stdout, ...test.stderr].map(String).join('\n');
 }
 
+function resumeLine(database: string, source: string, checkpoint: string): string {
+    return `Resume with: solidactions database import ${JSON.stringify(database)} ${JSON.stringify(source)} --resume ${JSON.stringify(checkpoint)} --yes`;
+}
+
 function expectNoSecrets(value: unknown): void {
     const rendered = typeof value === 'string' ? value : JSON.stringify(value);
     expect(rendered).not.toContain(CONFIG.apiKey);
@@ -251,6 +255,9 @@ describe('database import preflight and execution', () => {
         "\ufeffCREATE TABLE t (id);\r\n-- DOWNLOAD INCOMPLETE: browser stream failed\r\n",
         "CREATE TABLE t (id)\n",
         `INSERT INTO t VALUES ('${'x'.repeat(8 * 1024 * 1024)}');`,
+        '',
+        ' \n-- comments only;\n/* still only a comment */\n',
+        Buffer.from([0x43, 0x52, 0x45, 0x41, 0x54, 0x45, 0x20, 0xc3, 0x28, 0x3b]),
     ])('refuses an unsafe source before confirmation, native load, mint, or execution', async (sql) => {
         const databaseImportWithConfig = await requireImport();
         const root = tempRoot();
@@ -295,6 +302,89 @@ describe('database import preflight and execution', () => {
             .rejects.toMatchObject({ code: 'confirmation_required' });
         expect(test.events).toEqual([]);
         expect(test.posts).toEqual([]);
+    });
+
+    it('refuses a matching deterministic checkpoint without --resume before minting or replaying work', async () => {
+        const databaseImportWithConfig = await requireImport();
+        const outer = tempRoot();
+        const root = path.join(outer, 'project with spaces');
+        fs.mkdirSync(root);
+        const database = 'Finance North';
+        const statements = Array.from({ length: 101 }, (_, index) => `INSERT INTO t VALUES (${index});`);
+        const source = sourceFile(root, statements.join('\n'), 'seed file.sql');
+        const interrupted = importHarness(root, {
+            execute: async ({ sql }) => {
+                if (sql.includes('VALUES (100)')) throw new Error('INITIAL_FAILURE');
+            },
+        });
+        let initialFailure: unknown;
+        try {
+            await databaseImportWithConfig(database, source, { yes: true }, CONFIG, interrupted.dependencies);
+        } catch (error) {
+            initialFailure = error;
+        }
+        const [checkpoint] = checkpointFiles(root);
+        expect(checkpoint).toBeDefined();
+        expect(report(initialFailure, interrupted).split('\n')).toContain(resumeLine(database, source, checkpoint));
+        const before = fs.readFileSync(checkpoint);
+        const test = importHarness(root);
+
+        let caught: unknown;
+        try {
+            await databaseImportWithConfig(database, source, { yes: true }, CONFIG, test.dependencies);
+        } catch (error) {
+            caught = error;
+        }
+
+        expect(test.events).not.toContain('native:load');
+        expect(test.posts).toEqual([]);
+        expect(test.executions).toEqual([]);
+        expect(fs.readFileSync(checkpoint)).toEqual(before);
+        const lines = report(caught, test).split('\n').filter((line) => line.startsWith('Resume with:'));
+        expect(lines).toEqual([resumeLine(database, source, checkpoint)]);
+    });
+
+    it.each([
+        {
+            label: 'expires at the 30-second boundary',
+            access: {
+                url: 'libsql://physical-hostname.sentinel.invalid',
+                token: 'write-token-sentinel-near-expiry',
+                mode: 'write',
+                expires_at: '2026-08-07T12:00:30.000Z',
+                transport_debug: 'RAW_TRANSPORT_SECRET',
+            },
+        },
+        {
+            label: 'has the wrong mode',
+            access: {
+                url: 'libsql://physical-hostname.sentinel.invalid',
+                token: 'write-token-sentinel-read',
+                mode: 'read',
+                expires_at: '2026-08-07T12:10:00.000Z',
+                transport_debug: 'RAW_TRANSPORT_SECRET',
+            },
+        },
+    ])('rejects access that $label without creating a client or leaking metadata', async ({ access }) => {
+        const databaseImportWithConfig = await requireImport();
+        const root = tempRoot();
+        const source = sourceFile(root, 'CREATE TABLE t (id);');
+        const test = importHarness(root, { post: async () => access });
+
+        let caught: unknown;
+        try {
+            await databaseImportWithConfig('Analytics', source, { yes: true }, CONFIG, test.dependencies);
+        } catch (error) {
+            caught = error;
+        }
+
+        expect(test.clients).toEqual([]);
+        expect(test.executions).toEqual([]);
+        expect(test.closed).toEqual([]);
+        expect(importFiles(root)).toEqual([]);
+        const rendered = report(caught, test);
+        expectNoSecrets(rendered);
+        expect(rendered).not.toContain('RAW_TRANSPORT_SECRET');
     });
 
     it('imports a command-owned preflight snapshot with write-only ephemeral access and an exact managed envelope', async () => {
@@ -424,9 +514,11 @@ describe('database import preflight and execution', () => {
         }
 
         expect(test.executions).toHaveLength(1);
-        expect(checkpointFiles(root)).toHaveLength(1);
-        const checkpoint = JSON.parse(fs.readFileSync(checkpointFiles(root)[0], 'utf8'));
+        const checkpoints = checkpointFiles(root);
+        expect(checkpoints).toHaveLength(1);
+        const checkpoint = JSON.parse(fs.readFileSync(checkpoints[0], 'utf8'));
         expect(checkpoint).toMatchObject({ lastCompletedBatch: 1, nextStatement: 100 });
+        expect(report(caught, test).split('\n')).toContain(resumeLine('Analytics', source, checkpoints[0]));
         expectNoSecrets(report(caught, test));
         expectNoSecrets(checkpoint);
     });
@@ -471,7 +563,7 @@ describe('database import preflight and execution', () => {
         expect(fs.statSync(checkpoints[0]).mode & 0o777).toBe(0o600);
         expect(importFiles(root).filter((file) => file.endsWith('.tmp'))).toEqual([]);
         expect(report(caught, test)).toContain(
-            `Resume with: solidactions database import Analytics ${source} --resume ${checkpoints[0]} --yes`,
+            resumeLine('Analytics', source, checkpoints[0]),
         );
         expectNoSecrets(report(caught, test));
         expectNoSecrets(checkpoint);
@@ -503,9 +595,153 @@ describe('database import preflight and execution', () => {
         expect(report(caught, test)).not.toContain('Resume with:');
         expect(report(caught, test)).toMatch(/import_failed|checkpoint/i);
     });
+
+    it('never follows a deterministic checkpoint target symlink before minting', async () => {
+        const databaseImportWithConfig = await requireImport();
+        const root = tempRoot();
+        const statements = Array.from({ length: 101 }, (_, index) => `INSERT INTO t VALUES (${index});`);
+        const source = sourceFile(root, statements.join('\n'));
+        const interrupted = importHarness(root, {
+            execute: async ({ sql }) => {
+                if (sql.includes('VALUES (100)')) throw new Error('INITIAL_FAILURE');
+            },
+        });
+        await expect(databaseImportWithConfig('Analytics', source, { yes: true }, CONFIG, interrupted.dependencies))
+            .rejects.toMatchObject({ code: 'import_failed' });
+        const [target] = checkpointFiles(root);
+        expect(target).toBeDefined();
+        const victim = path.join(root, 'victim.json');
+        fs.writeFileSync(victim, 'VICTIM MUST REMAIN');
+        fs.unlinkSync(target);
+        fs.symlinkSync(victim, target);
+        const test = importHarness(root);
+
+        await expect(databaseImportWithConfig('Analytics', source, { yes: true }, CONFIG, test.dependencies))
+            .rejects.toMatchObject({ code: 'import_failed' });
+
+        expect(test.events).not.toContain('native:load');
+        expect(test.posts).toEqual([]);
+        expect(test.executions).toEqual([]);
+        expect(fs.readFileSync(victim, 'utf8')).toBe('VICTIM MUST REMAIN');
+        expect(fs.lstatSync(target).isSymbolicLink()).toBe(true);
+    });
+
+    it('never follows a pre-existing symlinked imports ancestor when deriving a checkpoint', async () => {
+        const databaseImportWithConfig = await requireImport();
+        const root = tempRoot();
+        const source = sourceFile(root, 'CREATE TABLE t (id);');
+        const victimDirectory = path.join(root, 'victim-imports');
+        const controlDirectory = path.join(root, '.solidactions');
+        fs.mkdirSync(victimDirectory);
+        fs.mkdirSync(controlDirectory);
+        fs.writeFileSync(path.join(victimDirectory, 'keep.txt'), 'VICTIM MUST REMAIN');
+        fs.symlinkSync(victimDirectory, path.join(controlDirectory, 'imports'), 'dir');
+        const test = importHarness(root);
+
+        await expect(databaseImportWithConfig('Analytics', source, { yes: true }, CONFIG, test.dependencies))
+            .rejects.toMatchObject({ code: 'import_failed' });
+
+        expect(test.events).not.toContain('native:load');
+        expect(test.posts).toEqual([]);
+        expect(fs.readdirSync(victimDirectory)).toEqual(['keep.txt']);
+        expect(fs.readFileSync(path.join(victimDirectory, 'keep.txt'), 'utf8')).toBe('VICTIM MUST REMAIN');
+    });
+
+    it('does not retry or claim resumability when an imports-ancestor symlink appears after a committed batch', async () => {
+        const databaseImportWithConfig = await requireImport();
+        const root = tempRoot();
+        const statements = Array.from({ length: 101 }, (_, index) => `INSERT INTO t VALUES (${index});`);
+        const source = sourceFile(root, statements.join('\n'));
+        const controlDirectory = path.join(root, '.solidactions');
+        const imports = path.join(controlDirectory, 'imports');
+        const victimDirectory = path.join(root, 'victim-directory');
+        fs.mkdirSync(controlDirectory);
+        fs.mkdirSync(victimDirectory);
+        fs.writeFileSync(path.join(victimDirectory, 'keep.txt'), 'VICTIM MUST REMAIN');
+        let executions = 0;
+        const test = importHarness(root, {
+            execute: async () => {
+                executions += 1;
+                if (executions === 1) fs.symlinkSync(victimDirectory, imports, 'dir');
+            },
+        });
+
+        let caught: unknown;
+        try {
+            await databaseImportWithConfig('Analytics', source, { yes: true }, CONFIG, test.dependencies);
+        } catch (error) {
+            caught = error;
+        }
+
+        expect(test.executions).toHaveLength(1);
+        expect(fs.lstatSync(imports).isSymbolicLink()).toBe(true);
+        expect(fs.readFileSync(path.join(victimDirectory, 'keep.txt'), 'utf8')).toBe('VICTIM MUST REMAIN');
+        expect(fs.readdirSync(victimDirectory)).toEqual(['keep.txt']);
+        expect(report(caught, test)).not.toContain('Resume with:');
+        expect(caught).toMatchObject({ code: 'import_failed' });
+    });
 });
 
 describe('database import resume validation', () => {
+    it('refuses a directory supplied as --resume before native load or mint', async () => {
+        const databaseImportWithConfig = await requireImport();
+        const root = tempRoot();
+        const source = sourceFile(root, 'CREATE TABLE t (id);');
+        const resume = path.join(root, 'resume-directory');
+        fs.mkdirSync(resume);
+        const test = importHarness(root);
+
+        await expect(databaseImportWithConfig(
+            'Analytics', source, { yes: true, resume }, CONFIG, test.dependencies,
+        )).rejects.toMatchObject({ code: 'import_failed' });
+
+        expect(test.events).not.toContain('native:load');
+        expect(test.posts).toEqual([]);
+    });
+
+    it('requires --resume to name a regular non-symlink checkpoint file', async () => {
+        const databaseImportWithConfig = await requireImport();
+        const root = tempRoot();
+        const source = sourceFile(root, 'CREATE TABLE t (id);\nINSERT INTO t VALUES (1);');
+        const victim = writeCheckpoint(root, checkpointFor(source, 'Analytics'), 'victim.json');
+        const resume = path.join(path.dirname(victim), 'resume-link.json');
+        fs.symlinkSync(victim, resume);
+        const before = fs.readFileSync(victim);
+        const test = importHarness(root);
+
+        await expect(databaseImportWithConfig(
+            'Analytics', source, { yes: true, resume }, CONFIG, test.dependencies,
+        )).rejects.toMatchObject({ code: 'import_failed' });
+
+        expect(test.events).not.toContain('native:load');
+        expect(test.posts).toEqual([]);
+        expect(fs.readFileSync(victim)).toEqual(before);
+        expect(fs.lstatSync(resume).isSymbolicLink()).toBe(true);
+    });
+
+    it('refuses a --resume path beneath a symlinked ancestor before native load or mint', async () => {
+        const databaseImportWithConfig = await requireImport();
+        const root = tempRoot();
+        const source = sourceFile(root, 'CREATE TABLE t (id);\nINSERT INTO t VALUES (1);');
+        const victimDirectory = path.join(root, 'victim-imports');
+        fs.mkdirSync(victimDirectory);
+        const victim = path.join(victimDirectory, 'resume.json');
+        fs.writeFileSync(victim, `${JSON.stringify(checkpointFor(source, 'Analytics'))}\n`, { mode: 0o600 });
+        const linkedAncestor = path.join(root, 'linked-imports');
+        fs.symlinkSync(victimDirectory, linkedAncestor, 'dir');
+        const resume = path.join(linkedAncestor, 'resume.json');
+        const before = fs.readFileSync(victim);
+        const test = importHarness(root);
+
+        await expect(databaseImportWithConfig(
+            'Analytics', source, { yes: true, resume }, CONFIG, test.dependencies,
+        )).rejects.toMatchObject({ code: 'import_failed' });
+
+        expect(test.events).not.toContain('native:load');
+        expect(test.posts).toEqual([]);
+        expect(fs.readFileSync(victim)).toEqual(before);
+    });
+
     it.each([
         ['wrong version', { version: 99 }],
         ['wrong database', { database: 'Other' }],
@@ -602,6 +838,9 @@ describe('database create --from real importer', () => {
         'CREATE TABLE t (id);\n-- DOWNLOAD INCOMPLETE: stream failed\n',
         'CREATE TABLE t (id)\n',
         `INSERT INTO t VALUES ('${'x'.repeat(8 * 1024 * 1024)}');`,
+        '',
+        ' \n-- comments only;\n/* still only a comment */\n',
+        Buffer.from([0x43, 0x52, 0x45, 0x41, 0x54, 0x45, 0x20, 0xc3, 0x28, 0x3b]),
     ])('preflights marker, parse, and size failures before provisioning or native loading', async (sql) => {
         const databaseCreateWithConfig = await requireCreate();
         const root = tempRoot();

--- a/tests/database-import-command.test.ts
+++ b/tests/database-import-command.test.ts
@@ -4,6 +4,7 @@ import os from 'os';
 import path from 'path';
 import { pathToFileURL } from 'url';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DatabaseOperationError } from '../src/utils/database-data-plane';
 
 const CONFIG = {
     host: 'https://app.example.test',
@@ -538,6 +539,95 @@ describe('database import preflight and execution', () => {
         expectNoSecrets(checkpoint);
     });
 
+    it.each([
+        {
+            code: 'read_only_mode',
+            message: 'Database writes are disabled.',
+            status: 403,
+        },
+        {
+            code: 'plan_denied',
+            message: 'Database writes are unavailable on this plan.',
+            status: 403,
+        },
+        {
+            code: 'rate_limited',
+            message: 'Database access is temporarily rate limited.',
+            status: 429,
+        },
+    ])('preserves a $code renewal refusal and suppresses unsafe resume guidance', async ({ code, message, status }) => {
+        const databaseImportWithConfig = await requireImport();
+        const root = tempRoot();
+        const statements = Array.from({ length: 101 }, (_, index) => `INSERT INTO t VALUES (${index});`);
+        const source = sourceFile(root, statements.join('\n'));
+        let clock = Date.parse('2026-08-07T12:00:00.000Z');
+        const test = importHarness(root, {
+            now: () => clock,
+            post: async (attempt) => {
+                if (attempt === 2) {
+                    const denied: any = new Error('RAW_TRANSPORT_SECRET');
+                    denied.response = { status, data: { code, message } };
+                    throw denied;
+                }
+                return {
+                    url: 'libsql://physical-hostname.sentinel.invalid',
+                    token: 'write-token-sentinel-1',
+                    mode: 'write',
+                    expires_at: '2026-08-07T12:10:00.000Z',
+                };
+            },
+            execute: async () => {
+                clock = Date.parse('2026-08-07T12:09:31.000Z');
+            },
+        });
+
+        let caught: unknown;
+        try {
+            await databaseImportWithConfig('Analytics', source, { yes: true }, CONFIG, test.dependencies);
+        } catch (error) {
+            caught = error;
+        }
+
+        expect(caught).toMatchObject({ code, message, status });
+        expect(checkpointFiles(root)).toHaveLength(1);
+        expect(report(caught, test)).not.toContain('Resume with:');
+        expectNoSecrets(report(caught, test));
+    });
+
+    it('preserves a structured batch refusal without offering a policy-invalid resume', async () => {
+        const databaseImportWithConfig = await requireImport();
+        const root = tempRoot();
+        const statements = Array.from({ length: 101 }, (_, index) => `INSERT INTO t VALUES (${index});`);
+        const source = sourceFile(root, statements.join('\n'));
+        const test = importHarness(root, {
+            execute: async ({ sql }) => {
+                if (sql.includes('VALUES (100)')) {
+                    throw new DatabaseOperationError(
+                        'read_only_mode',
+                        'Database writes were disabled during import.',
+                        403,
+                    );
+                }
+            },
+        });
+
+        let caught: unknown;
+        try {
+            await databaseImportWithConfig('Analytics', source, { yes: true }, CONFIG, test.dependencies);
+        } catch (error) {
+            caught = error;
+        }
+
+        expect(caught).toMatchObject({
+            code: 'read_only_mode',
+            message: 'Database writes were disabled during import.',
+            status: 403,
+        });
+        expect(checkpointFiles(root)).toHaveLength(1);
+        expect(report(caught, test)).not.toContain('Resume with:');
+        expectNoSecrets(report(caught, test));
+    });
+
     it('never replays a failed or unknown batch and emits the exact stable resume command for the checkpoint', async () => {
         const databaseImportWithConfig = await requireImport();
         const root = tempRoot();
@@ -584,6 +674,43 @@ describe('database import preflight and execution', () => {
         expectNoSecrets(checkpoint);
         expect(caught).toMatchObject({ code: 'import_failed' });
         expect(test.closed).toEqual([1]);
+    });
+
+    it('resumes strictly after committed batches when a later batch is interrupted mid-execution', async () => {
+        const databaseImportWithConfig = await requireImport();
+        const root = tempRoot();
+        const statements = Array.from({ length: 201 }, (_, index) => `INSERT INTO t VALUES (${index});`);
+        const source = sourceFile(root, statements.join('\n'));
+        const interrupted = importHarness(root, {
+            execute: async ({ sql }) => {
+                if (sql.includes('VALUES (100)')) throw new Error('MID_BATCH_INTERRUPTION');
+            },
+        });
+
+        await expect(
+            databaseImportWithConfig('Analytics', source, { yes: true }, CONFIG, interrupted.dependencies),
+        ).rejects.toMatchObject({ code: 'import_failed' });
+
+        const [checkpoint] = checkpointFiles(root);
+        expect(JSON.parse(fs.readFileSync(checkpoint, 'utf8'))).toMatchObject({
+            lastCompletedBatch: 1,
+            nextStatement: 100,
+        });
+
+        const resumed = importHarness(root);
+        await databaseImportWithConfig(
+            'Analytics',
+            source,
+            { yes: true, resume: checkpoint },
+            CONFIG,
+            resumed.dependencies,
+        );
+
+        expect(resumed.executions).toHaveLength(2);
+        expect(resumed.executions[0].sql).toContain('VALUES (100)');
+        expect(resumed.executions[0].sql).not.toContain('VALUES (99)');
+        expect(resumed.executions[1].sql).toContain('VALUES (200)');
+        expect(checkpointFiles(root)).toEqual([]);
     });
 
     it('does not claim resumability when atomic checkpoint publication fails after a committed batch', async () => {

--- a/tests/database-import-command.test.ts
+++ b/tests/database-import-command.test.ts
@@ -433,6 +433,21 @@ describe('database import preflight and execution', () => {
         expect(output).toContain(String(fs.statSync(source).size));
     });
 
+    it('distinguishes committed source progress from total source size', async () => {
+        const databaseImportWithConfig = await requireImport();
+        const root = tempRoot();
+        const statement = 'INSERT INTO t VALUES (1);';
+        const source = sourceFile(root, `${statement}\n`);
+        const test = importHarness(root);
+
+        await databaseImportWithConfig('Analytics', source, { yes: true }, CONFIG, test.dependencies);
+
+        expect(test.stdout).toEqual([
+            `Imported checkpoint: 1 statements, committed source progress: ${Buffer.byteLength(statement)} source bytes.`,
+            `Imported 1 statements (${fs.statSync(source).size} total source bytes) into database "Analytics".`,
+        ]);
+    });
+
     it('batches at 512 KiB of UTF-8 SQL and runs one larger legal group alone', async () => {
         const databaseImportWithConfig = await requireImport();
         const root = tempRoot();

--- a/tests/database-import-command.test.ts
+++ b/tests/database-import-command.test.ts
@@ -871,6 +871,51 @@ describe('database import resume validation', () => {
         expect(test.stdout.join('\n')).toMatch(/Imported 2 statements/i);
         expect(test.stdout.join('\n')).toContain(String(fs.statSync(source).size));
     });
+
+    it('reports the exact last completed resume position before guidance when access fails pre-execution', async () => {
+        const databaseImportWithConfig = await requireImport();
+        const root = tempRoot();
+        const statements = Array.from({ length: 101 }, (_, index) => `INSERT INTO t VALUES (${index});`);
+        const source = sourceFile(root, statements.join('\n'));
+        const completedSourceBytes = Buffer.byteLength(statements.slice(0, 100).join('\n'));
+        const checkpoint = writeCheckpoint(root, checkpointFor(source, 'Analytics', {
+            lastCompletedBatch: 1,
+            nextStatement: 100,
+            completedSourceBytes,
+        }));
+        const before = fs.readFileSync(checkpoint);
+        const test = importHarness(root, {
+            post: async () => {
+                const denied: any = new Error('RAW_TRANSPORT_SECRET');
+                denied.config = { headers: { Authorization: 'Bearer RAW_TRANSPORT_SECRET' } };
+                denied.response = {
+                    status: 403,
+                    data: { code: 'read_only_mode', message: 'Database writes are disabled.' },
+                    config: denied.config,
+                };
+                throw denied;
+            },
+        });
+
+        let caught: unknown;
+        try {
+            await databaseImportWithConfig(
+                'Analytics', source, { yes: true, resume: checkpoint }, CONFIG, test.dependencies,
+            );
+        } catch (error) {
+            caught = error;
+        }
+
+        const lines = report(caught, test).split('\n');
+        const position = `Last completed position: batch 1, 100 statements, ${completedSourceBytes} source bytes.`;
+        const guidance = resumeLine('Analytics', source, checkpoint);
+        expect(lines).toContain(position);
+        expect(lines.indexOf(position)).toBeLessThan(lines.indexOf(guidance));
+        expect(test.executions).toEqual([]);
+        expect(test.clients).toEqual([]);
+        expect(fs.readFileSync(checkpoint)).toEqual(before);
+        expectNoSecrets(report(caught, test));
+    });
 });
 
 describe('database create --from real importer', () => {
@@ -911,6 +956,28 @@ describe('database create --from real importer', () => {
         ]);
         expect(test.executions).toEqual([{ client: 1, sql: managedEnvelope([statement]) }]);
         expect(test.confirm).not.toHaveBeenCalled();
+    });
+
+    it('keeps --json create-from stdout as one undecorated create response', async () => {
+        const databaseCreateWithConfig = await requireCreate();
+        const root = tempRoot();
+        const source = sourceFile(root, 'CREATE TABLE t (id);');
+        const test = importHarness(root);
+        const expected = {
+            database: {
+                name: 'Analytics',
+                status: 'ready',
+                deleted_at: null,
+                purge_at: null,
+                size_bytes: 0,
+            },
+        };
+
+        await databaseCreateWithConfig('requested-name', { from: source, json: true }, CONFIG, test.dependencies);
+
+        expect(test.stdout).toHaveLength(1);
+        expect(JSON.parse(test.stdout[0])).toEqual(expected);
+        expectNoSecrets(test.stdout);
     });
 
     it('leaves a newly created database in place and returns actionable import_failed guidance', async () => {

--- a/tests/database-import-command.test.ts
+++ b/tests/database-import-command.test.ts
@@ -654,6 +654,7 @@ describe('database import preflight and execution', () => {
         const source = sourceFile(root, statements.join('\n'));
         const controlDirectory = path.join(root, '.solidactions');
         const imports = path.join(controlDirectory, 'imports');
+        const displacedImports = path.join(controlDirectory, 'imports-displaced-by-attacker');
         const victimDirectory = path.join(root, 'victim-directory');
         fs.mkdirSync(controlDirectory);
         fs.mkdirSync(victimDirectory);
@@ -662,7 +663,10 @@ describe('database import preflight and execution', () => {
         const test = importHarness(root, {
             execute: async () => {
                 executions += 1;
-                if (executions === 1) fs.symlinkSync(victimDirectory, imports, 'dir');
+                if (executions === 1) {
+                    if (fs.existsSync(imports)) fs.renameSync(imports, displacedImports);
+                    fs.symlinkSync(victimDirectory, imports, 'dir');
+                }
             },
         });
 
@@ -677,6 +681,10 @@ describe('database import preflight and execution', () => {
         expect(fs.lstatSync(imports).isSymbolicLink()).toBe(true);
         expect(fs.readFileSync(path.join(victimDirectory, 'keep.txt'), 'utf8')).toBe('VICTIM MUST REMAIN');
         expect(fs.readdirSync(victimDirectory)).toEqual(['keep.txt']);
+        if (fs.existsSync(displacedImports)) {
+            expect(fs.lstatSync(displacedImports).isDirectory()).toBe(true);
+            expect(fs.realpathSync(displacedImports)).not.toBe(fs.realpathSync(victimDirectory));
+        }
         expect(report(caught, test)).not.toContain('Resume with:');
         expect(caught).toMatchObject({ code: 'import_failed' });
     });

--- a/tests/database-import-command.test.ts
+++ b/tests/database-import-command.test.ts
@@ -784,6 +784,38 @@ describe('database import resume validation', () => {
         expect(test.executions).toEqual([]);
     });
 
+    it.each([
+        {
+            label: 'batch count exceeds the deterministic boundary count',
+            lastCompletedBatch: 2,
+            nextStatement: 100,
+        },
+        {
+            label: 'statement position is not a deterministic batch boundary',
+            lastCompletedBatch: 1,
+            nextStatement: 50,
+        },
+    ])('rejects a checkpoint whose $label before native load or mint', async ({ lastCompletedBatch, nextStatement }) => {
+        const databaseImportWithConfig = await requireImport();
+        const root = tempRoot();
+        const statements = Array.from({ length: 101 }, (_, index) => `INSERT INTO t VALUES (${index});`);
+        const source = sourceFile(root, statements.join('\n'));
+        const checkpoint = writeCheckpoint(root, checkpointFor(source, 'Analytics', {
+            lastCompletedBatch,
+            nextStatement,
+            completedSourceBytes: Buffer.byteLength(statements.slice(0, nextStatement).join('\n')),
+        }));
+        const test = importHarness(root);
+
+        await expect(databaseImportWithConfig(
+            'Analytics', source, { yes: true, resume: checkpoint }, CONFIG, test.dependencies,
+        )).rejects.toMatchObject({ code: 'import_failed' });
+
+        expect(test.events).not.toContain('native:load');
+        expect(test.posts).toEqual([]);
+        expect(test.executions).toEqual([]);
+    });
+
     it('rejects corrupt JSON and same-size source mutation before native load or mint', async () => {
         const databaseImportWithConfig = await requireImport();
         const root = tempRoot();
@@ -908,5 +940,62 @@ describe('database create --from real importer', () => {
         expect(rendered).toMatch(/remain|left in place/i);
         expect(rendered).toContain('--resume');
         expectNoSecrets(rendered);
+    });
+
+    it('namespaces a partial create-from checkpoint and guidance by the API-returned canonical name', async () => {
+        const databaseCreateWithConfig = await requireCreate();
+        const root = tempRoot();
+        const statements = Array.from({ length: 101 }, (_, index) => `INSERT INTO t VALUES (${index});`);
+        const source = sourceFile(root, statements.join('\n'));
+        const test = importHarness(root, {
+            execute: async ({ sql }) => {
+                if (sql.includes('VALUES (100)')) throw new Error('CONTROLLED_SECOND_BATCH_FAILURE');
+            },
+        });
+
+        let caught: unknown;
+        try {
+            await databaseCreateWithConfig('requested-name', { from: source }, CONFIG, test.dependencies);
+        } catch (error) {
+            caught = error;
+        }
+
+        const checkpoints = checkpointFiles(root);
+        expect(checkpoints).toHaveLength(1);
+        expect(path.basename(checkpoints[0])).toMatch(/^analytics-/);
+        expect(report(caught, test).split('\n')).toContain(resumeLine('Analytics', source, checkpoints[0]));
+        expect(JSON.parse(fs.readFileSync(checkpoints[0], 'utf8'))).toMatchObject({ database: 'Analytics' });
+    });
+
+    it('makes a create-from checkpoint discoverable by a later plain import of the returned name without replay', async () => {
+        const databaseCreateWithConfig = await requireCreate();
+        const databaseImportWithConfig = await requireImport();
+        const root = tempRoot();
+        const statements = Array.from({ length: 101 }, (_, index) => `INSERT INTO t VALUES (${index});`);
+        const source = sourceFile(root, statements.join('\n'));
+        const interrupted = importHarness(root, {
+            execute: async ({ sql }) => {
+                if (sql.includes('VALUES (100)')) throw new Error('CONTROLLED_SECOND_BATCH_FAILURE');
+            },
+        });
+        await expect(databaseCreateWithConfig(
+            'requested-name', { from: source }, CONFIG, interrupted.dependencies,
+        )).rejects.toMatchObject({ code: 'import_failed' });
+        const [checkpoint] = checkpointFiles(root);
+        const before = fs.readFileSync(checkpoint);
+        const plain = importHarness(root);
+
+        let caught: unknown;
+        try {
+            await databaseImportWithConfig('Analytics', source, { yes: true }, CONFIG, plain.dependencies);
+        } catch (error) {
+            caught = error;
+        }
+
+        expect(plain.events).not.toContain('native:load');
+        expect(plain.posts).toEqual([]);
+        expect(plain.executions).toEqual([]);
+        expect(fs.readFileSync(checkpoint)).toEqual(before);
+        expect(report(caught, plain).split('\n')).toContain(resumeLine('Analytics', source, checkpoint));
     });
 });

--- a/tests/database-import-command.test.ts
+++ b/tests/database-import-command.test.ts
@@ -251,6 +251,23 @@ describe('database import command registration', () => {
 });
 
 describe('database import preflight and execution', () => {
+    it('closes a stalled atomic batch at the per-verb deadline and does not publish progress', async () => {
+        const databaseImportWithConfig = await requireImport();
+        const root = tempRoot();
+        const source = sourceFile(root, 'CREATE TABLE stalled (id);');
+        const test = importHarness(root, {
+            execute: async () => new Promise(() => undefined),
+        });
+        test.dependencies.dataPlaneTimeoutMs = 10;
+
+        await expect(databaseImportWithConfig('Analytics', source, { yes: true }, CONFIG, test.dependencies))
+            .rejects.toMatchObject({ code: 'upstream_unavailable' });
+
+        expect(test.closed).toEqual([1]);
+        expect(checkpointFiles(root)).toEqual([]);
+        expect(test.stdout).toEqual([]);
+    }, 1_000);
+
     it.each([
         "CREATE TABLE t (id);\n-- DOWNLOAD INCOMPLETE: stream failed\n",
         "\ufeffCREATE TABLE t (id);\r\n-- DOWNLOAD INCOMPLETE: browser stream failed\r\n",

--- a/tests/database-import-command.test.ts
+++ b/tests/database-import-command.test.ts
@@ -1,0 +1,665 @@
+import { createHash } from 'crypto';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { pathToFileURL } from 'url';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const CONFIG = {
+    host: 'https://app.example.test',
+    apiKey: 'control-plane-pat-sentinel',
+    workspaceId: 'workspace-1146',
+};
+
+const roots: string[] = [];
+
+afterEach(() => {
+    for (const root of roots.splice(0)) {
+        fs.chmodSync(root, 0o700);
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+});
+
+async function commandModule(): Promise<Record<string, unknown>> {
+    const url = pathToFileURL(path.resolve(__dirname, '../src/commands/database.ts')).href;
+    return await import(url) as Record<string, unknown>;
+}
+
+async function requireImport(): Promise<Function> {
+    const module = await commandModule();
+    expect(module.databaseImportWithConfig, 'databaseImportWithConfig export').toBeTypeOf('function');
+    return module.databaseImportWithConfig as Function;
+}
+
+async function requireCreate(): Promise<Function> {
+    const module = await commandModule();
+    expect(module.databaseCreateWithConfig, 'databaseCreateWithConfig export').toBeTypeOf('function');
+    return module.databaseCreateWithConfig as Function;
+}
+
+function tempRoot(): string {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'sa-database-import-'));
+    roots.push(root);
+    return root;
+}
+
+function sourceFile(root: string, sql: string, name = 'seed.sql'): string {
+    const file = path.join(root, name);
+    fs.writeFileSync(file, sql, { encoding: 'utf8', mode: 0o600 });
+    return file;
+}
+
+interface Execution {
+    client: number;
+    sql: string;
+}
+
+interface HarnessOptions {
+    confirm?: boolean;
+    isTTY?: boolean;
+    now?: () => number;
+    expiresAt?: string[];
+    post?: (attempt: number, body: Record<string, unknown>) => Promise<unknown>;
+    execute?: (execution: Execution) => Promise<void>;
+    onLoad?: () => void;
+    filesystem?: typeof fs.promises;
+}
+
+function importHarness(root: string, options: HarnessOptions = {}) {
+    const events: string[] = [];
+    const posts: Array<{ url: string; body: Record<string, unknown>; options: Record<string, unknown> }> = [];
+    const clients: Record<string, unknown>[] = [];
+    const executions: Execution[] = [];
+    const closed: number[] = [];
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const confirm = vi.fn(async () => {
+        events.push('confirm');
+        return options.confirm ?? true;
+    });
+    const expiresAt = options.expiresAt ?? ['2026-08-07T12:10:00.000Z'];
+    let clientCount = 0;
+    let accessAttempt = 0;
+
+    const dependencies: Record<string, unknown> = {
+        cwd: root,
+        filesystem: options.filesystem,
+        now: options.now ?? (() => Date.parse('2026-08-07T12:00:00.000Z')),
+        isTTY: options.isTTY ?? true,
+        confirm,
+        stdout: (line: string) => stdout.push(line),
+        stderr: (line: string) => stderr.push(line),
+        loadClient: async () => {
+            events.push('native:load');
+            options.onLoad?.();
+            return {
+                createClient: (config: Record<string, unknown>) => {
+                    const client = ++clientCount;
+                    clients.push(config);
+                    events.push(`client:${client}:create`);
+                    return {
+                        execute: async () => {
+                            throw new Error('import must use executeMultiple');
+                        },
+                        executeMultiple: async (statement: unknown) => {
+                            const execution = { client, sql: String(statement) };
+                            executions.push(execution);
+                            events.push(`client:${client}:execute:${executions.length}`);
+                            await options.execute?.(execution);
+                        },
+                        close: async () => {
+                            closed.push(client);
+                            events.push(`client:${client}:close`);
+                        },
+                    };
+                },
+            };
+        },
+        post: async (url: string, body: Record<string, unknown>, requestOptions: Record<string, unknown>) => {
+            posts.push({ url, body, options: requestOptions });
+            events.push(`post:${String(body.operation)}`);
+            if (body.operation === 'create') {
+                if (options.post) return { data: await options.post(0, body) };
+                return {
+                    data: {
+                        database: {
+                            name: 'Analytics',
+                            status: 'ready',
+                            deleted_at: null,
+                            purge_at: null,
+                            size_bytes: 0,
+                        },
+                    },
+                };
+            }
+
+            const attempt = ++accessAttempt;
+            if (options.post) return { data: await options.post(attempt, body) };
+            return {
+                data: {
+                    url: 'libsql://physical-hostname.sentinel.invalid',
+                    token: `write-token-sentinel-${attempt}`,
+                    mode: 'write',
+                    expires_at: expiresAt[Math.min(attempt - 1, expiresAt.length - 1)],
+                },
+            };
+        },
+    };
+
+    return { events, posts, clients, executions, closed, stdout, stderr, confirm, dependencies };
+}
+
+function managedEnvelope(statements: string[]): string {
+    return [
+        'PRAGMA foreign_keys=OFF;',
+        'BEGIN IMMEDIATE;',
+        ...statements,
+        'COMMIT;',
+        'PRAGMA foreign_keys=ON;',
+    ].join('\n');
+}
+
+function accessPosts(test: ReturnType<typeof importHarness>) {
+    return test.posts.filter((call) => call.body.operation === 'access');
+}
+
+function expectWriteAccess(test: ReturnType<typeof importHarness>): void {
+    for (const call of accessPosts(test)) {
+        expect(call).toEqual({
+            url: 'https://app.example.test/api/v1/databases',
+            body: { operation: 'access', name: 'Analytics', mode: 'write' },
+            options: {
+                headers: {
+                    Accept: 'application/json',
+                    Authorization: 'Bearer control-plane-pat-sentinel',
+                    'Content-Type': 'application/json',
+                    'X-Workspace-Id': 'workspace-1146',
+                },
+            },
+        });
+    }
+}
+
+function importFiles(root: string): string[] {
+    const directory = path.join(root, '.solidactions', 'imports');
+    return fs.existsSync(directory)
+        ? fs.readdirSync(directory).map((name) => path.join(directory, name))
+        : [];
+}
+
+function checkpointFiles(root: string): string[] {
+    return importFiles(root).filter((file) => file.endsWith('.json'));
+}
+
+function checkpointFor(source: string, database: string, overrides: Record<string, unknown> = {}) {
+    const content = fs.readFileSync(source);
+    return {
+        version: 1,
+        database,
+        source: {
+            sha256: createHash('sha256').update(content).digest('hex'),
+            sizeBytes: content.length,
+        },
+        lastCompletedBatch: 1,
+        nextStatement: 1,
+        completedSourceBytes: Buffer.byteLength(content.toString('utf8').split('\n')[0]),
+        ...overrides,
+    };
+}
+
+function writeCheckpoint(root: string, value: Record<string, unknown>, name = 'resume.json'): string {
+    const directory = path.join(root, '.solidactions', 'imports');
+    fs.mkdirSync(directory, { recursive: true });
+    const file = path.join(directory, name);
+    fs.writeFileSync(file, `${JSON.stringify(value)}\n`, { mode: 0o600 });
+    return file;
+}
+
+function report(error: unknown, test: ReturnType<typeof importHarness>): string {
+    const value = error as { code?: unknown; message?: unknown } | null;
+    return [value?.code, value?.message, ...test.stdout, ...test.stderr].map(String).join('\n');
+}
+
+function expectNoSecrets(value: unknown): void {
+    const rendered = typeof value === 'string' ? value : JSON.stringify(value);
+    expect(rendered).not.toContain(CONFIG.apiKey);
+    expect(rendered).not.toContain('write-token-sentinel');
+    expect(rendered).not.toContain('physical-hostname.sentinel.invalid');
+    expect(rendered).not.toContain('RAW_TRANSPORT_SECRET');
+}
+
+describe('database import command registration', () => {
+    it('registers a real Commander action and required --resume checkpoint option', async () => {
+        const { program } = await import('../src/index');
+        const database = program.commands.find((command) => command.name() === 'database');
+        const command = database?.commands.find((candidate) => candidate.name() === 'import') as any;
+
+        expect(command).toBeDefined();
+        expect(command._actionHandler, 'database import action').toBeTypeOf('function');
+        expect(command.registeredArguments.map((argument: any) => [argument.name(), argument.required])).toEqual([
+            ['name', true],
+            ['file.sql', true],
+        ]);
+        expect(command.options.find((option: any) => option.long === '--yes')).toBeDefined();
+        expect(command.options.find((option: any) => option.long === '--resume')).toMatchObject({ required: true });
+    });
+});
+
+describe('database import preflight and execution', () => {
+    it.each([
+        "CREATE TABLE t (id);\n-- DOWNLOAD INCOMPLETE: stream failed\n",
+        "\ufeffCREATE TABLE t (id);\r\n-- DOWNLOAD INCOMPLETE: browser stream failed\r\n",
+        "CREATE TABLE t (id)\n",
+        `INSERT INTO t VALUES ('${'x'.repeat(8 * 1024 * 1024)}');`,
+    ])('refuses an unsafe source before confirmation, native load, mint, or execution', async (sql) => {
+        const databaseImportWithConfig = await requireImport();
+        const root = tempRoot();
+        const source = sourceFile(root, sql);
+        const test = importHarness(root);
+
+        await expect(databaseImportWithConfig('Analytics', source, { yes: true }, CONFIG, test.dependencies))
+            .rejects.toMatchObject({ code: 'import_failed' });
+
+        expect(test.confirm).not.toHaveBeenCalled();
+        expect(test.events).not.toContain('native:load');
+        expect(test.posts).toEqual([]);
+        expect(test.executions).toEqual([]);
+    });
+
+    it('requires confirmation, supports --yes, and always preflights before loading native code or minting', async () => {
+        const databaseImportWithConfig = await requireImport();
+        const root = tempRoot();
+        const source = sourceFile(root, 'CREATE TABLE t (id);');
+        const declined = importHarness(root, { confirm: false });
+
+        await databaseImportWithConfig('Analytics', source, {}, CONFIG, declined.dependencies);
+
+        expect(declined.confirm).toHaveBeenCalledOnce();
+        expect(declined.events).toEqual(['confirm']);
+        expect(declined.stdout).toEqual(['Cancelled.']);
+
+        const accepted = importHarness(root);
+        await databaseImportWithConfig('Analytics', source, { yes: true }, CONFIG, accepted.dependencies);
+        expect(accepted.confirm).not.toHaveBeenCalled();
+        expect(accepted.events.indexOf('native:load')).toBeLessThan(accepted.events.indexOf('post:access'));
+        expect(accepted.events.indexOf('post:access')).toBeLessThan(accepted.events.indexOf('client:1:execute:1'));
+    });
+
+    it('fails non-interactively without --yes before native load or mint', async () => {
+        const databaseImportWithConfig = await requireImport();
+        const root = tempRoot();
+        const source = sourceFile(root, 'CREATE TABLE t (id);');
+        const test = importHarness(root, { isTTY: false });
+
+        await expect(databaseImportWithConfig('Analytics', source, {}, CONFIG, test.dependencies))
+            .rejects.toMatchObject({ code: 'confirmation_required' });
+        expect(test.events).toEqual([]);
+        expect(test.posts).toEqual([]);
+    });
+
+    it('imports a command-owned preflight snapshot with write-only ephemeral access and an exact managed envelope', async () => {
+        const databaseImportWithConfig = await requireImport();
+        const root = tempRoot();
+        const original = "INSERT INTO items VALUES ('original');";
+        const source = sourceFile(root, original);
+        const test = importHarness(root, {
+            onLoad: () => fs.writeFileSync(source, "INSERT INTO items VALUES ('raced replacement');"),
+        });
+
+        await databaseImportWithConfig('Analytics', source, { yes: true }, CONFIG, test.dependencies);
+
+        expectWriteAccess(test);
+        expect(accessPosts(test)).toHaveLength(1);
+        expect(test.clients).toEqual([{
+            url: 'libsql://physical-hostname.sentinel.invalid',
+            authToken: 'write-token-sentinel-1',
+            intMode: 'string',
+        }]);
+        expect(test.executions).toEqual([{ client: 1, sql: managedEnvelope([original]) }]);
+        expect(test.closed).toEqual([1]);
+        expect(checkpointFiles(root)).toEqual([]);
+        expect(importFiles(root).filter((file) => /\.tmp$/.test(file))).toEqual([]);
+        expectNoSecrets(test.stdout);
+        expectNoSecrets(test.stderr);
+    });
+
+    it('batches deterministically at 100 groups and reports committed statements and source bytes after each batch', async () => {
+        const databaseImportWithConfig = await requireImport();
+        const root = tempRoot();
+        const statements = Array.from({ length: 101 }, (_, index) => `INSERT INTO t VALUES (${index});`);
+        const source = sourceFile(root, statements.join('\n'));
+        const test = importHarness(root);
+
+        await databaseImportWithConfig('Analytics', source, { yes: true }, CONFIG, test.dependencies);
+
+        expect(test.executions).toEqual([
+            { client: 1, sql: managedEnvelope(statements.slice(0, 100)) },
+            { client: 1, sql: managedEnvelope(statements.slice(100)) },
+        ]);
+        const output = test.stdout.join('\n');
+        expect(output).toMatch(/100 statements.*source bytes/i);
+        expect(output).toMatch(/101 statements.*source bytes/i);
+        expect(output).toMatch(/Imported 101 statements/i);
+        expect(output).toContain(String(fs.statSync(source).size));
+    });
+
+    it('batches at 512 KiB of UTF-8 SQL and runs one larger legal group alone', async () => {
+        const databaseImportWithConfig = await requireImport();
+        const root = tempRoot();
+        const statement = (marker: string, bytes: number) => {
+            const prefix = `INSERT INTO t VALUES ('${marker}`;
+            const suffix = "');";
+            return `${prefix}${'é'.repeat(Math.floor((bytes - Buffer.byteLength(prefix + suffix)) / 2))}${suffix}`;
+        };
+        const first = statement('a', 300 * 1024);
+        const second = statement('b', 300 * 1024);
+        const oversized = statement('c', 600 * 1024);
+        const source = sourceFile(root, [first, second, oversized].join('\n'));
+        const test = importHarness(root);
+
+        await databaseImportWithConfig('Analytics', source, { yes: true }, CONFIG, test.dependencies);
+
+        expect(test.executions.map((execution) => execution.sql)).toEqual([
+            managedEnvelope([first]),
+            managedEnvelope([second]),
+            managedEnvelope([oversized]),
+        ]);
+    });
+
+    it('renews proactively only between batches and closes the old client before a fresh write mint', async () => {
+        const databaseImportWithConfig = await requireImport();
+        const root = tempRoot();
+        const statements = Array.from({ length: 101 }, (_, index) => `INSERT INTO t VALUES (${index});`);
+        const source = sourceFile(root, statements.join('\n'));
+        let clock = Date.parse('2026-08-07T12:00:00.000Z');
+        const test = importHarness(root, {
+            now: () => clock,
+            expiresAt: ['2026-08-07T12:10:00.000Z', '2026-08-07T12:20:00.000Z'],
+            execute: async () => {
+                clock = Date.parse('2026-08-07T12:09:31.000Z');
+            },
+        });
+
+        await databaseImportWithConfig('Analytics', source, { yes: true }, CONFIG, test.dependencies);
+
+        expect(accessPosts(test)).toHaveLength(2);
+        expect(test.executions.map(({ client }) => client)).toEqual([1, 2]);
+        expect(test.closed).toEqual([1, 2]);
+        expect(test.events.indexOf('client:1:execute:1')).toBeLessThan(test.events.indexOf('client:1:close'));
+        expect(test.events.indexOf('client:1:close')).toBeLessThan(test.events.lastIndexOf('post:access'));
+        expect(test.events.lastIndexOf('post:access')).toBeLessThan(test.events.indexOf('client:2:execute:2'));
+    });
+
+    it('stops before the next batch when renewal is refused and retains only the last valid checkpoint', async () => {
+        const databaseImportWithConfig = await requireImport();
+        const root = tempRoot();
+        const statements = Array.from({ length: 101 }, (_, index) => `INSERT INTO t VALUES (${index});`);
+        const source = sourceFile(root, statements.join('\n'));
+        let clock = Date.parse('2026-08-07T12:00:00.000Z');
+        const test = importHarness(root, {
+            now: () => clock,
+            post: async (attempt) => {
+                if (attempt === 2) {
+                    const denied: any = new Error('RAW_TRANSPORT_SECRET');
+                    denied.response = { status: 403, data: { code: 'read_only_mode', message: 'Database writes are disabled.' } };
+                    throw denied;
+                }
+                return {
+                    url: 'libsql://physical-hostname.sentinel.invalid',
+                    token: 'write-token-sentinel-1',
+                    mode: 'write',
+                    expires_at: '2026-08-07T12:10:00.000Z',
+                };
+            },
+            execute: async () => {
+                clock = Date.parse('2026-08-07T12:09:31.000Z');
+            },
+        });
+
+        let caught: unknown;
+        try {
+            await databaseImportWithConfig('Analytics', source, { yes: true }, CONFIG, test.dependencies);
+        } catch (error) {
+            caught = error;
+        }
+
+        expect(test.executions).toHaveLength(1);
+        expect(checkpointFiles(root)).toHaveLength(1);
+        const checkpoint = JSON.parse(fs.readFileSync(checkpointFiles(root)[0], 'utf8'));
+        expect(checkpoint).toMatchObject({ lastCompletedBatch: 1, nextStatement: 100 });
+        expectNoSecrets(report(caught, test));
+        expectNoSecrets(checkpoint);
+    });
+
+    it('never replays a failed or unknown batch and emits the exact stable resume command for the checkpoint', async () => {
+        const databaseImportWithConfig = await requireImport();
+        const root = tempRoot();
+        const statements = Array.from({ length: 101 }, (_, index) => `INSERT INTO t VALUES (${index});`);
+        const source = sourceFile(root, statements.join('\n'));
+        const test = importHarness(root, {
+            execute: async ({ sql }) => {
+                if (sql.includes('VALUES (100)')) throw new Error('RAW_TRANSPORT_SECRET');
+            },
+        });
+
+        let caught: unknown;
+        try {
+            await databaseImportWithConfig('Analytics', source, { yes: true }, CONFIG, test.dependencies);
+        } catch (error) {
+            caught = error;
+        }
+
+        expect(test.executions).toHaveLength(2);
+        const checkpoints = checkpointFiles(root);
+        expect(checkpoints).toHaveLength(1);
+        const checkpoint = JSON.parse(fs.readFileSync(checkpoints[0], 'utf8'));
+        const digest = createHash('sha256').update(fs.readFileSync(source)).digest('hex');
+        expect(checkpoint).toMatchObject({
+            version: 1,
+            database: 'Analytics',
+            lastCompletedBatch: 1,
+            nextStatement: 100,
+        });
+        expect(checkpoint.source).toEqual({
+            sha256: digest,
+            sizeBytes: fs.statSync(source).size,
+        });
+        expect(checkpoint.completedSourceBytes).toBe(Buffer.byteLength(statements.slice(0, 100).join('\n')));
+        expect(path.basename(checkpoints[0])).toContain('analytics');
+        expect(path.basename(checkpoints[0])).toContain(digest.slice(0, 12));
+        expect(path.basename(checkpoints[0])).toContain(String(fs.statSync(source).size));
+        expect(fs.statSync(checkpoints[0]).mode & 0o777).toBe(0o600);
+        expect(importFiles(root).filter((file) => file.endsWith('.tmp'))).toEqual([]);
+        expect(report(caught, test)).toContain(
+            `Resume with: solidactions database import Analytics ${source} --resume ${checkpoints[0]} --yes`,
+        );
+        expectNoSecrets(report(caught, test));
+        expectNoSecrets(checkpoint);
+        expect(caught).toMatchObject({ code: 'import_failed' });
+        expect(test.closed).toEqual([1]);
+    });
+
+    it('does not claim resumability when atomic checkpoint publication fails after a committed batch', async () => {
+        const databaseImportWithConfig = await requireImport();
+        const root = tempRoot();
+        const source = sourceFile(root, 'CREATE TABLE t (id);');
+        const filesystem = Object.create(fs.promises) as typeof fs.promises;
+        filesystem.rename = async (from: fs.PathLike, to: fs.PathLike) => {
+            if (String(to).endsWith('.json')) throw new Error('CHECKPOINT_RENAME_SENTINEL');
+            return fs.promises.rename(from, to);
+        };
+        const test = importHarness(root, { filesystem });
+
+        let caught: unknown;
+        try {
+            await databaseImportWithConfig('Analytics', source, { yes: true }, CONFIG, test.dependencies);
+        } catch (error) {
+            caught = error;
+        }
+
+        expect(test.executions).toHaveLength(1);
+        expect(checkpointFiles(root)).toEqual([]);
+        expect(importFiles(root).filter((file) => file.endsWith('.tmp'))).toEqual([]);
+        expect(report(caught, test)).not.toContain('Resume with:');
+        expect(report(caught, test)).toMatch(/import_failed|checkpoint/i);
+    });
+});
+
+describe('database import resume validation', () => {
+    it.each([
+        ['wrong version', { version: 99 }],
+        ['wrong database', { database: 'Other' }],
+        ['wrong size', { source: { sha256: 'replace', sizeBytes: 999 } }],
+        ['out-of-range statement', { nextStatement: 999, completedSourceBytes: 999 }],
+        ['invalid source boundary', { nextStatement: 1, completedSourceBytes: 7 }],
+    ])('rejects %s before native load or mint', async (_label, mutation) => {
+        const databaseImportWithConfig = await requireImport();
+        const root = tempRoot();
+        const source = sourceFile(root, 'CREATE TABLE t (id);\nINSERT INTO t VALUES (1);');
+        const base = checkpointFor(source, 'Analytics');
+        const value = {
+            ...base,
+            ...mutation,
+            source: 'source' in mutation
+                ? { ...base.source, ...(mutation.source as Record<string, unknown>) }
+                : base.source,
+        };
+        const checkpoint = writeCheckpoint(root, value);
+        const test = importHarness(root);
+
+        await expect(databaseImportWithConfig(
+            'Analytics',
+            source,
+            { yes: true, resume: checkpoint },
+            CONFIG,
+            test.dependencies,
+        )).rejects.toMatchObject({ code: 'import_failed' });
+
+        expect(test.events).not.toContain('native:load');
+        expect(test.posts).toEqual([]);
+        expect(test.executions).toEqual([]);
+    });
+
+    it('rejects corrupt JSON and same-size source mutation before native load or mint', async () => {
+        const databaseImportWithConfig = await requireImport();
+        const root = tempRoot();
+        const source = sourceFile(root, 'CREATE TABLE t (id);\nINSERT INTO t VALUES (1);');
+        const corrupt = writeCheckpoint(root, {});
+        fs.writeFileSync(corrupt, '{not-json', { mode: 0o600 });
+        const corruptTest = importHarness(root);
+
+        await expect(databaseImportWithConfig(
+            'Analytics', source, { yes: true, resume: corrupt }, CONFIG, corruptTest.dependencies,
+        )).rejects.toMatchObject({ code: 'import_failed' });
+        expect(corruptTest.events).not.toContain('native:load');
+
+        const valid = writeCheckpoint(root, checkpointFor(source, 'Analytics'), 'changed.json');
+        const originalSize = fs.statSync(source).size;
+        const changed = fs.readFileSync(source, 'utf8').replace('VALUES (1)', 'VALUES (2)');
+        fs.writeFileSync(source, changed);
+        expect(fs.statSync(source).size).toBe(originalSize);
+        const changedTest = importHarness(root);
+
+        await expect(databaseImportWithConfig(
+            'Analytics', source, { yes: true, resume: valid }, CONFIG, changedTest.dependencies,
+        )).rejects.toMatchObject({ code: 'import_failed' });
+        expect(changedTest.events).not.toContain('native:load');
+        expect(changedTest.posts).toEqual([]);
+    });
+
+    it('continues from a valid parser boundary, skips completed groups, and removes the checkpoint on success', async () => {
+        const databaseImportWithConfig = await requireImport();
+        const root = tempRoot();
+        const firstPrefix = "INSERT INTO t VALUES ('first";
+        const firstSuffix = "');";
+        const first = `${firstPrefix}${'x'.repeat(520 * 1024 - firstPrefix.length - firstSuffix.length)}${firstSuffix}`;
+        const second = "INSERT INTO t VALUES ('second');";
+        const source = sourceFile(root, `${first}\n${second}`);
+        const checkpointValue = checkpointFor(source, 'Analytics', {
+            completedSourceBytes: Buffer.byteLength(first),
+        });
+        const checkpoint = writeCheckpoint(root, checkpointValue);
+        const test = importHarness(root);
+
+        await databaseImportWithConfig(
+            'Analytics',
+            source,
+            { yes: true, resume: checkpoint },
+            CONFIG,
+            test.dependencies,
+        );
+
+        expect(test.executions).toEqual([{ client: 1, sql: managedEnvelope([second]) }]);
+        expect(fs.existsSync(checkpoint)).toBe(false);
+        expect(checkpointFiles(root)).toEqual([]);
+        expect(test.stdout.join('\n')).toMatch(/Imported 2 statements/i);
+        expect(test.stdout.join('\n')).toContain(String(fs.statSync(source).size));
+    });
+});
+
+describe('database create --from real importer', () => {
+    it.each([
+        'CREATE TABLE t (id);\n-- DOWNLOAD INCOMPLETE: stream failed\n',
+        'CREATE TABLE t (id)\n',
+        `INSERT INTO t VALUES ('${'x'.repeat(8 * 1024 * 1024)}');`,
+    ])('preflights marker, parse, and size failures before provisioning or native loading', async (sql) => {
+        const databaseCreateWithConfig = await requireCreate();
+        const root = tempRoot();
+        const source = sourceFile(root, sql);
+        const test = importHarness(root);
+
+        await expect(databaseCreateWithConfig(
+            'requested-name', { from: source }, CONFIG, test.dependencies,
+        )).rejects.toMatchObject({ code: 'import_failed' });
+
+        expect(test.posts).toEqual([]);
+        expect(test.events).not.toContain('native:load');
+        expect(test.confirm).not.toHaveBeenCalled();
+    });
+
+    it('provisions after preflight and imports the returned name without a second confirmation', async () => {
+        const databaseCreateWithConfig = await requireCreate();
+        const root = tempRoot();
+        const statement = 'CREATE TABLE t (id);';
+        const source = sourceFile(root, statement);
+        const test = importHarness(root);
+
+        await databaseCreateWithConfig('requested-name', { from: source }, CONFIG, test.dependencies);
+
+        expect(test.posts.map((call) => call.body)).toEqual([
+            { operation: 'create', name: 'requested-name' },
+            { operation: 'access', name: 'Analytics', mode: 'write' },
+        ]);
+        expect(test.executions).toEqual([{ client: 1, sql: managedEnvelope([statement]) }]);
+        expect(test.confirm).not.toHaveBeenCalled();
+    });
+
+    it('leaves a newly created database in place and returns actionable import_failed guidance', async () => {
+        const databaseCreateWithConfig = await requireCreate();
+        const root = tempRoot();
+        const statements = Array.from({ length: 101 }, (_, index) => `INSERT INTO t VALUES (${index});`);
+        const source = sourceFile(root, statements.join('\n'));
+        const test = importHarness(root, {
+            execute: async ({ sql }) => {
+                if (sql.includes('VALUES (100)')) throw new Error('RAW_TRANSPORT_SECRET');
+            },
+        });
+
+        let caught: unknown;
+        try {
+            await databaseCreateWithConfig('requested-name', { from: source }, CONFIG, test.dependencies);
+        } catch (error) {
+            caught = error;
+        }
+
+        expect(test.posts.filter((call) => call.body.operation === 'create')).toHaveLength(1);
+        expect(test.posts.filter((call) => call.body.operation === 'delete')).toEqual([]);
+        expect(checkpointFiles(root)).toHaveLength(1);
+        const rendered = report(caught, test);
+        expect(rendered).toMatch(/import_failed/i);
+        expect(rendered).toMatch(/created|new database/i);
+        expect(rendered).toMatch(/remain|left in place/i);
+        expect(rendered).toContain('--resume');
+        expectNoSecrets(rendered);
+    });
+});

--- a/tests/database-lifecycle-commands.test.ts
+++ b/tests/database-lifecycle-commands.test.ts
@@ -427,6 +427,34 @@ describe('database lifecycle error boundary', () => {
         expect(rendered).not.toContain(CONFIG.apiKey);
         expect(rendered).not.toContain('RAW_AXIOS_TOKEN_ABILITY_SENTINEL');
     });
+
+    it('maps the stable unauthenticated code to actionable login guidance', async () => {
+        const databaseListWithConfig = await requireExport('databaseListWithConfig');
+        const test = harness();
+        const appError: any = new Error(`RAW_UNAUTHENTICATED_SENTINEL ${CONFIG.apiKey}`);
+        appError.response = {
+            status: 401,
+            data: {
+                code: 'unauthenticated',
+                message: 'Unauthenticated.',
+            },
+        };
+        test.dependencies.post = async () => { throw appError; };
+
+        let caught: any;
+        try {
+            await databaseListWithConfig({}, CONFIG, test.dependencies);
+        } catch (error) {
+            caught = error;
+        }
+
+        expect(caught).toMatchObject({ code: 'unauthenticated', status: 401 });
+        expect(caught?.message).toContain('solidactions login');
+        expect(caught?.message).not.toContain('upstream_unavailable');
+        const rendered = `${String(caught)}\n${JSON.stringify(caught)}\n${test.stderr.join('\n')}`;
+        expect(rendered).not.toContain(CONFIG.apiKey);
+        expect(rendered).not.toContain('RAW_UNAUTHENTICATED_SENTINEL');
+    });
 });
 
 function runBuiltCli(args: string[], env: NodeJS.ProcessEnv): Promise<{ code: number | null; stdout: string; stderr: string }> {

--- a/tests/database-lifecycle-commands.test.ts
+++ b/tests/database-lifecycle-commands.test.ts
@@ -113,6 +113,8 @@ function expectControlPost(call: PostCall, body: Record<string, unknown>): void 
                 'Content-Type': 'application/json',
                 'X-Workspace-Id': 'workspace-1146',
             },
+            signal: expect.any(AbortSignal),
+            timeout: 30_000,
         },
     });
 }

--- a/tests/database-lifecycle-commands.test.ts
+++ b/tests/database-lifecycle-commands.test.ts
@@ -1,0 +1,439 @@
+import * as http from 'http';
+import path from 'path';
+import { spawn } from 'child_process';
+import { AddressInfo } from 'net';
+import { pathToFileURL } from 'url';
+import { describe, expect, it, vi } from 'vitest';
+
+interface DatabaseRecord {
+    name: string;
+    status: string;
+    deleted_at: string | null;
+    purge_at: string | null;
+    size_bytes: number;
+}
+
+interface Config {
+    host: string;
+    apiKey: string;
+    workspaceId: string;
+}
+
+interface PostCall {
+    url: string;
+    body: Record<string, unknown>;
+    options: { headers: Record<string, string> };
+}
+
+interface CommandDependencies {
+    post: (
+        url: string,
+        body: Record<string, unknown>,
+        options: { headers: Record<string, string> },
+    ) => Promise<{ data: unknown }>;
+    stdout: (line: string) => void;
+    stderr: (line: string) => void;
+    confirm: (message: string) => Promise<boolean | undefined>;
+    isTTY: boolean;
+    importDatabase: (name: string, file: string) => Promise<void>;
+}
+
+const CONFIG: Config = {
+    host: 'https://app.example.test',
+    apiKey: 'control-plane-pat',
+    workspaceId: 'workspace-1146',
+};
+
+const ACTIVE: DatabaseRecord = {
+    name: 'Analytics',
+    status: 'ready',
+    deleted_at: null,
+    purge_at: null,
+    size_bytes: 1234,
+};
+
+const DELETED: DatabaseRecord = {
+    name: 'Retired',
+    status: 'ready',
+    deleted_at: '2026-08-07T12:00:00.000000Z',
+    purge_at: '2026-09-06T12:00:00.000000Z',
+    size_bytes: 5678,
+};
+
+const LIST_RESPONSE = {
+    databases: [ACTIVE, DELETED],
+    quota: { used: 1, limit: 5 },
+};
+
+async function loadDatabaseCommands(): Promise<Record<string, unknown>> {
+    const moduleUrl = pathToFileURL(path.resolve(__dirname, '../src/commands/database.ts')).href;
+
+    try {
+        return await import(moduleUrl) as Record<string, unknown>;
+    } catch {
+        return {};
+    }
+}
+
+async function requireExport(name: string): Promise<Function> {
+    const module = await loadDatabaseCommands();
+    expect(module[name], `${name} export`).toBeTypeOf('function');
+    return module[name] as Function;
+}
+
+function harness(responseData: unknown = { database: ACTIVE }) {
+    const calls: PostCall[] = [];
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const confirm = vi.fn(async () => true as boolean | undefined);
+    const importDatabase = vi.fn(async () => undefined);
+    const dependencies: CommandDependencies = {
+        post: async (url, body, options) => {
+            calls.push({ url, body, options });
+            return { data: responseData };
+        },
+        stdout: (line) => stdout.push(line),
+        stderr: (line) => stderr.push(line),
+        confirm,
+        isTTY: true,
+        importDatabase,
+    };
+
+    return { calls, stdout, stderr, confirm, importDatabase, dependencies };
+}
+
+function expectControlPost(call: PostCall, body: Record<string, unknown>): void {
+    expect(call).toEqual({
+        url: 'https://app.example.test/api/v1/databases',
+        body,
+        options: {
+            headers: {
+                Accept: 'application/json',
+                Authorization: 'Bearer control-plane-pat',
+                'Content-Type': 'application/json',
+                'X-Workspace-Id': 'workspace-1146',
+            },
+        },
+    });
+}
+
+describe('database lifecycle control-plane contract', () => {
+    it('lists active and deleted rows with stable fields and quota in the shared table style', async () => {
+        const databaseListWithConfig = await requireExport('databaseListWithConfig');
+        const test = harness(LIST_RESPONSE);
+
+        await databaseListWithConfig({}, CONFIG, test.dependencies);
+
+        expect(test.calls).toHaveLength(1);
+        expectControlPost(test.calls[0], { operation: 'list' });
+        const output = test.stdout.join('\n');
+        expect(output).toMatch(/NAME/i);
+        expect(output).toMatch(/STATUS/i);
+        expect(output).toMatch(/SIZE/i);
+        expect(output).toMatch(/DELETED/i);
+        expect(output).toMatch(/PURGE/i);
+        expect(output).toContain('Analytics');
+        expect(output).toContain('Retired');
+        expect(output).toContain('1234');
+        expect(output).toContain(ACTIVE.status);
+        expect(output).toContain(DELETED.deleted_at);
+        expect(output).toContain(DELETED.purge_at);
+        expect(output).toMatch(/quota.*1.*5/i);
+        expect(test.stderr).toEqual([]);
+    });
+
+    it('writes the complete list response as JSON with no decoration', async () => {
+        const databaseListWithConfig = await requireExport('databaseListWithConfig');
+        const test = harness(LIST_RESPONSE);
+
+        await databaseListWithConfig({ json: true }, CONFIG, test.dependencies);
+
+        expect(JSON.parse(test.stdout.join('\n'))).toEqual(LIST_RESPONSE);
+        expect(test.stderr).toEqual([]);
+        expect(test.stdout.join('\n')).not.toMatch(/Databases:|Quota:|\u001b\[/);
+    });
+
+    it('creates with the exact operation and renders the stable response payload as JSON', async () => {
+        const databaseCreateWithConfig = await requireExport('databaseCreateWithConfig');
+        const payload = { database: ACTIVE };
+        const test = harness(payload);
+
+        await databaseCreateWithConfig('Analytics', { json: true }, CONFIG, test.dependencies);
+
+        expect(test.calls).toHaveLength(1);
+        expectControlPost(test.calls[0], { operation: 'create', name: 'Analytics' });
+        expect(JSON.parse(test.stdout.join('\n'))).toEqual(payload);
+        expect(test.stderr).toEqual([]);
+    });
+
+    it('undeletes with the exact operation and renders the stable response payload as JSON', async () => {
+        const databaseUndeleteWithConfig = await requireExport('databaseUndeleteWithConfig');
+        const payload = { database: ACTIVE };
+        const test = harness(payload);
+
+        await databaseUndeleteWithConfig('Analytics', { json: true }, CONFIG, test.dependencies);
+
+        expect(test.calls).toHaveLength(1);
+        expectControlPost(test.calls[0], { operation: 'undelete', name: 'Analytics' });
+        expect(JSON.parse(test.stdout.join('\n'))).toEqual(payload);
+        expect(test.stderr).toEqual([]);
+    });
+
+    it('deletes with --yes without prompting and preserves the stable JSON payload', async () => {
+        const databaseDeleteWithConfig = await requireExport('databaseDeleteWithConfig');
+        const payload = { database: DELETED };
+        const test = harness(payload);
+
+        await databaseDeleteWithConfig('Retired', { yes: true, json: true }, CONFIG, test.dependencies);
+
+        expect(test.confirm).not.toHaveBeenCalled();
+        expect(test.calls).toHaveLength(1);
+        expectControlPost(test.calls[0], { operation: 'delete', name: 'Retired' });
+        expect(JSON.parse(test.stdout.join('\n'))).toEqual(payload);
+        expect(test.stderr).toEqual([]);
+    });
+});
+
+describe('database delete confirmation safety', () => {
+    it('prompts interactively before posting when --yes is absent', async () => {
+        const databaseDeleteWithConfig = await requireExport('databaseDeleteWithConfig');
+        const test = harness({ database: DELETED });
+
+        await databaseDeleteWithConfig('Retired', {}, CONFIG, test.dependencies);
+
+        expect(test.confirm).toHaveBeenCalledOnce();
+        expect(test.confirm.mock.calls[0][0]).toContain('Retired');
+        expect(test.calls).toHaveLength(1);
+        expectControlPost(test.calls[0], { operation: 'delete', name: 'Retired' });
+    });
+
+    it.each([
+        ['decline', false],
+        ['EOF', undefined],
+    ])('treats interactive %s as cancellation and performs no POST', async (_label, answer) => {
+        const databaseDeleteWithConfig = await requireExport('databaseDeleteWithConfig');
+        const test = harness({ database: DELETED });
+        test.dependencies.confirm = vi.fn(async () => answer);
+
+        await databaseDeleteWithConfig('Retired', {}, CONFIG, test.dependencies);
+
+        expect(test.calls).toEqual([]);
+        expect(test.stdout.join('\n')).toMatch(/cancelled/i);
+    });
+
+    it('refuses non-interactive deletion without --yes and performs no POST', async () => {
+        const databaseDeleteWithConfig = await requireExport('databaseDeleteWithConfig');
+        const test = harness({ database: DELETED });
+        test.dependencies.isTTY = false;
+
+        await expect(databaseDeleteWithConfig('Retired', {}, CONFIG, test.dependencies))
+            .rejects.toThrow(/--yes/i);
+
+        expect(test.confirm).not.toHaveBeenCalled();
+        expect(test.calls).toEqual([]);
+    });
+
+    it('never prompts in JSON mode and requires --yes before deletion', async () => {
+        const databaseDeleteWithConfig = await requireExport('databaseDeleteWithConfig');
+        const test = harness({ database: DELETED });
+
+        await expect(databaseDeleteWithConfig('Retired', { json: true }, CONFIG, test.dependencies))
+            .rejects.toThrow(/--yes/i);
+
+        expect(test.confirm).not.toHaveBeenCalled();
+        expect(test.calls).toEqual([]);
+        expect(test.stdout).toEqual([]);
+    });
+});
+
+describe('database create --from importer handoff', () => {
+    it('provisions first, then hands the created logical name and file to the future importer', async () => {
+        const databaseCreateWithConfig = await requireExport('databaseCreateWithConfig');
+        const events: string[] = [];
+        const test = harness({ database: ACTIVE });
+        test.dependencies.post = async (url, body, options) => {
+            events.push('provision');
+            test.calls.push({ url, body, options });
+            return { data: { database: ACTIVE } };
+        };
+        test.dependencies.importDatabase = vi.fn(async (name, file) => {
+            events.push(`import:${name}:${file}`);
+        });
+
+        await databaseCreateWithConfig(
+            'requested-name',
+            { from: 'fixtures/seed.sql' },
+            CONFIG,
+            test.dependencies,
+        );
+
+        expect(events).toEqual(['provision', 'import:Analytics:fixtures/seed.sql']);
+        expectControlPost(test.calls[0], { operation: 'create', name: 'requested-name' });
+    });
+
+    it('reports that the created database remains in place when the later import fails', async () => {
+        const databaseCreateWithConfig = await requireExport('databaseCreateWithConfig');
+        const test = harness({ database: ACTIVE });
+        const importHandoff = vi.fn(async () => {
+            throw new Error('IMPORT_HANDOFF_FAILURE_SENTINEL');
+        });
+        test.dependencies.importDatabase = importHandoff;
+
+        let caught: any;
+        try {
+            await databaseCreateWithConfig(
+                'requested-name',
+                { from: 'fixtures/seed.sql' },
+                CONFIG,
+                test.dependencies,
+            );
+        } catch (error) {
+            caught = error;
+        }
+
+        expect(test.calls).toHaveLength(1);
+        expect(importHandoff).toHaveBeenCalledOnce();
+        expect(importHandoff).toHaveBeenCalledWith('Analytics', 'fixtures/seed.sql');
+        const report = `${caught?.message ?? ''}\n${test.stderr.join('\n')}`;
+        expect(report).toMatch(/Analytics/);
+        expect(report).toMatch(/import.*fail/i);
+        expect(report).toMatch(/remain|left.*place/i);
+    });
+});
+
+describe('database lifecycle error boundary', () => {
+    it('retains stable app product errors without exposing Axios transport objects', async () => {
+        const databaseCreateWithConfig = await requireExport('databaseCreateWithConfig');
+        const test = harness();
+        const appError: any = new Error('Axios raw request dump');
+        appError.config = { headers: { Authorization: `Bearer ${CONFIG.apiKey}` } };
+        appError.request = { metadata: 'AXIOS_REQUEST_SENTINEL' };
+        appError.response = {
+            status: 409,
+            data: {
+                code: 'database_name_taken',
+                message: 'A database with this name already exists in this workspace.',
+            },
+            config: appError.config,
+            request: appError.request,
+        };
+        test.dependencies.post = async () => { throw appError; };
+
+        let caught: any;
+        try {
+            await databaseCreateWithConfig('Analytics', {}, CONFIG, test.dependencies);
+        } catch (error) {
+            caught = error;
+        }
+
+        expect(caught).toMatchObject({
+            code: 'database_name_taken',
+            message: 'A database with this name already exists in this workspace.',
+            status: 409,
+        });
+        expect(caught).not.toHaveProperty('config');
+        expect(caught).not.toHaveProperty('request');
+        expect(caught).not.toHaveProperty('response');
+        const rendered = `${String(caught)}\n${JSON.stringify(caught)}\n${test.stderr.join('\n')}`;
+        expect(rendered).not.toContain(CONFIG.apiKey);
+        expect(rendered).not.toContain('AXIOS_REQUEST_SENTINEL');
+        expect(rendered).not.toContain('Axios raw request dump');
+    });
+
+    it('adds actionable device re-login guidance without dumping the raw Axios error', async () => {
+        const databaseListWithConfig = await requireExport('databaseListWithConfig');
+        const test = harness();
+        const appError: any = new Error('RAW_AXIOS_TOKEN_ABILITY_SENTINEL');
+        appError.config = { headers: { Authorization: `Bearer ${CONFIG.apiKey}` } };
+        appError.response = {
+            status: 403,
+            data: {
+                code: 'token_missing_ability',
+                message: "This API key does not have the 'databases:read' ability.",
+                required_ability: 'databases:read',
+            },
+        };
+        test.dependencies.post = async () => { throw appError; };
+
+        let caught: any;
+        try {
+            await databaseListWithConfig({}, CONFIG, test.dependencies);
+        } catch (error) {
+            caught = error;
+        }
+
+        expect(caught).toMatchObject({ code: 'token_missing_ability', status: 403 });
+        expect(caught?.message).toContain("does not have the 'databases:read' ability");
+        expect(caught?.message).toContain('solidactions login --device');
+        const rendered = `${String(caught)}\n${JSON.stringify(caught)}\n${test.stderr.join('\n')}`;
+        expect(rendered).not.toContain(CONFIG.apiKey);
+        expect(rendered).not.toContain('RAW_AXIOS_TOKEN_ABILITY_SENTINEL');
+    });
+});
+
+function runBuiltCli(args: string[], env: NodeJS.ProcessEnv): Promise<{ code: number | null; stdout: string; stderr: string }> {
+    const cli = path.resolve(__dirname, '../dist/index.js');
+
+    return new Promise((resolve, reject) => {
+        const child = spawn(process.execPath, [cli, ...args], {
+            cwd: path.resolve(__dirname, '..'),
+            env: { ...process.env, ...env, NO_COLOR: '1' },
+            stdio: ['ignore', 'pipe', 'pipe'],
+        });
+        const stdout: Buffer[] = [];
+        const stderr: Buffer[] = [];
+        child.stdout.on('data', (chunk: Buffer) => stdout.push(chunk));
+        child.stderr.on('data', (chunk: Buffer) => stderr.push(chunk));
+        child.on('error', reject);
+        child.on('close', (code) => resolve({
+            code,
+            stdout: Buffer.concat(stdout).toString('utf8'),
+            stderr: Buffer.concat(stderr).toString('utf8'),
+        }));
+    });
+}
+
+describe('database lifecycle real CLI registration', () => {
+    it('dispatches database list through the built command action', async () => {
+        const requests: Array<{ method: string; url: string; body: string; headers: http.IncomingHttpHeaders }> = [];
+        const server = http.createServer((request, response) => {
+            const chunks: Buffer[] = [];
+            request.on('data', (chunk: Buffer) => chunks.push(chunk));
+            request.on('end', () => {
+                requests.push({
+                    method: request.method ?? '',
+                    url: request.url ?? '',
+                    body: Buffer.concat(chunks).toString('utf8'),
+                    headers: request.headers,
+                });
+                response.writeHead(200, { 'Content-Type': 'application/json' });
+                response.end(JSON.stringify(LIST_RESPONSE));
+            });
+        });
+        await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+        const port = (server.address() as AddressInfo).port;
+
+        let result: Awaited<ReturnType<typeof runBuiltCli>>;
+        try {
+            result = await runBuiltCli(['database', 'list', '--json'], {
+                SOLIDACTIONS_HOST: `http://127.0.0.1:${port}`,
+                SOLIDACTIONS_API_KEY: 'built-process-pat',
+                SOLIDACTIONS_WORKSPACE_ID: 'built-workspace',
+            });
+        } finally {
+            await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+        }
+
+        expect(result.code).toBe(0);
+        expect(result.stderr).toBe('');
+        expect(JSON.parse(result.stdout)).toEqual(LIST_RESPONSE);
+        expect(requests).toHaveLength(1);
+        expect(requests[0]).toMatchObject({
+            method: 'POST',
+            url: '/api/v1/databases',
+            body: JSON.stringify({ operation: 'list' }),
+        });
+        expect(requests[0].headers.authorization).toBe('Bearer built-process-pat');
+        expect(requests[0].headers['x-workspace-id']).toBe('built-workspace');
+    });
+});

--- a/tests/database-lifecycle-commands.test.ts
+++ b/tests/database-lifecycle-commands.test.ts
@@ -192,6 +192,63 @@ describe('database lifecycle control-plane contract', () => {
         expect(JSON.parse(test.stdout.join('\n'))).toEqual(payload);
         expect(test.stderr).toEqual([]);
     });
+
+    it.each([
+        {
+            label: 'create',
+            exportName: 'databaseCreateWithConfig',
+            name: 'Analytics',
+            options: {},
+            response: { database: ACTIVE },
+            operation: 'create',
+            success: /creat/i,
+            requiredValues: ['Analytics', 'ready'],
+        },
+        {
+            label: 'delete',
+            exportName: 'databaseDeleteWithConfig',
+            name: 'Retired',
+            options: { yes: true },
+            response: { database: DELETED },
+            operation: 'delete',
+            success: /delet/i,
+            requiredValues: ['Retired', 'ready', DELETED.deleted_at, DELETED.purge_at],
+        },
+        {
+            label: 'undelete',
+            exportName: 'databaseUndeleteWithConfig',
+            name: 'Analytics',
+            options: {},
+            response: { database: ACTIVE },
+            operation: 'undelete',
+            success: /restor|undelet/i,
+            requiredValues: ['Analytics', 'ready'],
+        },
+    ])('renders safe, operation-appropriate human output for $label', async (scenario) => {
+        const handler = await requireExport(scenario.exportName);
+        const response = {
+            ...scenario.response,
+            transport_debug: 'RAW_AXIOS_TRANSPORT_SENTINEL',
+            token: 'SUCCESS_RESPONSE_CREDENTIAL_SENTINEL',
+        };
+        const test = harness(response);
+
+        await handler(scenario.name, scenario.options, CONFIG, test.dependencies);
+
+        expect(test.calls).toHaveLength(1);
+        expectControlPost(test.calls[0], { operation: scenario.operation, name: scenario.name });
+        const output = test.stdout.join('\n');
+        expect(output).toMatch(scenario.success);
+        for (const value of scenario.requiredValues) {
+            expect(output).toContain(value);
+        }
+        expect(() => JSON.parse(output)).toThrow();
+        expect(output).not.toMatch(/\u001b\[/);
+        expect(output).not.toContain(CONFIG.apiKey);
+        expect(output).not.toContain('RAW_AXIOS_TRANSPORT_SENTINEL');
+        expect(output).not.toContain('SUCCESS_RESPONSE_CREDENTIAL_SENTINEL');
+        expect(test.stderr).toEqual([]);
+    });
 });
 
 describe('database delete confirmation safety', () => {
@@ -219,6 +276,7 @@ describe('database delete confirmation safety', () => {
 
         expect(test.calls).toEqual([]);
         expect(test.stdout.join('\n')).toMatch(/cancelled/i);
+        expect(test.stderr).toEqual([]);
     });
 
     it('refuses non-interactive deletion without --yes and performs no POST', async () => {

--- a/tests/database-native-ci-contract.test.ts
+++ b/tests/database-native-ci-contract.test.ts
@@ -1,0 +1,45 @@
+import fs from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+import { describe, expect, it } from 'vitest';
+
+const WORKFLOW_PATH = path.resolve(__dirname, '../.github/workflows/check.yml');
+
+interface WorkflowStep {
+    uses?: string;
+    run?: string;
+    with?: Record<string, unknown>;
+}
+
+interface WorkflowJob {
+    'runs-on': string;
+    strategy?: { matrix?: { os?: unknown[]; node?: unknown[] } };
+    steps?: WorkflowStep[];
+}
+
+describe('native database client CI contract', () => {
+    it('runs the embedded probe on Node 20 and 24 across Linux, macOS, and Windows', () => {
+        const workflow = yaml.load(fs.readFileSync(WORKFLOW_PATH, 'utf8')) as {
+            jobs?: Record<string, WorkflowJob>;
+        };
+        const job = workflow.jobs?.['native-database-client'];
+
+        expect(job).toBeDefined();
+        if (!job) return;
+
+        expect(job['runs-on']).toBe('${{ matrix.os }}');
+        expect(job.strategy?.matrix?.os).toEqual([
+            'ubuntu-latest',
+            'macos-latest',
+            'windows-latest',
+        ]);
+        expect(job.strategy?.matrix?.node?.map(String)).toEqual(['20', '24']);
+
+        const setupNode = job.steps?.find((step) => step.uses?.startsWith('actions/setup-node@'));
+        expect(setupNode?.with?.['node-version']).toBe('${{ matrix.node }}');
+
+        const commands = (job.steps ?? []).map((step) => step.run ?? '').join('\n');
+        expect(commands).toContain('npm ci');
+        expect(commands).toContain('node scripts/probe-native-database-client.mjs');
+    });
+});

--- a/tests/database-native-ci-contract.test.ts
+++ b/tests/database-native-ci-contract.test.ts
@@ -14,8 +14,11 @@ interface WorkflowStep {
 interface WorkflowJob {
     'runs-on': string;
     strategy?: { matrix?: { os?: unknown[]; node?: unknown[] } };
+    services?: Record<string, { image?: string }>;
     steps?: WorkflowStep[];
 }
+
+const REMOTE_SYNC_IMAGE = 'ghcr.io/tursodatabase/libsql-server:3ec6803@sha256:1bc51611928ccc51229bdc40ca0defcb915907f8f9f6a664b43529de0ca45fab';
 
 describe('native database client CI contract', () => {
     it('runs the embedded probe on Node 20 and 24 across Linux, macOS, and Windows', () => {
@@ -34,6 +37,9 @@ describe('native database client CI contract', () => {
             'windows-latest',
         ]);
         expect(job.strategy?.matrix?.node?.map(String)).toEqual(['20', '24']);
+        expect(
+            (job.strategy?.matrix?.os?.length ?? 0) * (job.strategy?.matrix?.node?.length ?? 0),
+        ).toBe(6);
 
         const setupNode = job.steps?.find((step) => step.uses?.startsWith('actions/setup-node@'));
         expect(setupNode?.with?.['node-version']).toBe('${{ matrix.node }}');
@@ -41,5 +47,28 @@ describe('native database client CI contract', () => {
         const commands = (job.steps ?? []).map((step) => step.run ?? '').join('\n');
         expect(commands).toContain('npm ci');
         expect(commands).toContain('node scripts/probe-native-database-client.mjs');
+    });
+
+    it('keeps the remote sync probe in a separate pinned Linux service job', () => {
+        const workflow = yaml.load(fs.readFileSync(WORKFLOW_PATH, 'utf8')) as {
+            jobs?: Record<string, WorkflowJob>;
+        };
+        const nativeJob = workflow.jobs?.['native-database-client'];
+        const remoteSyncJob = workflow.jobs?.['database-client-remote-sync'];
+
+        expect(nativeJob).toBeDefined();
+        expect(remoteSyncJob).toBeDefined();
+        expect(remoteSyncJob).not.toBe(nativeJob);
+        if (!remoteSyncJob) return;
+
+        expect(remoteSyncJob['runs-on']).toBe('ubuntu-latest');
+        expect(remoteSyncJob.strategy?.matrix).toBeUndefined();
+        expect(
+            Object.values(remoteSyncJob.services ?? {}).map((service) => service.image),
+        ).toContain(REMOTE_SYNC_IMAGE);
+
+        const commands = (remoteSyncJob.steps ?? []).map((step) => step.run ?? '').join('\n');
+        expect(commands).toContain('npm ci');
+        expect(commands).toContain('node scripts/probe-database-client-sync.mjs');
     });
 });

--- a/tests/database-native-probe-cleanup.test.ts
+++ b/tests/database-native-probe-cleanup.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { removeNativeProbeDirectory } from '../scripts/remove-native-probe-directory.mjs';
+
+describe('native database probe cleanup', () => {
+    it('asks Node fs.rm for bounded retries of transient Windows cleanup errors', async () => {
+        const remove = vi.fn().mockResolvedValue(undefined);
+
+        await removeNativeProbeDirectory('C:\\Temp\\solidactions-database-probe', remove);
+
+        expect(remove).toHaveBeenCalledOnce();
+        expect(remove).toHaveBeenCalledWith('C:\\Temp\\solidactions-database-probe', {
+            recursive: true,
+            force: true,
+            maxRetries: 5,
+            retryDelay: 100,
+        });
+    });
+
+    it('surfaces the cleanup failure when Node exhausts its retries', async () => {
+        const exhausted = Object.assign(new Error('resource busy'), { code: 'EBUSY' });
+        const remove = vi.fn().mockRejectedValue(exhausted);
+
+        await expect(removeNativeProbeDirectory('C:\\Temp\\probe.db', remove)).rejects.toBe(exhausted);
+    });
+});

--- a/tests/database-native-probe-cleanup.test.ts
+++ b/tests/database-native-probe-cleanup.test.ts
@@ -1,26 +1,38 @@
-import { describe, expect, it, vi } from 'vitest';
+import { access, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
 
 import { removeNativeProbeDirectory } from '../scripts/remove-native-probe-directory.mjs';
 
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
 describe('native database probe cleanup', () => {
-    it('asks Node fs.rm for bounded retries of transient Windows cleanup errors', async () => {
-        const remove = vi.fn().mockResolvedValue(undefined);
+    it('removes a real probe directory and its database file', async () => {
+        const probeDirectory = await mkdtemp(path.join(tmpdir(), 'solidactions-cleanup-test-'));
+        await writeFile(path.join(probeDirectory, 'probe.db'), 'probe');
 
-        await removeNativeProbeDirectory('C:\\Temp\\solidactions-database-probe', remove);
+        await removeNativeProbeDirectory(probeDirectory);
 
-        expect(remove).toHaveBeenCalledOnce();
-        expect(remove).toHaveBeenCalledWith('C:\\Temp\\solidactions-database-probe', {
-            recursive: true,
-            force: true,
-            maxRetries: 5,
-            retryDelay: 100,
-        });
+        await expect(access(probeDirectory)).rejects.toMatchObject({ code: 'ENOENT' });
     });
 
-    it('surfaces the cleanup failure when Node exhausts its retries', async () => {
-        const exhausted = Object.assign(new Error('resource busy'), { code: 'EBUSY' });
-        const remove = vi.fn().mockRejectedValue(exhausted);
+    it('keeps bounded Windows retries wired into the native probe', async () => {
+        const helperSource = await readFile(
+            path.join(repositoryRoot, 'scripts/remove-native-probe-directory.mjs'),
+            'utf8',
+        );
+        const probeSource = await readFile(
+            path.join(repositoryRoot, 'scripts/probe-native-database-client.mjs'),
+            'utf8',
+        );
 
-        await expect(removeNativeProbeDirectory('C:\\Temp\\probe.db', remove)).rejects.toBe(exhausted);
+        expect(helperSource).toContain('recursive: true');
+        expect(helperSource).toContain('force: true');
+        expect(helperSource).toContain('maxRetries: 5');
+        expect(helperSource).toContain('retryDelay: 100');
+        expect(probeSource).toContain("from './remove-native-probe-directory.mjs'");
+        expect(probeSource).toContain('await removeNativeProbeDirectory(probeDirectory)');
     });
 });

--- a/tests/database-pull-command.test.ts
+++ b/tests/database-pull-command.test.ts
@@ -48,10 +48,19 @@ function pullHarness(
     sync: (attempt: number, config: Record<string, unknown>) => Promise<void> = async (_attempt, config) => {
         fs.writeFileSync(fileURLToPath(String(config.url)), 'READ ONLY REPLICA');
     },
+    finalize: (
+        statement: unknown,
+        config: Record<string, unknown>,
+    ) => Promise<unknown> = async () => ({
+        columns: ['busy', 'log', 'checkpointed'],
+        rows: [['0', '0', '0']],
+    }),
 ) {
     const events: string[] = [];
     const posts: Array<{ url: string; body: Record<string, unknown>; options: Record<string, unknown> }> = [];
     const clientConfigs: Array<Record<string, unknown>> = [];
+    const finalizerConfigs: Array<Record<string, unknown>> = [];
+    const finalizerStatements: unknown[] = [];
     const stdout: string[] = [];
     const stderr: string[] = [];
     const confirm = vi.fn(async () => true as boolean | undefined);
@@ -64,6 +73,21 @@ function pullHarness(
             events.push('load');
             return {
                 createClient: (config: Record<string, unknown>) => {
+                    if (!Object.prototype.hasOwnProperty.call(config, 'syncUrl')) {
+                        finalizerConfigs.push(config);
+                        events.push('finalize:create');
+                        return {
+                            execute: async (statement: unknown) => {
+                                events.push('finalize:execute');
+                                finalizerStatements.push(statement);
+                                return finalize(statement, config);
+                            },
+                            close: async () => {
+                                events.push('finalize:close');
+                            },
+                        };
+                    }
+
                     const current = ++attempt;
                     clientConfigs.push(config);
                     events.push(`create:${current}`);
@@ -98,7 +122,17 @@ function pullHarness(
         isTTY: true,
     };
 
-    return { events, posts, clientConfigs, stdout, stderr, confirm, dependencies };
+    return {
+        events,
+        posts,
+        clientConfigs,
+        finalizerConfigs,
+        finalizerStatements,
+        stdout,
+        stderr,
+        confirm,
+        dependencies,
+    };
 }
 
 function expectOnlyReadAccess(posts: ReturnType<typeof pullHarness>['posts'], name = 'Analytics'): void {
@@ -119,6 +153,17 @@ function expectOnlyReadAccess(posts: ReturnType<typeof pullHarness>['posts'], na
     }
     expect(JSON.stringify(posts)).not.toContain('READ ONLY REPLICA');
     expect(JSON.stringify(posts)).not.toContain('SELECT');
+}
+
+function replicaCompanions(temp: string): string[] {
+    return [`${temp}-wal`, `${temp}-shm`, `${temp}-client_wal_index`];
+}
+
+function writeReplicaWithCompanions(temp: string, contents = 'MAIN FILE BEFORE CHECKPOINT'): void {
+    fs.writeFileSync(temp, contents);
+    for (const companion of replicaCompanions(temp)) {
+        fs.writeFileSync(companion, `OWNED ${path.basename(companion)}`);
+    }
 }
 
 describe('database pull read-only replica contract', () => {
@@ -370,6 +415,16 @@ describe('database pull read-only replica contract', () => {
 
             return {
                 createClient: (config: Record<string, unknown>) => {
+                    if (!Object.prototype.hasOwnProperty.call(config, 'syncUrl')) {
+                        return {
+                            execute: async () => ({
+                                columns: ['busy', 'log', 'checkpointed'],
+                                rows: [['0', '0', '0']],
+                            }),
+                            close: async () => undefined,
+                        };
+                    }
+
                     creates += 1;
                     expect(fileURLToPath(String(config.url))).toBe(temp);
                     if (creates === 1) {
@@ -402,6 +457,148 @@ describe('database pull read-only replica contract', () => {
         expectOnlyReadAccess(test.posts);
         expect(fs.readFileSync(target, 'utf8')).toBe('COMPLETE REPLICA');
         expect(fs.statSync(target).mode & 0o777).toBe(0o444);
+    });
+
+    it('checkpoints owned sync companions through one credential-free local client before publishing', async () => {
+        const databasePullWithConfig = await requirePull();
+        const root = tempRoot();
+        const target = path.join(root, 'analytics.db');
+        const temp = path.join(root, '.analytics.db.solidactions-task7.tmp');
+        const unrelated = `${temp}-foreign`;
+        const test = pullHarness(
+            root,
+            async () => {
+                writeReplicaWithCompanions(temp);
+                fs.writeFileSync(unrelated, 'NOT A KNOWN COMPANION');
+            },
+            async (statement, config) => {
+                expect(statement).toBe('PRAGMA wal_checkpoint(TRUNCATE)');
+                expect(config).toEqual({ url: pathToFileURL(temp).href, intMode: 'string' });
+                fs.writeFileSync(temp, 'STANDALONE SYNCED ROW');
+                return {
+                    columns: ['busy', 'log', 'checkpointed'],
+                    rows: [['0', '4', '4']],
+                };
+            },
+        );
+        const realPromises = fs.promises;
+        test.dependencies.filesystem = {
+            ...realPromises,
+            unlink: async (file: fs.PathLike) => {
+                if (replicaCompanions(temp).includes(String(file))) test.events.push('companion:unlink');
+                return realPromises.unlink(file);
+            },
+            chmod: async (file: fs.PathLike, mode: fs.Mode) => {
+                test.events.push('chmod');
+                return realPromises.chmod(file, mode);
+            },
+            rename: async (from: fs.PathLike, to: fs.PathLike) => {
+                test.events.push('rename');
+                return realPromises.rename(from, to);
+            },
+        } as any;
+
+        await databasePullWithConfig('Analytics', target, {}, CONFIG, test.dependencies);
+
+        expect(test.posts).toHaveLength(1);
+        expectOnlyReadAccess(test.posts);
+        expect(test.clientConfigs).toHaveLength(1);
+        expect(test.finalizerConfigs).toEqual([{ url: pathToFileURL(temp).href, intMode: 'string' }]);
+        expect(test.finalizerStatements).toEqual(['PRAGMA wal_checkpoint(TRUNCATE)']);
+        expect(test.events.indexOf('close:1')).toBeLessThan(test.events.indexOf('finalize:create'));
+        expect(test.events.indexOf('finalize:create')).toBeLessThan(test.events.indexOf('finalize:execute'));
+        expect(test.events.indexOf('finalize:execute')).toBeLessThan(test.events.indexOf('finalize:close'));
+        expect(test.events.indexOf('finalize:close')).toBeLessThan(test.events.indexOf('companion:unlink'));
+        expect(test.events.lastIndexOf('companion:unlink')).toBeLessThan(test.events.indexOf('chmod'));
+        expect(test.events.indexOf('chmod')).toBeLessThan(test.events.indexOf('rename'));
+        expect(fs.readFileSync(target, 'utf8')).toBe('STANDALONE SYNCED ROW');
+        expect(fs.statSync(target).mode & 0o777).toBe(0o444);
+        for (const companion of replicaCompanions(temp)) expect(fs.existsSync(companion)).toBe(false);
+        expect(fs.readFileSync(unrelated, 'utf8')).toBe('NOT A KNOWN COMPANION');
+    });
+
+    it.each(['busy', 'error'] as const)(
+        'checkpoint %s preserves the old target and cleans only owned artifacts',
+        async (outcome) => {
+            const databasePullWithConfig = await requirePull();
+            const root = tempRoot();
+            const target = path.join(root, 'existing.db');
+            const temp = path.join(root, '.existing.db.solidactions-task7.tmp');
+            const unrelated = path.join(root, '.unrelated.solidactions-other.tmp');
+            fs.writeFileSync(target, 'OLD REPLICA');
+            fs.writeFileSync(unrelated, 'NOT OUR FILE');
+            const test = pullHarness(
+                root,
+                async () => writeReplicaWithCompanions(temp),
+                async () => {
+                    if (outcome === 'error') {
+                        throw new Error('RAW_CHECKPOINT_TOKEN_HOST_SENTINEL');
+                    }
+                    return {
+                        columns: ['busy', 'log', 'checkpointed'],
+                        rows: [['1', '4', '0']],
+                    };
+                },
+            );
+
+            let caught: any;
+            try {
+                await databasePullWithConfig('Analytics', target, { yes: true }, CONFIG, test.dependencies);
+            } catch (error) {
+                caught = error;
+            }
+
+            expect(caught).toMatchObject({ code: 'upstream_unavailable' });
+            const publicError = `${caught?.message ?? ''} ${caught?.stack ?? ''} ${JSON.stringify(caught)}`;
+            expect(publicError).toMatch(/failed|finaliz/i);
+            expect(publicError).not.toContain('RAW_CHECKPOINT_TOKEN_HOST_SENTINEL');
+            expect(publicError).not.toContain(CONFIG.apiKey);
+            expect(publicError).not.toContain('physical-hostname.sentinel.invalid');
+            expect(test.posts).toHaveLength(1);
+            expectOnlyReadAccess(test.posts);
+            expect(test.finalizerConfigs).toHaveLength(1);
+            expect(test.finalizerStatements).toEqual(['PRAGMA wal_checkpoint(TRUNCATE)']);
+            expect(test.events).toContain('finalize:close');
+            expect(fs.readFileSync(target, 'utf8')).toBe('OLD REPLICA');
+            expect(fs.existsSync(temp)).toBe(false);
+            for (const companion of replicaCompanions(temp)) expect(fs.existsSync(companion)).toBe(false);
+            expect(fs.readFileSync(unrelated, 'utf8')).toBe('NOT OUR FILE');
+        },
+    );
+
+    it('cleans a native-created replica when its first constructor throws', async () => {
+        const databasePullWithConfig = await requirePull();
+        const root = tempRoot();
+        const target = path.join(root, 'existing.db');
+        const temp = path.join(root, '.existing.db.solidactions-task7.tmp');
+        const unrelated = path.join(root, '.unrelated.solidactions-other.tmp');
+        fs.writeFileSync(target, 'OLD REPLICA');
+        fs.writeFileSync(unrelated, 'NOT OUR FILE');
+        const test = pullHarness(root);
+        test.dependencies.loadClient = async () => ({
+            createClient: (config: Record<string, unknown>) => {
+                expect(config).toMatchObject({ syncUrl: 'libsql://physical-hostname.sentinel.invalid' });
+                writeReplicaWithCompanions(temp, 'ORPHANED CONSTRUCTOR REPLICA');
+                throw new Error('RAW_CONSTRUCTOR_TOKEN_HOST_SENTINEL');
+            },
+        });
+
+        let caught: any;
+        try {
+            await databasePullWithConfig('Analytics', target, { yes: true }, CONFIG, test.dependencies);
+        } catch (error) {
+            caught = error;
+        }
+
+        expect(caught).toMatchObject({ code: 'upstream_unavailable' });
+        const publicError = `${caught?.message ?? ''} ${caught?.stack ?? ''} ${JSON.stringify(caught)}`;
+        expect(publicError).not.toContain('RAW_CONSTRUCTOR_TOKEN_HOST_SENTINEL');
+        expect(publicError).not.toContain(CONFIG.apiKey);
+        expect(test.posts).toHaveLength(1);
+        expect(fs.readFileSync(target, 'utf8')).toBe('OLD REPLICA');
+        expect(fs.existsSync(temp)).toBe(false);
+        for (const companion of replicaCompanions(temp)) expect(fs.existsSync(companion)).toBe(false);
+        expect(fs.readFileSync(unrelated, 'utf8')).toBe('NOT OUR FILE');
     });
 
     it('rolls back only its own replica when final rename fails and scrubs filesystem details', async () => {

--- a/tests/database-pull-command.test.ts
+++ b/tests/database-pull-command.test.ts
@@ -664,18 +664,4 @@ describe('database pull read-only replica contract', () => {
         expect(fs.readFileSync(unrelated, 'utf8')).toBe('NOT OUR FILE');
     });
 
-    it('fails --writable closed before filesystem work, native load, or mint', async () => {
-        const databasePullWithConfig = await requirePull();
-        const root = tempRoot();
-        const target = path.join(root, 'missing', 'analytics.db');
-        const test = pullHarness(root);
-
-        await expect(databasePullWithConfig('Analytics', target, { writable: true }, CONFIG, test.dependencies))
-            .rejects.toThrow(/writable.*not available|not available.*writable/i);
-
-        expect(test.events).toEqual([]);
-        expect(test.posts).toEqual([]);
-        expect(test.clientConfigs).toEqual([]);
-        expect(fs.existsSync(path.dirname(target))).toBe(false);
-    });
 });

--- a/tests/database-pull-command.test.ts
+++ b/tests/database-pull-command.test.ts
@@ -148,6 +148,8 @@ function expectOnlyReadAccess(posts: ReturnType<typeof pullHarness>['posts'], na
                     'Content-Type': 'application/json',
                     'X-Workspace-Id': 'workspace-1146',
                 },
+                signal: expect.any(AbortSignal),
+                timeout: 30_000,
             },
         });
     }
@@ -173,12 +175,15 @@ describe('database pull read-only replica contract', () => {
         const target = path.join(root, 'analytics.db');
         const test = pullHarness(root, async () => new Promise(() => undefined));
         test.dependencies.dataPlaneTimeoutMs = 10;
+        const delays: number[] = [];
+        test.dependencies.sleep = async (milliseconds: number) => delays.push(milliseconds);
 
         await expect(databasePullWithConfig('Analytics', target, {}, CONFIG, test.dependencies))
             .rejects.toMatchObject({ code: 'upstream_unavailable' });
 
-        expect(test.posts).toHaveLength(1);
-        expect(test.events.filter((event) => event.startsWith('close:'))).toEqual(['close:1']);
+        expect(test.posts).toHaveLength(3);
+        expect(test.events.filter((event) => event.startsWith('close:'))).toEqual(['close:1', 'close:2', 'close:3']);
+        expect(delays).toEqual([250, 500]);
         expect(fs.existsSync(target)).toBe(false);
     }, 1_000);
 
@@ -499,7 +504,9 @@ describe('database pull read-only replica contract', () => {
                         sync: async () => {
                             if (creates === 1) {
                                 fs.writeFileSync(temp, 'PARTIAL REPLICA');
-                                throw new Error('first sync needs fresh read access');
+                                throw Object.assign(new Error('first sync needs fresh read access'), {
+                                    code: 'ECONNRESET',
+                                });
                             }
                             fs.writeFileSync(temp, 'COMPLETE REPLICA');
                         },

--- a/tests/database-pull-command.test.ts
+++ b/tests/database-pull-command.test.ts
@@ -167,6 +167,21 @@ function writeReplicaWithCompanions(temp: string, contents = 'MAIN FILE BEFORE C
 }
 
 describe('database pull read-only replica contract', () => {
+    it('actively closes a stalled sync at the per-verb data deadline instead of hanging', async () => {
+        const databasePullWithConfig = await requirePull();
+        const root = tempRoot();
+        const target = path.join(root, 'analytics.db');
+        const test = pullHarness(root, async () => new Promise(() => undefined));
+        test.dependencies.dataPlaneTimeoutMs = 10;
+
+        await expect(databasePullWithConfig('Analytics', target, {}, CONFIG, test.dependencies))
+            .rejects.toMatchObject({ code: 'upstream_unavailable' });
+
+        expect(test.posts).toHaveLength(1);
+        expect(test.events.filter((event) => event.startsWith('close:'))).toEqual(['close:1']);
+        expect(fs.existsSync(target)).toBe(false);
+    }, 1_000);
+
     it.each([
         { name: '../../', expected: path.join('.solidactions', 'databases', 'database.db') },
         { name: '../../Customer Data/2026', expected: path.join('.solidactions', 'databases', 'customer-data-2026.db') },

--- a/tests/database-pull-command.test.ts
+++ b/tests/database-pull-command.test.ts
@@ -351,6 +351,59 @@ describe('database pull read-only replica contract', () => {
         expect(fs.statSync(target).mode & 0o777).toBe(0o444);
     });
 
+    it('hands the exclusive reservation to native creation once, then preserves the partial replica for retry', async () => {
+        const databasePullWithConfig = await requirePull();
+        const root = tempRoot();
+        const target = path.join(root, 'analytics.db');
+        const temp = path.join(root, '.analytics.db.solidactions-task7.tmp');
+        const test = pullHarness(root);
+        let loads = 0;
+        let creates = 0;
+
+        test.dependencies.loadClient = async () => {
+            loads += 1;
+            expect(fs.existsSync(temp), 'exclusive reservation or partial replica must exist while loading native support')
+                .toBe(true);
+            if (loads > 1) {
+                expect(fs.readFileSync(temp, 'utf8')).toBe('PARTIAL REPLICA');
+            }
+
+            return {
+                createClient: (config: Record<string, unknown>) => {
+                    creates += 1;
+                    expect(fileURLToPath(String(config.url))).toBe(temp);
+                    if (creates === 1) {
+                        expect(fs.existsSync(temp), 'native client must create the initial replica itself').toBe(false);
+                        fs.writeFileSync(temp, 'NATIVE REPLICA');
+                    } else {
+                        expect(fs.readFileSync(temp, 'utf8'), 'retry must retain incremental replica state')
+                            .toBe('PARTIAL REPLICA');
+                    }
+
+                    return {
+                        sync: async () => {
+                            if (creates === 1) {
+                                fs.writeFileSync(temp, 'PARTIAL REPLICA');
+                                throw new Error('first sync needs fresh read access');
+                            }
+                            fs.writeFileSync(temp, 'COMPLETE REPLICA');
+                        },
+                        close: async () => undefined,
+                    };
+                },
+            };
+        };
+
+        await databasePullWithConfig('Analytics', target, {}, CONFIG, test.dependencies);
+
+        expect(loads).toBe(2);
+        expect(creates).toBe(2);
+        expect(test.posts).toHaveLength(2);
+        expectOnlyReadAccess(test.posts);
+        expect(fs.readFileSync(target, 'utf8')).toBe('COMPLETE REPLICA');
+        expect(fs.statSync(target).mode & 0o777).toBe(0o444);
+    });
+
     it('rolls back only its own replica when final rename fails and scrubs filesystem details', async () => {
         const databasePullWithConfig = await requirePull();
         const root = tempRoot();

--- a/tests/database-pull-command.test.ts
+++ b/tests/database-pull-command.test.ts
@@ -330,7 +330,7 @@ describe('database pull read-only replica contract', () => {
         expect(fs.readFileSync(temp, 'utf8')).toBe('PRE-EXISTING TEMP OWNED BY SOMEONE ELSE');
     });
 
-    it('makes exactly three attempts with fresh read access, the same temp path, and a close per failed sync', async () => {
+    it('bounds transient transport retries with backoff, fresh access, one temp path, and a close per attempt', async () => {
         const databasePullWithConfig = await requirePull();
         const root = tempRoot();
         const target = path.join(root, 'existing.db');
@@ -342,8 +342,15 @@ describe('database pull read-only replica contract', () => {
             fs.writeFileSync(temp, 'PARTIAL REPLICA');
             fs.writeFileSync(`${temp}-wal`, 'WAL');
             fs.writeFileSync(`${temp}-shm`, 'SHM');
-            throw new Error(`sync failure physical-hostname.sentinel.invalid ${String(config.authToken)}`);
+            throw Object.assign(
+                new Error(`transport failure physical-hostname.sentinel.invalid ${String(config.authToken)}`),
+                { code: 'ECONNRESET' },
+            );
         });
+        const delays: number[] = [];
+        test.dependencies.sleep = async (milliseconds: number) => {
+            delays.push(milliseconds);
+        };
 
         let caught: any;
         try {
@@ -362,6 +369,7 @@ describe('database pull read-only replica contract', () => {
             'fresh-read-token-sentinel-3',
         ]);
         expect(test.events.filter((event) => event.startsWith('close:'))).toEqual(['close:1', 'close:2', 'close:3']);
+        expect(delays).toEqual([250, 500]);
         expect(caught).toMatchObject({ code: 'upstream_unavailable' });
         const publicError = `${caught?.message ?? ''} ${caught?.stack ?? ''} ${JSON.stringify(caught)}`;
         expect(publicError).toMatch(/failed/i);
@@ -376,15 +384,21 @@ describe('database pull read-only replica contract', () => {
         expect(fs.readFileSync(unrelated, 'utf8')).toBe('DO NOT DELETE');
     });
 
-    it('stops renewing after the first successful resumed sync', async () => {
+    it('remints exactly once after credential expiry and stops after the resumed sync succeeds', async () => {
         const databasePullWithConfig = await requirePull();
         const root = tempRoot();
         const target = path.join(root, 'analytics.db');
         const test = pullHarness(root, async (attempt, config) => {
             const temp = fileURLToPath(String(config.url));
             fs.writeFileSync(temp, attempt === 1 ? 'PARTIAL' : 'COMPLETE REPLICA');
-            if (attempt === 1) throw new Error('expired credential with raw details');
+            if (attempt === 1) {
+                throw Object.assign(new Error('JWT expired with raw credential details'), {
+                    code: 'SQLITE_AUTH',
+                });
+            }
         });
+        const delays: number[] = [];
+        test.dependencies.sleep = async (milliseconds: number) => delays.push(milliseconds);
 
         await databasePullWithConfig('Analytics', target, {}, CONFIG, test.dependencies);
 
@@ -392,8 +406,39 @@ describe('database pull read-only replica contract', () => {
         expect(test.clientConfigs).toHaveLength(2);
         expect(test.clientConfigs[0].url).toBe(test.clientConfigs[1].url);
         expect(test.events.filter((event) => event.startsWith('close:'))).toEqual(['close:1', 'close:2']);
+        expect(delays).toEqual([]);
         expect(fs.readFileSync(target, 'utf8')).toBe('COMPLETE REPLICA');
         expect(fs.statSync(target).mode & 0o777).toBe(0o444);
+    });
+
+    it.each([
+        { label: 'local SQLite', code: 'SQLITE_CORRUPT' },
+        { label: 'Hrana protocol', code: 'HRANA_PROTO_ERROR' },
+    ])('does not retry a deterministic $label failure', async ({ code }) => {
+        const databasePullWithConfig = await requirePull();
+        const root = tempRoot();
+        const target = path.join(root, 'analytics.db');
+        const test = pullHarness(root, async (_attempt, config) => {
+            fs.writeFileSync(fileURLToPath(String(config.url)), 'INVALID PARTIAL REPLICA');
+            throw Object.assign(new Error('DETERMINISTIC_FAILURE_SECRET_SENTINEL'), { code });
+        });
+        const delays: number[] = [];
+        test.dependencies.sleep = async (milliseconds: number) => delays.push(milliseconds);
+
+        let caught: any;
+        try {
+            await databasePullWithConfig('Analytics', target, {}, CONFIG, test.dependencies);
+        } catch (error) {
+            caught = error;
+        }
+
+        expect(test.posts).toHaveLength(1);
+        expect(test.clientConfigs).toHaveLength(1);
+        expect(test.events.filter((event) => event.startsWith('close:'))).toEqual(['close:1']);
+        expect(delays).toEqual([]);
+        expect(caught).toMatchObject({ code: 'upstream_unavailable' });
+        expect(`${String(caught)} ${JSON.stringify(caught)}`).not.toContain('DETERMINISTIC_FAILURE_SECRET_SENTINEL');
+        expect(fs.existsSync(target)).toBe(false);
     });
 
     it('hands the exclusive reservation to native creation once, then preserves the partial replica for retry', async () => {

--- a/tests/database-pull-command.test.ts
+++ b/tests/database-pull-command.test.ts
@@ -243,6 +243,31 @@ describe('database pull read-only replica contract', () => {
         expect(fs.lstatSync(target).isSymbolicLink()).toBe(true);
     });
 
+    it('refuses a symlinked destination parent before native load, mint, or file creation', async () => {
+        const databasePullWithConfig = await requirePull();
+        const root = tempRoot();
+        const outside = path.join(root, 'outside');
+        const linkedParent = path.join(root, 'replicas');
+        fs.mkdirSync(outside);
+        fs.writeFileSync(path.join(outside, 'analytics.db'), 'OUTSIDE REPLICA');
+        fs.symlinkSync(outside, linkedParent, 'dir');
+        const test = pullHarness(root);
+
+        await expect(databasePullWithConfig(
+            'Analytics',
+            path.join(linkedParent, 'analytics.db'),
+            { yes: true },
+            CONFIG,
+            test.dependencies,
+        )).rejects.toThrow(/symbolic link/i);
+
+        expect(test.events).toEqual([]);
+        expect(test.posts).toEqual([]);
+        expect(test.confirm).not.toHaveBeenCalled();
+        expect(fs.readFileSync(path.join(outside, 'analytics.db'), 'utf8')).toBe('OUTSIDE REPLICA');
+        expect(fs.readdirSync(outside)).toEqual(['analytics.db']);
+    });
+
     it('reserves its sibling temp exclusively and never removes a colliding pre-existing file', async () => {
         const databasePullWithConfig = await requirePull();
         const root = tempRoot();
@@ -324,6 +349,69 @@ describe('database pull read-only replica contract', () => {
         expect(test.events.filter((event) => event.startsWith('close:'))).toEqual(['close:1', 'close:2']);
         expect(fs.readFileSync(target, 'utf8')).toBe('COMPLETE REPLICA');
         expect(fs.statSync(target).mode & 0o777).toBe(0o444);
+    });
+
+    it('rolls back only its own replica when final rename fails and scrubs filesystem details', async () => {
+        const databasePullWithConfig = await requirePull();
+        const root = tempRoot();
+        const target = path.join(root, 'existing.db');
+        const ownTemp = path.join(root, '.existing.db.solidactions-task7.tmp');
+        const unrelated = path.join(root, '.unrelated.solidactions-other.tmp');
+        fs.writeFileSync(target, 'OLD REPLICA');
+        fs.writeFileSync(unrelated, 'NOT OUR FILE');
+        const test = pullHarness(root);
+        test.dependencies.filesystem = {
+            ...fs.promises,
+            rename: async () => {
+                throw new Error(`rename leaked ${CONFIG.apiKey} RAW_RENAME_PATH_SENTINEL`);
+            },
+        } as any;
+
+        let caught: any;
+        try {
+            await databasePullWithConfig('Analytics', target, { yes: true }, CONFIG, test.dependencies);
+        } catch (error) {
+            caught = error;
+        }
+
+        expect(caught).toMatchObject({ code: 'upstream_unavailable' });
+        const publicError = `${caught?.message ?? ''} ${caught?.stack ?? ''} ${JSON.stringify(caught)}`;
+        expect(publicError).not.toContain(CONFIG.apiKey);
+        expect(publicError).not.toContain('RAW_RENAME_PATH_SENTINEL');
+        expect(fs.readFileSync(target, 'utf8')).toBe('OLD REPLICA');
+        expect(fs.existsSync(ownTemp)).toBe(false);
+        expect(fs.readFileSync(unrelated, 'utf8')).toBe('NOT OUR FILE');
+    });
+
+    it('cleans a reserved temp after native loading fails before minting while preserving other files', async () => {
+        const databasePullWithConfig = await requirePull();
+        const root = tempRoot();
+        const target = path.join(root, 'existing.db');
+        const ownTemp = path.join(root, '.existing.db.solidactions-task7.tmp');
+        const unrelated = path.join(root, '.unrelated.solidactions-other.tmp');
+        fs.writeFileSync(target, 'OLD REPLICA');
+        fs.writeFileSync(unrelated, 'NOT OUR FILE');
+        const test = pullHarness(root);
+        test.dependencies.loadClient = async () => {
+            expect(fs.existsSync(ownTemp), 'temp must be reserved before native loading').toBe(true);
+            throw new Error('NATIVE_LOAD_SECRET_SENTINEL');
+        };
+
+        let caught: any;
+        try {
+            await databasePullWithConfig('Analytics', target, { yes: true }, CONFIG, test.dependencies);
+        } catch (error) {
+            caught = error;
+        }
+
+        expect(caught).toMatchObject({ code: 'database_client_unsupported' });
+        expect(`${caught?.message ?? ''} ${caught?.stack ?? ''} ${JSON.stringify(caught)}`)
+            .not.toContain('NATIVE_LOAD_SECRET_SENTINEL');
+        expect(test.posts).toEqual([]);
+        expect(test.clientConfigs).toEqual([]);
+        expect(fs.readFileSync(target, 'utf8')).toBe('OLD REPLICA');
+        expect(fs.existsSync(ownTemp)).toBe(false);
+        expect(fs.readFileSync(unrelated, 'utf8')).toBe('NOT OUR FILE');
     });
 
     it('fails --writable closed before filesystem work, native load, or mint', async () => {

--- a/tests/database-pull-command.test.ts
+++ b/tests/database-pull-command.test.ts
@@ -1,0 +1,343 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+interface Config {
+    host: string;
+    apiKey: string;
+    workspaceId: string;
+}
+
+const CONFIG: Config = {
+    host: 'https://app.example.test',
+    apiKey: 'control-plane-pat-sentinel',
+    workspaceId: 'workspace-1146',
+};
+
+const roots: string[] = [];
+
+afterEach(() => {
+    for (const root of roots.splice(0)) {
+        fs.chmodSync(root, 0o700);
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+});
+
+async function requirePull(): Promise<Function> {
+    const url = pathToFileURL(path.resolve(__dirname, '../src/commands/database.ts')).href;
+    let module: Record<string, unknown> = {};
+    try {
+        module = await import(url) as Record<string, unknown>;
+    } catch {
+        // The first TDD slice intentionally lands before the production export.
+    }
+    expect(module.databasePullWithConfig, 'databasePullWithConfig export').toBeTypeOf('function');
+    return module.databasePullWithConfig as Function;
+}
+
+function tempRoot(): string {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'sa-database-pull-'));
+    roots.push(root);
+    return root;
+}
+
+function pullHarness(
+    root: string,
+    sync: (attempt: number, config: Record<string, unknown>) => Promise<void> = async (_attempt, config) => {
+        fs.writeFileSync(fileURLToPath(String(config.url)), 'READ ONLY REPLICA');
+    },
+) {
+    const events: string[] = [];
+    const posts: Array<{ url: string; body: Record<string, unknown>; options: Record<string, unknown> }> = [];
+    const clientConfigs: Array<Record<string, unknown>> = [];
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const confirm = vi.fn(async () => true as boolean | undefined);
+    let attempt = 0;
+
+    const dependencies = {
+        cwd: root,
+        tempPath: (target: string) => path.join(path.dirname(target), `.${path.basename(target)}.solidactions-task7.tmp`),
+        loadClient: async () => {
+            events.push('load');
+            return {
+                createClient: (config: Record<string, unknown>) => {
+                    const current = ++attempt;
+                    clientConfigs.push(config);
+                    events.push(`create:${current}`);
+                    return {
+                        sync: async () => {
+                            events.push(`sync:${current}`);
+                            await sync(current, config);
+                        },
+                        close: async () => {
+                            events.push(`close:${current}`);
+                        },
+                    };
+                },
+            };
+        },
+        post: async (url: string, body: Record<string, unknown>, options: Record<string, unknown>) => {
+            const mint = posts.length + 1;
+            events.push(`mint:${mint}`);
+            posts.push({ url, body, options });
+            return {
+                data: {
+                    url: 'libsql://physical-hostname.sentinel.invalid',
+                    token: `fresh-read-token-sentinel-${mint}`,
+                    mode: 'read',
+                    expires_at: '2026-08-07T12:10:00Z',
+                },
+            };
+        },
+        stdout: (line: string) => stdout.push(line),
+        stderr: (line: string) => stderr.push(line),
+        confirm,
+        isTTY: true,
+    };
+
+    return { events, posts, clientConfigs, stdout, stderr, confirm, dependencies };
+}
+
+function expectOnlyReadAccess(posts: ReturnType<typeof pullHarness>['posts'], name = 'Analytics'): void {
+    expect(posts.length).toBeGreaterThan(0);
+    for (const post of posts) {
+        expect(post).toEqual({
+            url: 'https://app.example.test/api/v1/databases',
+            body: { operation: 'access', name, mode: 'read' },
+            options: {
+                headers: {
+                    Accept: 'application/json',
+                    Authorization: 'Bearer control-plane-pat-sentinel',
+                    'Content-Type': 'application/json',
+                    'X-Workspace-Id': 'workspace-1146',
+                },
+            },
+        });
+    }
+    expect(JSON.stringify(posts)).not.toContain('READ ONLY REPLICA');
+    expect(JSON.stringify(posts)).not.toContain('SELECT');
+}
+
+describe('database pull read-only replica contract', () => {
+    it.each([
+        { name: '../../', expected: path.join('.solidactions', 'databases', 'database.db') },
+        { name: '../../Customer Data/2026', expected: path.join('.solidactions', 'databases', 'customer-data-2026.db') },
+        { name: '/tmp/Root DB', expected: path.join('.solidactions', 'databases', 'tmp-root-db.db') },
+    ])('keeps the safe default for $name under $expected', async ({ name, expected }) => {
+        const databasePullWithConfig = await requirePull();
+        const root = tempRoot();
+        const test = pullHarness(root);
+
+        await databasePullWithConfig(name, undefined, {}, CONFIG, test.dependencies);
+
+        const target = path.join(root, expected);
+        expect(fs.readFileSync(target, 'utf8')).toBe('READ ONLY REPLICA');
+        expect(fs.statSync(target).mode & 0o777).toBe(0o444);
+        expect(path.relative(path.join(root, '.solidactions', 'databases'), target)).not.toMatch(/^\.\.(?:[/\\]|$)/);
+        expectOnlyReadAccess(test.posts, name);
+        expect(test.stdout.join('\n')).toContain(expected);
+        expect(test.stderr).toEqual([]);
+    });
+
+    it('creates explicit parents and loads native support before minting read access', async () => {
+        const databasePullWithConfig = await requirePull();
+        const root = tempRoot();
+        const target = path.join(root, 'nested', 'replicas', 'analytics.db');
+        const realPromises = fs.promises;
+        const events: string[] = [];
+        const test = pullHarness(root);
+        test.dependencies.filesystem = {
+            ...realPromises,
+            chmod: async (file: fs.PathLike, mode: fs.Mode) => {
+                events.push('chmod');
+                return realPromises.chmod(file, mode);
+            },
+            rename: async (from: fs.PathLike, to: fs.PathLike) => {
+                events.push('rename');
+                return realPromises.rename(from, to);
+            },
+        } as any;
+        const originalLoad = test.dependencies.loadClient;
+        test.dependencies.loadClient = async () => {
+            events.push('load');
+            const loaded = await originalLoad();
+            return {
+                createClient: (config: Record<string, unknown>) => {
+                    const client = loaded.createClient(config);
+                    const close = client.close;
+                    client.close = async () => {
+                        events.push('close');
+                        await close();
+                    };
+                    return client;
+                },
+            };
+        };
+        const originalPost = test.dependencies.post;
+        test.dependencies.post = async (...args: any[]) => {
+            events.push('mint');
+            return (originalPost as any)(...args);
+        };
+
+        await databasePullWithConfig('Analytics', target, {}, CONFIG, test.dependencies);
+
+        expect(events.indexOf('load')).toBeLessThan(events.indexOf('mint'));
+        expect(events.indexOf('close')).toBeLessThan(events.indexOf('chmod'));
+        expect(events.indexOf('chmod')).toBeLessThan(events.indexOf('rename'));
+        expect(fs.readFileSync(target, 'utf8')).toBe('READ ONLY REPLICA');
+        expect(fs.statSync(target).mode & 0o777).toBe(0o444);
+        expect(test.clientConfigs).toHaveLength(1);
+        const tempUrl = String(test.clientConfigs[0].url);
+        expect(tempUrl).toBe(pathToFileURL(path.join(path.dirname(target), '.analytics.db.solidactions-task7.tmp')).href);
+        expect(test.clientConfigs[0]).toEqual({
+            url: tempUrl,
+            syncUrl: 'libsql://physical-hostname.sentinel.invalid',
+            authToken: 'fresh-read-token-sentinel-1',
+            intMode: 'string',
+        });
+        expectOnlyReadAccess(test.posts);
+    });
+
+    it.each([
+        { label: 'non-TTY', isTTY: false, answer: true },
+        { label: 'decline', isTTY: true, answer: false },
+        { label: 'EOF', isTTY: true, answer: undefined },
+    ])('$label refuses an existing target before native load, mint, or file changes', async ({ isTTY, answer }) => {
+        const databasePullWithConfig = await requirePull();
+        const root = tempRoot();
+        const target = path.join(root, 'existing.db');
+        fs.writeFileSync(target, 'OLD REPLICA');
+        const test = pullHarness(root);
+        test.dependencies.isTTY = isTTY;
+        test.dependencies.confirm = vi.fn(async () => answer);
+
+        const outcome = databasePullWithConfig('Analytics', target, {}, CONFIG, test.dependencies);
+        if (isTTY) await outcome;
+        else await expect(outcome).rejects.toMatchObject({ code: 'confirmation_required' });
+
+        expect(test.posts).toEqual([]);
+        expect(test.clientConfigs).toEqual([]);
+        expect(test.events).toEqual([]);
+        expect(fs.readFileSync(target, 'utf8')).toBe('OLD REPLICA');
+    });
+
+    it('refuses a destination symlink before native load or mint, even with --yes', async () => {
+        const databasePullWithConfig = await requirePull();
+        const root = tempRoot();
+        const outside = path.join(root, 'outside.db');
+        const target = path.join(root, 'linked.db');
+        fs.writeFileSync(outside, 'DO NOT REPLACE');
+        fs.symlinkSync(outside, target);
+        const test = pullHarness(root);
+
+        await expect(databasePullWithConfig('Analytics', target, { yes: true }, CONFIG, test.dependencies))
+            .rejects.toThrow(/symbolic link/i);
+
+        expect(test.events).toEqual([]);
+        expect(test.posts).toEqual([]);
+        expect(test.confirm).not.toHaveBeenCalled();
+        expect(fs.readFileSync(outside, 'utf8')).toBe('DO NOT REPLACE');
+        expect(fs.lstatSync(target).isSymbolicLink()).toBe(true);
+    });
+
+    it('reserves its sibling temp exclusively and never removes a colliding pre-existing file', async () => {
+        const databasePullWithConfig = await requirePull();
+        const root = tempRoot();
+        const target = path.join(root, 'analytics.db');
+        const temp = path.join(root, '.analytics.db.solidactions-task7.tmp');
+        fs.writeFileSync(temp, 'PRE-EXISTING TEMP OWNED BY SOMEONE ELSE');
+        const test = pullHarness(root);
+
+        await expect(databasePullWithConfig('Analytics', target, {}, CONFIG, test.dependencies))
+            .rejects.toThrow(/temporary|already exists|failed/i);
+
+        expect(test.posts).toEqual([]);
+        expect(test.clientConfigs).toEqual([]);
+        expect(fs.existsSync(target)).toBe(false);
+        expect(fs.readFileSync(temp, 'utf8')).toBe('PRE-EXISTING TEMP OWNED BY SOMEONE ELSE');
+    });
+
+    it('makes exactly three attempts with fresh read access, the same temp path, and a close per failed sync', async () => {
+        const databasePullWithConfig = await requirePull();
+        const root = tempRoot();
+        const target = path.join(root, 'existing.db');
+        const unrelated = path.join(root, '.someone-elses-replica.tmp');
+        fs.writeFileSync(target, 'OLD REPLICA');
+        fs.writeFileSync(unrelated, 'DO NOT DELETE');
+        const test = pullHarness(root, async (_attempt, config) => {
+            const temp = fileURLToPath(String(config.url));
+            fs.writeFileSync(temp, 'PARTIAL REPLICA');
+            fs.writeFileSync(`${temp}-wal`, 'WAL');
+            fs.writeFileSync(`${temp}-shm`, 'SHM');
+            throw new Error(`sync failure physical-hostname.sentinel.invalid ${String(config.authToken)}`);
+        });
+
+        let caught: any;
+        try {
+            await databasePullWithConfig('Analytics', target, { yes: true }, CONFIG, test.dependencies);
+        } catch (error) {
+            caught = error;
+        }
+
+        expect(test.posts).toHaveLength(3);
+        expectOnlyReadAccess(test.posts);
+        expect(test.clientConfigs).toHaveLength(3);
+        expect(new Set(test.clientConfigs.map((config) => config.url))).toHaveLength(1);
+        expect(test.clientConfigs.map((config) => config.authToken)).toEqual([
+            'fresh-read-token-sentinel-1',
+            'fresh-read-token-sentinel-2',
+            'fresh-read-token-sentinel-3',
+        ]);
+        expect(test.events.filter((event) => event.startsWith('close:'))).toEqual(['close:1', 'close:2', 'close:3']);
+        expect(caught).toMatchObject({ code: 'upstream_unavailable' });
+        const publicError = `${caught?.message ?? ''} ${caught?.stack ?? ''} ${JSON.stringify(caught)}`;
+        expect(publicError).toMatch(/failed/i);
+        expect(publicError).not.toContain('physical-hostname.sentinel.invalid');
+        expect(publicError).not.toContain('fresh-read-token-sentinel');
+        expect(publicError).not.toContain(CONFIG.apiKey);
+        expect(fs.readFileSync(target, 'utf8')).toBe('OLD REPLICA');
+        const temp = fileURLToPath(String(test.clientConfigs[0].url));
+        expect(fs.existsSync(temp)).toBe(false);
+        expect(fs.existsSync(`${temp}-wal`)).toBe(false);
+        expect(fs.existsSync(`${temp}-shm`)).toBe(false);
+        expect(fs.readFileSync(unrelated, 'utf8')).toBe('DO NOT DELETE');
+    });
+
+    it('stops renewing after the first successful resumed sync', async () => {
+        const databasePullWithConfig = await requirePull();
+        const root = tempRoot();
+        const target = path.join(root, 'analytics.db');
+        const test = pullHarness(root, async (attempt, config) => {
+            const temp = fileURLToPath(String(config.url));
+            fs.writeFileSync(temp, attempt === 1 ? 'PARTIAL' : 'COMPLETE REPLICA');
+            if (attempt === 1) throw new Error('expired credential with raw details');
+        });
+
+        await databasePullWithConfig('Analytics', target, {}, CONFIG, test.dependencies);
+
+        expect(test.posts).toHaveLength(2);
+        expect(test.clientConfigs).toHaveLength(2);
+        expect(test.clientConfigs[0].url).toBe(test.clientConfigs[1].url);
+        expect(test.events.filter((event) => event.startsWith('close:'))).toEqual(['close:1', 'close:2']);
+        expect(fs.readFileSync(target, 'utf8')).toBe('COMPLETE REPLICA');
+        expect(fs.statSync(target).mode & 0o777).toBe(0o444);
+    });
+
+    it('fails --writable closed before filesystem work, native load, or mint', async () => {
+        const databasePullWithConfig = await requirePull();
+        const root = tempRoot();
+        const target = path.join(root, 'missing', 'analytics.db');
+        const test = pullHarness(root);
+
+        await expect(databasePullWithConfig('Analytics', target, { writable: true }, CONFIG, test.dependencies))
+            .rejects.toThrow(/writable.*not available|not available.*writable/i);
+
+        expect(test.events).toEqual([]);
+        expect(test.posts).toEqual([]);
+        expect(test.clientConfigs).toEqual([]);
+        expect(fs.existsSync(path.dirname(target))).toBe(false);
+    });
+});

--- a/tests/database-remote-sync-probe.test.ts
+++ b/tests/database-remote-sync-probe.test.ts
@@ -1,0 +1,100 @@
+import path from 'path';
+import { pathToFileURL } from 'url';
+import { describe, expect, it } from 'vitest';
+
+interface ProbeOptions {
+    createClient: (config: Record<string, unknown>) => unknown;
+    remoteUrl: string;
+    localUrl: string;
+}
+
+async function loadProbe(): Promise<(options: ProbeOptions) => Promise<void>> {
+    const moduleUrl = pathToFileURL(path.resolve(__dirname, '../scripts/probe-database-client-sync.mjs')).href;
+    const module = await import(moduleUrl) as Record<string, unknown>;
+
+    expect(module.runRemoteSyncProbe).toBeTypeOf('function');
+    return module.runRemoteSyncProbe as (options: ProbeOptions) => Promise<void>;
+}
+
+function statementSql(statement: unknown): string {
+    if (typeof statement === 'string') return statement;
+    return String((statement as { sql?: unknown })?.sql ?? '');
+}
+
+describe('remote database sync probe', () => {
+    it('seeds the remote before opening, syncing, and querying a local file replica', async () => {
+        const runRemoteSyncProbe = await loadProbe();
+        const remoteUrl = 'http://127.0.0.1:8080';
+        const localUrl = 'file:/tmp/solidactions-sync-probe.db';
+        const events: string[] = [];
+        const remoteStatements: string[] = [];
+        const localStatements: string[] = [];
+        const clientConfigs: Array<Record<string, unknown>> = [];
+
+        await runRemoteSyncProbe({
+            remoteUrl,
+            localUrl,
+            createClient: (config) => {
+                clientConfigs.push(config);
+                if (config.url === remoteUrl) {
+                    events.push('open-remote');
+                    return {
+                        execute: async (statement: unknown) => {
+                            remoteStatements.push(statementSql(statement));
+                            events.push('seed-remote');
+                            return { rows: [] };
+                        },
+                        close: () => events.push('close-remote'),
+                    };
+                }
+
+                events.push('open-local');
+                return {
+                    sync: async () => events.push('sync-local'),
+                    execute: async (statement: unknown) => {
+                        localStatements.push(statementSql(statement));
+                        events.push('query-local');
+                        return { rows: [{ value: 'remote-sync-ready' }] };
+                    },
+                    close: () => events.push('close-local'),
+                };
+            },
+        });
+
+        expect(clientConfigs).toEqual([
+            expect.objectContaining({ url: remoteUrl }),
+            expect.objectContaining({ url: localUrl, syncUrl: remoteUrl }),
+        ]);
+        expect(remoteStatements).toHaveLength(2);
+        expect(remoteStatements[0]).toMatch(/^CREATE TABLE/i);
+        expect(remoteStatements[1]).toMatch(/^INSERT INTO/i);
+        expect(localStatements).toHaveLength(1);
+        expect(localStatements[0]).toMatch(/^SELECT /i);
+        expect(events.indexOf('seed-remote')).toBeLessThan(events.indexOf('open-local'));
+        expect(events.indexOf('sync-local')).toBeLessThan(events.indexOf('query-local'));
+        expect(events).toContain('close-remote');
+        expect(events).toContain('close-local');
+    });
+
+    it('rejects an unexpected synced row and still closes both clients', async () => {
+        const runRemoteSyncProbe = await loadProbe();
+        const closed: string[] = [];
+
+        await expect(runRemoteSyncProbe({
+            remoteUrl: 'http://127.0.0.1:8080',
+            localUrl: 'file:/tmp/solidactions-sync-probe.db',
+            createClient: (config) => config.syncUrl
+                ? {
+                    sync: async () => undefined,
+                    execute: async () => ({ rows: [{ value: 'wrong-row' }] }),
+                    close: () => closed.push('local'),
+                }
+                : {
+                    execute: async () => ({ rows: [] }),
+                    close: () => closed.push('remote'),
+                },
+        })).rejects.toThrow(/unexpected result/i);
+
+        expect(closed).toEqual(expect.arrayContaining(['remote', 'local']));
+    });
+});

--- a/tests/database-sql-import-parser.test.ts
+++ b/tests/database-sql-import-parser.test.ts
@@ -75,7 +75,7 @@ describe('database SQL import parser', () => {
         expect(parsed.groups).toHaveLength(4);
     });
 
-    it('keeps a trigger body, internal semicolons, and nested CASE END expressions in one group', async () => {
+    it('keeps trigger BEGIN/END, internal semicolons, and nested CASE END expressions in one group', async () => {
         const parse = await requireParser();
         const before = 'CREATE TABLE audit (value TEXT);';
         const trigger = [
@@ -144,6 +144,79 @@ describe('database SQL import parser', () => {
         const parsed = parse(source);
 
         expect(parsed.groups.map((group) => group.sql)).toEqual(['CREATE TABLE t (id);']);
+    });
+
+    it('accepts one leading UTF-8 BOM without polluting SQL while preserving its original byte offset', async () => {
+        const parse = await requireParser();
+        const sql = 'CREATE TABLE t (id);';
+        const source = Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), Buffer.from(sql)]);
+
+        const parsed = parse(source);
+
+        expect(parsed.groups).toEqual([{
+            sql,
+            startByte: 3,
+            endByte: 3 + Buffer.byteLength(sql),
+            startLine: 1,
+            endLine: 1,
+        }]);
+    });
+
+    it('accepts trailing whitespace and comments after the last complete statement', async () => {
+        const parse = await requireParser();
+        const sql = 'CREATE TABLE t (id);';
+
+        const parsed = parse(`${sql}\n \t-- trailing line; comment\n/* trailing block; comment */\n`);
+
+        expect(parsed.groups.map((group) => group.sql)).toEqual([sql]);
+    });
+
+    it.each([
+        ['', 'empty input'],
+        ['  \n-- only; a line comment\n/* only a block; comment */\n', 'comment-only input'],
+    ])('parses $1 to zero groups for the command layer to reject', async (source) => {
+        const parse = await requireParser();
+
+        expect(parse(source)).toEqual({ foreignKeysOff: false, groups: [] });
+    });
+
+    it('refuses malformed UTF-8 instead of replacement-decoding it', async () => {
+        const parse = await requireParser();
+        const malformed = Buffer.concat([
+            Buffer.from('CREATE TABLE t (value TEXT);\nINSERT INTO t VALUES (\''),
+            Buffer.from([0xc3, 0x28]),
+            Buffer.from("');"),
+        ]);
+
+        let caught: unknown;
+        try {
+            parse(malformed);
+        } catch (error) {
+            caught = error;
+        }
+
+        const report = errorReport(caught);
+        expect(report).toMatch(/import_failed/i);
+        expect(report).toMatch(/UTF-8|encoding/i);
+    });
+
+    it.each([
+        ['OFF', 'PRAGMA foreign_keys=OFF;\nCREATE TABLE t (id);'],
+        ['ON', 'CREATE TABLE t (id);\nPRAGMA foreign_keys=ON;'],
+    ])('refuses standalone foreign_keys=%s outside a complete canonical envelope', async (mode, source) => {
+        const parse = await requireParser();
+
+        let caught: unknown;
+        try {
+            parse(source);
+        } catch (error) {
+            caught = error;
+        }
+
+        const report = errorReport(caught);
+        expect(report).toMatch(/import_failed/i);
+        expect(report).toMatch(/foreign_keys/i);
+        expect(report).toMatch(mode === 'OFF' ? /line 1\b/i : /line 2\b/i);
     });
 
     it.each([

--- a/tests/database-sql-import-parser.test.ts
+++ b/tests/database-sql-import-parser.test.ts
@@ -1,0 +1,239 @@
+import { Buffer } from 'buffer';
+import fs from 'fs';
+import path from 'path';
+import { pathToFileURL } from 'url';
+import { describe, expect, it } from 'vitest';
+
+interface SqlGroup {
+    sql: string;
+    startByte: number;
+    endByte: number;
+    startLine: number;
+    endLine: number;
+}
+
+interface ParsedImport {
+    groups: SqlGroup[];
+    foreignKeysOff: boolean;
+}
+
+async function requireParser(): Promise<(source: Buffer | string) => ParsedImport> {
+    const url = pathToFileURL(path.resolve(__dirname, '../src/commands/database.ts')).href;
+    const module = await import(url) as Record<string, unknown>;
+    expect(module.parseDatabaseImportSql, 'parseDatabaseImportSql export').toBeTypeOf('function');
+    return module.parseDatabaseImportSql as (source: Buffer | string) => ParsedImport;
+}
+
+function exactGroup(source: string, sql: string, startLine: number, endLine = startLine): SqlGroup {
+    const characterStart = source.indexOf(sql);
+    expect(characterStart, `fixture contains ${sql.slice(0, 30)}`).toBeGreaterThanOrEqual(0);
+    return {
+        sql,
+        startByte: Buffer.byteLength(source.slice(0, characterStart), 'utf8'),
+        endByte: Buffer.byteLength(source.slice(0, characterStart + sql.length), 'utf8'),
+        startLine,
+        endLine,
+    };
+}
+
+function errorReport(error: unknown): string {
+    const value = error as { code?: unknown; message?: unknown } | null;
+    return `${String(value?.code ?? '')}\n${String(value?.message ?? '')}`;
+}
+
+describe('database SQL import parser', () => {
+    it('reports original UTF-8 byte offsets and source lines for every complete group', async () => {
+        const parse = await requireParser();
+        const first = 'CREATE TABLE "café" (value TEXT);';
+        const second = "INSERT INTO \"café\" VALUES ('snowman ☃; intact');";
+        const source = `${first}\n\n${second}\n`;
+
+        const parsed = parse(Buffer.from(source, 'utf8'));
+
+        expect(parsed).toEqual({
+            foreignKeysOff: false,
+            groups: [
+                exactGroup(source, first, 1),
+                exactGroup(source, second, 3),
+            ],
+        });
+    });
+
+    it('does not split on semicolons in every supported quote and comment form', async () => {
+        const parse = await requireParser();
+        const statements = [
+            "INSERT INTO t VALUES ('single; quote', 'doubled '' quote; stays');",
+            'CREATE TABLE "double;identifier" ([bracket;identifier] TEXT, `backtick;identifier` TEXT);',
+            '-- line comment; is not a boundary\nINSERT INTO t VALUES (1);',
+            '/* block; comment\n   still comment; */\nINSERT INTO t VALUES (2);',
+        ];
+        const source = statements.join('\n');
+
+        const parsed = parse(source);
+
+        expect(parsed.groups.map((group) => group.sql)).toEqual(statements);
+        expect(parsed.groups).toHaveLength(4);
+    });
+
+    it('keeps a trigger body, internal semicolons, and nested CASE END expressions in one group', async () => {
+        const parse = await requireParser();
+        const before = 'CREATE TABLE audit (value TEXT);';
+        const trigger = [
+            'CREATE TRIGGER audit_insert AFTER INSERT ON audit BEGIN',
+            "  INSERT INTO audit VALUES ('BEGIN; and END; in text');",
+            '  SELECT CASE WHEN NEW.value IS NULL THEN',
+            "    CASE WHEN 1 THEN 'inner;case' ELSE 'other' END",
+            "  ELSE 'outer' END;",
+            '  UPDATE audit SET value = value || ";quoted identifier literal";',
+            'END;',
+        ].join('\n');
+        const after = "INSERT INTO audit VALUES ('after');";
+        const source = `${before}\n${trigger}\n${after}\n`;
+
+        const parsed = parse(source);
+
+        expect(parsed.groups).toEqual([
+            exactGroup(source, before, 1),
+            exactGroup(source, trigger, 2, 8),
+            exactGroup(source, after, 9),
+        ]);
+    });
+
+    it('normalizes only the canonical sqlite dump envelope while preserving inner order and locations', async () => {
+        const parse = await requireParser();
+        const fixture = path.resolve(__dirname, 'fixtures/database-import/sqlite-dump.sql');
+        const source = fs.readFileSync(fixture, 'utf8');
+        const create = 'CREATE TABLE "audit;events" (id INTEGER PRIMARY KEY, value TEXT NOT NULL);';
+        const insert = "INSERT INTO \"audit;events\" VALUES(1,'one;still one');";
+        const trigger = [
+            'CREATE TRIGGER audit_insert AFTER INSERT ON "audit;events" BEGIN',
+            '  UPDATE "audit;events"',
+            "  SET value = CASE WHEN NEW.value = 'raw;value' THEN 'normalized' ELSE NEW.value END",
+            '  WHERE id = NEW.id;',
+            'END;',
+        ].join('\n');
+
+        const parsed = parse(source);
+
+        expect(parsed).toEqual({
+            foreignKeysOff: true,
+            groups: [
+                exactGroup(source, create, 3),
+                exactGroup(source, insert, 4),
+                exactGroup(source, trigger, 5, 9),
+            ],
+        });
+    });
+
+    it.each([
+        {
+            label: 'minimal BEGIN spelling',
+            source: 'BEGIN;\nCREATE TABLE t (id);\nCOMMIT;\n',
+        },
+        {
+            label: 'no optional pragmas',
+            source: 'BEGIN TRANSACTION;\nCREATE TABLE t (id);\nCOMMIT;\n',
+        },
+        {
+            label: 'foreign key controls and comments',
+            source: '-- sqlite dump\nPRAGMA foreign_keys = OFF;\nBEGIN;\nCREATE TABLE t (id);\nCOMMIT;\nPRAGMA foreign_keys = ON;\n',
+        },
+    ])('accepts canonical wrapper variant: $label', async ({ source }) => {
+        const parse = await requireParser();
+
+        const parsed = parse(source);
+
+        expect(parsed.groups.map((group) => group.sql)).toEqual(['CREATE TABLE t (id);']);
+    });
+
+    it.each([
+        ['BEGIN', 'CREATE TABLE t (id);\nBEGIN IMMEDIATE;\n'],
+        ['END', 'CREATE TABLE t (id);\nEND;\n'],
+        ['COMMIT', 'CREATE TABLE t (id);\nCOMMIT;\n'],
+        ['ROLLBACK', 'CREATE TABLE t (id);\nROLLBACK;\n'],
+        ['SAVEPOINT', 'CREATE TABLE t (id);\nSAVEPOINT import_step;\n'],
+        ['RELEASE', 'CREATE TABLE t (id);\nRELEASE import_step;\n'],
+    ])('refuses non-wrapper top-level %s with a stable source line', async (control, source) => {
+        const parse = await requireParser();
+
+        let caught: unknown;
+        try {
+            parse(source);
+        } catch (error) {
+            caught = error;
+        }
+
+        const report = errorReport(caught);
+        expect(report).toMatch(/import_failed/i);
+        expect(report).toContain(control);
+        expect(report).toMatch(/line 2\b/i);
+    });
+
+    it.each([
+        ['journal_mode', 'PRAGMA journal_mode=WAL;'],
+        ['defer_foreign_keys', 'PRAGMA defer_foreign_keys=ON;'],
+        ['foreign_keys', 'PRAGMA foreign_keys=ON;\nCREATE TABLE t (id);'],
+        ['user_version', 'PRAGMA user_version=5;'],
+    ])('refuses unsupported top-level PRAGMA %s by name and line', async (pragma, statement) => {
+        const parse = await requireParser();
+        const source = `-- header\n${statement}\n`;
+
+        let caught: unknown;
+        try {
+            parse(source);
+        } catch (error) {
+            caught = error;
+        }
+
+        const report = errorReport(caught);
+        expect(report).toMatch(/import_failed/i);
+        expect(report).toContain(pragma);
+        expect(report).toMatch(/line 2\b/i);
+    });
+
+    it.each([
+        ['single quote', "INSERT INTO t VALUES ('unterminated);"],
+        ['double quote', 'CREATE TABLE "unterminated (id);'],
+        ['bracket identifier', 'CREATE TABLE [unterminated (id);'],
+        ['backtick identifier', 'CREATE TABLE `unterminated (id);'],
+        ['block comment', 'CREATE TABLE t (id); /* unterminated'],
+        ['trigger', 'CREATE TRIGGER tr AFTER INSERT ON t BEGIN SELECT 1;'],
+        ['ordinary statement', 'CREATE TABLE t (id)'],
+        ['ambiguous END', 'CREATE TRIGGER tr AFTER INSERT ON t BEGIN SELECT CASE WHEN 1 THEN 2 END;'],
+    ])('refuses incomplete or ambiguous input: $0', async (_label, source) => {
+        const parse = await requireParser();
+
+        expect(() => parse(source)).toThrow(/line|incomplete|unterminated|boundary|trigger/i);
+    });
+
+    it.each([
+        "CREATE TABLE t (id);\n-- DOWNLOAD INCOMPLETE: service unavailable\n",
+        "\ufeffCREATE TABLE t (id);\r\n-- DOWNLOAD INCOMPLETE: browser stream failed\r\n",
+    ])('refuses a raw incomplete-download marker instead of treating it as a comment', async (source) => {
+        const parse = await requireParser();
+
+        let caught: unknown;
+        try {
+            parse(Buffer.from(source, 'utf8'));
+        } catch (error) {
+            caught = error;
+        }
+
+        const report = errorReport(caught);
+        expect(report).toMatch(/import_failed/i);
+        expect(report).toMatch(/download.*incomplete|incomplete.*download/i);
+    });
+
+    it('accepts an exact 8 MiB statement and refuses one byte more', async () => {
+        const parse = await requireParser();
+        const limit = 8 * 1024 * 1024;
+        const prefix = "INSERT INTO payloads(value) VALUES ('";
+        const suffix = "');";
+        const atLimit = `${prefix}${'x'.repeat(limit - Buffer.byteLength(prefix + suffix))}${suffix}`;
+        const overLimit = atLimit.replace("');", "x');");
+
+        expect(Buffer.byteLength(atLimit)).toBe(limit);
+        expect(parse(atLimit).groups).toHaveLength(1);
+        expect(() => parse(overLimit)).toThrow(/8 MiB|statement.*large|import_failed/i);
+    });
+});

--- a/tests/database-sql-import-parser.test.ts
+++ b/tests/database-sql-import-parser.test.ts
@@ -162,6 +162,19 @@ describe('database SQL import parser', () => {
         }]);
     });
 
+    it.each([
+        Buffer.concat([
+            Buffer.from([0xef, 0xbb, 0xbf]),
+            Buffer.from([0xef, 0xbb, 0xbf]),
+            Buffer.from('CREATE TABLE t (id);'),
+        ]),
+        '\uFEFF\uFEFFCREATE TABLE t (id);',
+    ])('rejects more than one leading UTF-8 BOM', async (source) => {
+        const parse = await requireParser();
+
+        expect(() => parse(source)).toThrow(/more than one leading UTF-8 BOM/i);
+    });
+
     it('accepts trailing whitespace and comments after the last complete statement', async () => {
         const parse = await requireParser();
         const sql = 'CREATE TABLE t (id);';

--- a/tests/database-writable-pull-command.test.ts
+++ b/tests/database-writable-pull-command.test.ts
@@ -213,6 +213,25 @@ function expectNoSecrets(value: unknown): void {
 }
 
 describe('database pull --writable foreground attached session', () => {
+    it('closes a stalled initial sync at its deadline before warning or accepting input', async () => {
+        const databasePullWithConfig = await requirePull();
+        const root = tempRoot();
+        const target = path.join(root, 'analytics.db');
+        const test = writableHarness(root, {
+            lines: ['DELETE FROM ledger;', '.exit'],
+            sync: async () => new Promise(() => undefined),
+        });
+        test.dependencies.dataPlaneTimeoutMs = 10;
+
+        await expect(databasePullWithConfig('Analytics', target, { writable: true }, CONFIG, test.dependencies))
+            .rejects.toMatchObject({ code: 'upstream_unavailable' });
+
+        expect(test.closed).toEqual([1]);
+        expect(test.stdout).not.toContain(WARNING);
+        expect(test.events).not.toContain('input:1');
+        expect(fs.existsSync(target)).toBe(false);
+    }, 1_000);
+
     it.each([
         { ending: '.exit', lines: ["INSERT INTO notes(body) VALUES ('one;two');", '.exit'] },
         { ending: 'EOF', lines: ["INSERT INTO notes(body) VALUES ('one;two');"] },

--- a/tests/database-writable-pull-command.test.ts
+++ b/tests/database-writable-pull-command.test.ts
@@ -454,6 +454,46 @@ describe('database pull --writable foreground attached session', () => {
         expect(test.closed).toEqual([1]);
     });
 
+    it('shares hardened SQL framing for comments, quoted identifiers, and trigger bodies', async () => {
+        const databasePullWithConfig = await requirePull();
+        const root = tempRoot();
+        const trigger = [
+            'CREATE TRIGGER "audit;insert" AFTER INSERT ON "source;table" BEGIN',
+            "  INSERT INTO audit_log(message) VALUES ('first; body');",
+            "  UPDATE audit_log SET message = CASE WHEN message = 'first; body' THEN 'updated' ELSE message END;",
+            'END;',
+        ];
+        const test = writableHarness(root, {
+            lines: [
+                '-- comment semicolon; is not a statement boundary',
+                'CREATE TABLE "source;table" (id INTEGER);',
+                ...trigger,
+                '.exit',
+            ],
+        });
+
+        await databasePullWithConfig(
+            'Analytics',
+            path.join(root, 'analytics.db'),
+            { writable: true },
+            CONFIG,
+            test.dependencies,
+        );
+
+        expect(test.executions).toEqual([
+            {
+                client: 1,
+                method: 'execute',
+                sql: '-- comment semicolon; is not a statement boundary\nCREATE TABLE "source;table" (id INTEGER);',
+            },
+            {
+                client: 1,
+                method: 'execute',
+                sql: trigger.join('\n'),
+            },
+        ]);
+    });
+
     it('refuses .exit with incomplete buffered SQL without executing or replacing an old target', async () => {
         const databasePullWithConfig = await requirePull();
         const root = tempRoot();

--- a/tests/database-writable-pull-command.test.ts
+++ b/tests/database-writable-pull-command.test.ts
@@ -58,6 +58,7 @@ interface HarnessOptions {
     mint?: (attempt: number) => Promise<Record<string, unknown>>;
     execute?: (execution: Execution) => Promise<unknown>;
     sync?: (client: number, config: Record<string, unknown>) => Promise<void>;
+    close?: (client: number, config: Record<string, unknown>) => Promise<void>;
     finalize?: () => Promise<unknown>;
     abortSignal?: AbortSignal;
 }
@@ -133,6 +134,7 @@ function writableHarness(root: string, options: HarnessOptions = {}) {
                     close: async () => {
                         closed.push(client);
                         events.push(`client:${client}:close`);
+                        await options.close?.(client, config);
                     },
                 };
             },
@@ -533,6 +535,208 @@ describe('database pull --writable foreground attached session', () => {
         )).rejects.toThrow(/temporary|already exists|failed/i);
         expect(collision.posts).toEqual([]);
         expect(fs.readFileSync(temp, 'utf8')).toBe('SOMEONE ELSES TEMP');
+    });
+
+    it.each([
+        { ending: 'immediate EOF', lines: [] },
+        { ending: 'whitespace EOF', lines: ['', '   ', '\t'] },
+        { ending: 'whitespace .exit', lines: ['', '   ', '.exit'] },
+    ])('treats $ending as an empty session and publishes normally', async ({ lines }) => {
+        const databasePullWithConfig = await requirePull();
+        const root = tempRoot();
+        const target = path.join(root, 'analytics.db');
+        const test = writableHarness(root, { lines });
+
+        await databasePullWithConfig('Analytics', target, { writable: true }, CONFIG, test.dependencies);
+
+        expect(test.stdout[0]).toBe(WARNING);
+        expect(test.executions).toEqual([]);
+        expect(test.closed).toEqual([1]);
+        expect(test.finalizerConfigs).toHaveLength(1);
+        expect(fs.statSync(target).mode & 0o777).toBe(0o444);
+        expect(fs.readdirSync(root)).toEqual(['analytics.db']);
+    });
+
+    it.each(['normal exit', 'proactive renewal'] as const)(
+        '%s close failure preserves the old target without finalization or further mint/input',
+        async (phase) => {
+            const databasePullWithConfig = await requirePull();
+            const root = tempRoot();
+            const target = path.join(root, 'analytics.db');
+            const temp = path.join(root, '.analytics.db.solidactions-task8.tmp');
+            fs.writeFileSync(target, 'OLD REPLICA');
+            let now = Date.parse('2026-08-07T12:00:00.000Z');
+            const lines = phase === 'normal exit' ? ['.exit'] : ['SELECT 1;', 'SELECT 2;'];
+            const test = writableHarness(root, {
+                lines,
+                now: () => now,
+                execute: async () => {
+                    now = Date.parse('2026-08-07T12:09:31.000Z');
+                    return { columns: ['value'], rows: [['1']], rowsAffected: 0 };
+                },
+                close: async (client) => {
+                    if (client === 1) throw new Error('RAW_TRANSPORT_SECRET close failure');
+                },
+            });
+
+            let caught: unknown;
+            try {
+                await databasePullWithConfig(
+                    'Analytics',
+                    target,
+                    { writable: true, yes: true },
+                    CONFIG,
+                    test.dependencies,
+                );
+            } catch (error) {
+                caught = error;
+            }
+
+            expect(caught).toBeDefined();
+            expect(test.closed).toEqual([1]);
+            expect(test.posts).toHaveLength(1);
+            expect(test.events).not.toContain('input:2');
+            expect(test.finalizerConfigs).toEqual([]);
+            expect(fs.readFileSync(target, 'utf8')).toBe('OLD REPLICA');
+            expect(fs.existsSync(temp)).toBe(false);
+            for (const suffix of ['-wal', '-shm', '-journal', '-client_wal_index']) {
+                expect(fs.existsSync(`${temp}${suffix}`)).toBe(false);
+            }
+            expectNoSecrets(caught);
+            expectNoSecrets(test.stdout);
+            expectNoSecrets(test.stderr);
+        },
+    );
+
+    it('does not publish a replica when the replacement renewal client fails to sync', async () => {
+        const databasePullWithConfig = await requirePull();
+        const root = tempRoot();
+        const target = path.join(root, 'analytics.db');
+        const temp = path.join(root, '.analytics.db.solidactions-task8.tmp');
+        fs.writeFileSync(target, 'OLD REPLICA');
+        let now = Date.parse('2026-08-07T12:00:00.000Z');
+        const test = writableHarness(root, {
+            lines: ['SELECT 1;', 'DELETE FROM audit_log;'],
+            now: () => now,
+            expiresAt: ['2026-08-07T12:10:00.000Z', '2026-08-07T12:20:00.000Z'],
+            execute: async () => {
+                now = Date.parse('2026-08-07T12:09:31.000Z');
+                return { columns: ['value'], rows: [['1']], rowsAffected: 0 };
+            },
+            sync: async (client) => {
+                if (client === 2) throw new Error('RAW_TRANSPORT_SECRET partial renewal sync');
+            },
+        });
+
+        let caught: unknown;
+        try {
+            await databasePullWithConfig(
+                'Analytics',
+                target,
+                { writable: true, yes: true },
+                CONFIG,
+                test.dependencies,
+            );
+        } catch (error) {
+            caught = error;
+        }
+
+        expect(caught).toBeDefined();
+        expect(test.posts).toHaveLength(2);
+        expect(test.closed).toEqual([1, 2]);
+        expect(test.events).not.toContain('input:2');
+        expect(test.finalizerConfigs).toEqual([]);
+        expect(fs.readFileSync(target, 'utf8')).toBe('OLD REPLICA');
+        expect(fs.existsSync(temp)).toBe(false);
+        for (const suffix of ['-wal', '-shm', '-journal', '-client_wal_index']) {
+            expect(fs.existsSync(`${temp}${suffix}`)).toBe(false);
+        }
+        expectNoSecrets(caught);
+    });
+
+    it('refuses a substituted temp symlink before credential-free finalization or chmod', async () => {
+        const databasePullWithConfig = await requirePull();
+        const root = tempRoot();
+        const target = path.join(root, 'analytics.db');
+        const temp = path.join(root, '.analytics.db.solidactions-task8.tmp');
+        const victim = path.join(root, 'victim.db');
+        fs.writeFileSync(target, 'OLD REPLICA');
+        fs.writeFileSync(victim, 'VICTIM CONTENT', { mode: 0o640 });
+        const victimMode = fs.statSync(victim).mode & 0o777;
+        const test = writableHarness(root, {
+            lines: ['.exit'],
+            close: async (client) => {
+                if (client !== 1) return;
+                fs.unlinkSync(temp);
+                fs.symlinkSync(victim, temp);
+            },
+        });
+
+        let caught: unknown;
+        try {
+            await databasePullWithConfig(
+                'Analytics',
+                target,
+                { writable: true, yes: true },
+                CONFIG,
+                test.dependencies,
+            );
+        } catch (error) {
+            caught = error;
+        }
+
+        expect(caught).toBeDefined();
+        expect(test.finalizerConfigs).toEqual([]);
+        expect(fs.readFileSync(target, 'utf8')).toBe('OLD REPLICA');
+        expect(fs.existsSync(temp)).toBe(false);
+        expect(fs.readFileSync(victim, 'utf8')).toBe('VICTIM CONTENT');
+        expect(fs.statSync(victim).mode & 0o777).toBe(victimMode);
+        expectNoSecrets(caught);
+    });
+
+    it.each([
+        { label: 'at the window', expiresAt: '2026-08-07T12:00:30.000Z' },
+        { label: 'inside the window', expiresAt: '2026-08-07T12:00:29.999Z' },
+    ])('rejects access expiring $label before attached client creation or input', async ({ expiresAt }) => {
+        const databasePullWithConfig = await requirePull();
+        const root = tempRoot();
+        const target = path.join(root, 'analytics.db');
+        const temp = path.join(root, '.analytics.db.solidactions-task8.tmp');
+        fs.writeFileSync(target, 'OLD REPLICA');
+        const test = writableHarness(root, {
+            lines: ['DELETE FROM audit_log;'],
+            mint: async (attempt) => {
+                if (attempt > 1) throw new Error('SECOND_MINT_MUST_NOT_HAPPEN');
+                return {
+                    url: 'libsql://physical-hostname.sentinel.invalid',
+                    token: 'fresh-write-token-sentinel-1',
+                    mode: 'write',
+                    expires_at: expiresAt,
+                };
+            },
+        });
+
+        let caught: unknown;
+        try {
+            await databasePullWithConfig(
+                'Analytics',
+                target,
+                { writable: true, yes: true },
+                CONFIG,
+                test.dependencies,
+            );
+        } catch (error) {
+            caught = error;
+        }
+
+        expect(caught).toBeDefined();
+        expect(test.posts).toHaveLength(1);
+        expect(test.attachedConfigs).toEqual([]);
+        expect(test.finalizerConfigs).toEqual([]);
+        expect(test.events.some((event) => event.startsWith('input:'))).toBe(false);
+        expect(fs.readFileSync(target, 'utf8')).toBe('OLD REPLICA');
+        expect(fs.existsSync(temp)).toBe(false);
+        expectNoSecrets(caught);
     });
 
     it.each(['setup', 'finalization'] as const)(

--- a/tests/database-writable-pull-command.test.ts
+++ b/tests/database-writable-pull-command.test.ts
@@ -1,0 +1,544 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const CONFIG = {
+    host: 'https://app.example.test',
+    apiKey: 'control-plane-pat-sentinel',
+    workspaceId: 'workspace-1146',
+};
+
+const WARNING = 'Writable live session: writes go to the live workspace database.';
+const roots: string[] = [];
+
+afterEach(() => {
+    for (const root of roots.splice(0)) {
+        fs.chmodSync(root, 0o700);
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+});
+
+async function requirePull(): Promise<Function> {
+    const url = pathToFileURL(path.resolve(__dirname, '../src/commands/database.ts')).href;
+    const module = await import(url) as Record<string, unknown>;
+    expect(module.databasePullWithConfig, 'databasePullWithConfig export').toBeTypeOf('function');
+    return module.databasePullWithConfig as Function;
+}
+
+function tempRoot(): string {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'sa-database-writable-pull-'));
+    roots.push(root);
+    return root;
+}
+
+function lineSource(
+    lines: string[],
+    onRead: (line: string, index: number) => void = () => undefined,
+): AsyncIterable<string> {
+    return {
+        async *[Symbol.asyncIterator]() {
+            for (const [index, line] of lines.entries()) {
+                onRead(line, index);
+                yield line;
+            }
+        },
+    };
+}
+
+type Execution = { client: number; method: 'execute' | 'executeMultiple'; sql: string };
+
+interface HarnessOptions {
+    lines?: string[];
+    input?: AsyncIterable<string>;
+    onRead?: (line: string, index: number) => void;
+    now?: () => number;
+    expiresAt?: string[];
+    mint?: (attempt: number) => Promise<Record<string, unknown>>;
+    execute?: (execution: Execution) => Promise<unknown>;
+    sync?: (client: number, config: Record<string, unknown>) => Promise<void>;
+    finalize?: () => Promise<unknown>;
+    abortSignal?: AbortSignal;
+}
+
+function writableHarness(root: string, options: HarnessOptions = {}) {
+    const events: string[] = [];
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const posts: Array<{ url: string; body: Record<string, unknown>; options: Record<string, unknown> }> = [];
+    const attachedConfigs: Record<string, unknown>[] = [];
+    const finalizerConfigs: Record<string, unknown>[] = [];
+    const executions: Execution[] = [];
+    const closed: number[] = [];
+    const expiresAt = options.expiresAt ?? ['2026-08-07T12:10:00.000Z'];
+    let attached = 0;
+
+    const dependencies: Record<string, unknown> = {
+        cwd: root,
+        tempPath: (target: string) => path.join(path.dirname(target), `.${path.basename(target)}.solidactions-task8.tmp`),
+        now: options.now ?? (() => Date.parse('2026-08-07T12:00:00.000Z')),
+        input: options.input ?? lineSource(options.lines ?? ['.exit'], (line, index) => {
+            events.push(`input:${index + 1}`);
+            options.onRead?.(line, index);
+        }),
+        abortSignal: options.abortSignal,
+        loadClient: async () => ({
+            createClient: (config: Record<string, unknown>) => {
+                if (!Object.prototype.hasOwnProperty.call(config, 'syncUrl')) {
+                    finalizerConfigs.push(config);
+                    events.push('finalizer:create');
+                    return {
+                        execute: async (statement: unknown) => {
+                            events.push('finalizer:checkpoint');
+                            expect(statement).toBe('PRAGMA wal_checkpoint(TRUNCATE)');
+                            return options.finalize?.() ?? {
+                                columns: ['busy', 'log', 'checkpointed'],
+                                rows: [['0', '1', '1']],
+                            };
+                        },
+                        close: async () => events.push('finalizer:close'),
+                    };
+                }
+
+                const client = ++attached;
+                attachedConfigs.push(config);
+                events.push(`client:${client}:create`);
+                const temp = fileURLToPath(String(config.url));
+                fs.writeFileSync(temp, `ATTACHED REPLICA ${client}`);
+
+                const run = async (method: Execution['method'], statement: unknown) => {
+                    const execution = { client, method, sql: String(statement) };
+                    executions.push(execution);
+                    events.push(`client:${client}:${method}`);
+                    return options.execute?.(execution) ?? {
+                        columns: [],
+                        rows: [],
+                        rowsAffected: 1,
+                        lastInsertRowid: undefined,
+                    };
+                };
+
+                return {
+                    sync: async () => {
+                        events.push(`client:${client}:sync`);
+                        await options.sync?.(client, config);
+                        fs.writeFileSync(`${temp}-wal`, `OWNED WAL ${client}`);
+                        fs.writeFileSync(`${temp}-shm`, `OWNED SHM ${client}`);
+                        fs.writeFileSync(`${temp}-client_wal_index`, `OWNED INDEX ${client}`);
+                    },
+                    execute: (statement: unknown) => run('execute', statement),
+                    executeMultiple: (statement: unknown) => run('executeMultiple', statement),
+                    close: async () => {
+                        closed.push(client);
+                        events.push(`client:${client}:close`);
+                    },
+                };
+            },
+        }),
+        post: async (url: string, body: Record<string, unknown>, requestOptions: Record<string, unknown>) => {
+            const attempt = posts.length + 1;
+            posts.push({ url, body, options: requestOptions });
+            events.push(`mint:${attempt}`);
+            if (options.mint) {
+                return { data: await options.mint(attempt) };
+            }
+            return {
+                data: {
+                    url: 'libsql://physical-hostname.sentinel.invalid',
+                    token: `fresh-write-token-sentinel-${attempt}`,
+                    mode: 'write',
+                    expires_at: expiresAt[Math.min(attempt - 1, expiresAt.length - 1)],
+                },
+            };
+        },
+        stdout: (line: string) => {
+            stdout.push(line);
+            events.push(`stdout:${line}`);
+        },
+        stderr: (line: string) => {
+            stderr.push(line);
+            events.push('stderr');
+        },
+        confirm: vi.fn(async () => true as boolean | undefined),
+        isTTY: true,
+    };
+
+    return {
+        events,
+        stdout,
+        stderr,
+        posts,
+        attachedConfigs,
+        finalizerConfigs,
+        executions,
+        closed,
+        dependencies,
+    };
+}
+
+function expectWriteAccess(posts: ReturnType<typeof writableHarness>['posts']): void {
+    expect(posts.length).toBeGreaterThan(0);
+    for (const post of posts) {
+        expect(post).toEqual({
+            url: 'https://app.example.test/api/v1/databases',
+            body: { operation: 'access', name: 'Analytics', mode: 'write' },
+            options: {
+                headers: {
+                    Accept: 'application/json',
+                    Authorization: 'Bearer control-plane-pat-sentinel',
+                    'Content-Type': 'application/json',
+                    'X-Workspace-Id': 'workspace-1146',
+                },
+            },
+        });
+    }
+}
+
+function expectNoSecrets(value: unknown): void {
+    const rendered = typeof value === 'string' ? value : JSON.stringify(value);
+    expect(rendered).not.toContain(CONFIG.apiKey);
+    expect(rendered).not.toContain('fresh-write-token-sentinel');
+    expect(rendered).not.toContain('physical-hostname.sentinel.invalid');
+    expect(rendered).not.toContain('RAW_TRANSPORT_SECRET');
+}
+
+describe('database pull --writable foreground attached session', () => {
+    it.each([
+        { ending: '.exit', lines: ["INSERT INTO notes(body) VALUES ('one;two');", '.exit'] },
+        { ending: 'EOF', lines: ["INSERT INTO notes(body) VALUES ('one;two');"] },
+    ])('warns before consuming SQL and cleanly finalizes one write-through client on $ending', async ({ lines }) => {
+        const databasePullWithConfig = await requirePull();
+        const root = tempRoot();
+        const target = path.join(root, 'analytics.db');
+        const test = writableHarness(root, {
+            lines,
+        });
+
+        await databasePullWithConfig('Analytics', target, { writable: true }, CONFIG, test.dependencies);
+
+        expect(test.stdout[0]).toBe(WARNING);
+        expect(test.events.indexOf(`stdout:${WARNING}`)).toBeLessThan(test.events.indexOf('input:1'));
+        expectWriteAccess(test.posts);
+        expect(test.attachedConfigs).toEqual([{
+            url: pathToFileURL(path.join(root, '.analytics.db.solidactions-task8.tmp')).href,
+            syncUrl: 'libsql://physical-hostname.sentinel.invalid',
+            authToken: 'fresh-write-token-sentinel-1',
+            intMode: 'string',
+            readYourWrites: true,
+            offline: false,
+        }]);
+        expect(test.events.indexOf('client:1:sync')).toBeLessThan(test.events.indexOf('input:1'));
+        expect(test.executions).toEqual([{
+            client: 1,
+            method: 'execute',
+            sql: "INSERT INTO notes(body) VALUES ('one;two');",
+        }]);
+        expect(test.closed).toEqual([1]);
+        expect(test.events.indexOf('client:1:close')).toBeLessThan(test.events.indexOf('finalizer:create'));
+        expect(test.finalizerConfigs).toEqual([{
+            url: pathToFileURL(path.join(root, '.analytics.db.solidactions-task8.tmp')).href,
+            intMode: 'string',
+        }]);
+        expect(fs.statSync(target).mode & 0o777).toBe(0o444);
+        expectNoSecrets(fs.readFileSync(target));
+        expectNoSecrets(test.stdout);
+        expectNoSecrets(test.stderr);
+    });
+
+    it('accumulates multiline SQL and keeps an explicit transaction in one execution group', async () => {
+        const databasePullWithConfig = await requirePull();
+        const root = tempRoot();
+        const test = writableHarness(root, {
+            lines: [
+                "INSERT INTO notes(body) VALUES ('first;",
+                "second');",
+                'BEGIN;',
+                "INSERT INTO notes(body) VALUES ('inside; transaction');",
+                'COMMIT;',
+                '.exit',
+            ],
+        });
+
+        await databasePullWithConfig('Analytics', path.join(root, 'analytics.db'), { writable: true }, CONFIG, test.dependencies);
+
+        expect(test.executions).toHaveLength(2);
+        expect(test.executions[0]).toEqual({
+            client: 1,
+            method: 'execute',
+            sql: "INSERT INTO notes(body) VALUES ('first;\nsecond');",
+        });
+        expect(test.executions[1].client).toBe(1);
+        expect(test.executions[1].method).toBe('executeMultiple');
+        expect(test.executions[1].sql).toBe("BEGIN;\nINSERT INTO notes(body) VALUES ('inside; transaction');\nCOMMIT;");
+    });
+
+    it('renews 30 seconds before expiry before asking the input source for another line', async () => {
+        const databasePullWithConfig = await requirePull();
+        const root = tempRoot();
+        let now = Date.parse('2026-08-07T12:00:00.000Z');
+        const test = writableHarness(root, {
+            now: () => now,
+            expiresAt: ['2026-08-07T12:10:00.000Z', '2026-08-07T12:20:00.000Z'],
+            lines: ['SELECT 1;', 'SELECT 2;', '.exit'],
+            execute: async ({ sql }) => {
+                if (sql === 'SELECT 1;') now = Date.parse('2026-08-07T12:09:31.000Z');
+                return { columns: ['value'], rows: [['1']], rowsAffected: 0 };
+            },
+        });
+
+        await databasePullWithConfig('Analytics', path.join(root, 'analytics.db'), { writable: true }, CONFIG, test.dependencies);
+
+        expectWriteAccess(test.posts);
+        expect(test.posts).toHaveLength(2);
+        expect(test.events.indexOf('client:1:close')).toBeLessThan(test.events.indexOf('mint:2'));
+        expect(test.events.indexOf('mint:2')).toBeLessThan(test.events.indexOf('client:2:sync'));
+        expect(test.events.indexOf('client:2:sync')).toBeLessThan(test.events.indexOf('input:2'));
+        expect(test.attachedConfigs[0].url).toBe(test.attachedConfigs[1].url);
+        expect(test.attachedConfigs.map((config) => config.authToken)).toEqual([
+            'fresh-write-token-sentinel-1',
+            'fresh-write-token-sentinel-2',
+        ]);
+        expect(test.executions.map(({ client, sql }) => ({ client, sql }))).toEqual([
+            { client: 1, sql: 'SELECT 1;' },
+            { client: 2, sql: 'SELECT 2;' },
+        ]);
+        expect(test.closed).toEqual([1, 2]);
+    });
+
+    it('stops before consuming more input when proactive renewal is refused', async () => {
+        const databasePullWithConfig = await requirePull();
+        const root = tempRoot();
+        let now = Date.parse('2026-08-07T12:00:00.000Z');
+        const test = writableHarness(root, {
+            now: () => now,
+            lines: ['SELECT 1;', 'DELETE FROM audit_log;', '.exit'],
+            execute: async () => {
+                now = Date.parse('2026-08-07T12:09:31.000Z');
+                return { columns: ['value'], rows: [['1']], rowsAffected: 0 };
+            },
+            mint: async (attempt) => {
+                if (attempt === 2) throw new Error('RAW_TRANSPORT_SECRET fuse denied');
+                return {
+                    url: 'libsql://physical-hostname.sentinel.invalid',
+                    token: 'fresh-write-token-sentinel-1',
+                    mode: 'write',
+                    expires_at: '2026-08-07T12:10:00.000Z',
+                };
+            },
+        });
+
+        let caught: unknown;
+        try {
+            await databasePullWithConfig('Analytics', path.join(root, 'analytics.db'), { writable: true }, CONFIG, test.dependencies);
+        } catch (error) {
+            caught = error;
+        }
+
+        expect(test.events).toContain('mint:2');
+        expect(test.events).not.toContain('input:2');
+        expect(test.executions.map(({ sql }) => sql)).toEqual(['SELECT 1;']);
+        expect(test.closed).toEqual([1]);
+        expectNoSecrets(caught);
+        expectNoSecrets(test.stdout);
+        expectNoSecrets(test.stderr);
+    });
+
+    it('never replays an auth-expired statement and renews only for subsequent input', async () => {
+        const databasePullWithConfig = await requirePull();
+        const root = tempRoot();
+        const test = writableHarness(root, {
+            lines: ["INSERT INTO ledger(value) VALUES ('once');", 'SELECT count(*) FROM ledger;', '.exit'],
+            execute: async ({ client, sql }) => {
+                if (client === 1) {
+                    throw Object.assign(new Error('RAW_TRANSPORT_SECRET fresh-write-token-sentinel-1'), {
+                        code: 'AUTH_TOKEN_EXPIRED',
+                    });
+                }
+                return { columns: ['count(*)'], rows: [['1']], rowsAffected: 0 };
+            },
+        });
+
+        await databasePullWithConfig('Analytics', path.join(root, 'analytics.db'), { writable: true }, CONFIG, test.dependencies);
+
+        expect(test.posts).toHaveLength(2);
+        expect(test.executions.map(({ client, sql }) => ({ client, sql }))).toEqual([
+            { client: 1, sql: "INSERT INTO ledger(value) VALUES ('once');" },
+            { client: 2, sql: 'SELECT count(*) FROM ledger;' },
+        ]);
+        expect(test.events.indexOf('client:1:close')).toBeLessThan(test.events.indexOf('mint:2'));
+        expect(test.stderr.join('\n')).toMatch(/unknown outcome/i);
+        expectNoSecrets(test.stderr);
+    });
+
+    it('reports a non-auth execution failure safely and continues without reminting', async () => {
+        const databasePullWithConfig = await requirePull();
+        const root = tempRoot();
+        const test = writableHarness(root, {
+            lines: ['BROKEN SQL;', 'SELECT 2;', '.exit'],
+            execute: async ({ sql }) => {
+                if (sql === 'BROKEN SQL;') throw new Error('RAW_TRANSPORT_SECRET syntax detail');
+                return { columns: ['2'], rows: [['2']], rowsAffected: 0 };
+            },
+        });
+
+        await databasePullWithConfig('Analytics', path.join(root, 'analytics.db'), { writable: true }, CONFIG, test.dependencies);
+
+        expect(test.posts).toHaveLength(1);
+        expect(test.executions.map(({ sql }) => sql)).toEqual(['BROKEN SQL;', 'SELECT 2;']);
+        expect(test.stderr).toHaveLength(1);
+        expectNoSecrets(test.stderr);
+        expect(test.closed).toEqual([1]);
+    });
+
+    it('refuses incomplete SQL at EOF without executing or replacing an old target', async () => {
+        const databasePullWithConfig = await requirePull();
+        const root = tempRoot();
+        const target = path.join(root, 'analytics.db');
+        fs.writeFileSync(target, 'OLD REPLICA');
+        const test = writableHarness(root, { lines: ["INSERT INTO notes(body) VALUES ('unfinished;"] });
+
+        let caught: unknown;
+        try {
+            await databasePullWithConfig('Analytics', target, { writable: true, yes: true }, CONFIG, test.dependencies);
+        } catch (error) {
+            caught = error;
+        }
+
+        expect(String((caught as Error)?.message ?? caught)).toMatch(/incomplete/i);
+        expect(test.executions).toEqual([]);
+        expect(test.closed).toEqual([1]);
+        expect(fs.readFileSync(target, 'utf8')).toBe('OLD REPLICA');
+        expect(fs.existsSync(path.join(root, '.analytics.db.solidactions-task8.tmp'))).toBe(false);
+        expectNoSecrets(caught);
+    });
+
+    it('treats abort as an interrupt, consumes no later SQL, and publishes a read-only credential-free replica', async () => {
+        const databasePullWithConfig = await requirePull();
+        const root = tempRoot();
+        const controller = new AbortController();
+        let reads = 0;
+        const test = writableHarness(root, {
+            abortSignal: controller.signal,
+            input: {
+                [Symbol.asyncIterator]() {
+                    return {
+                        async next() {
+                            reads += 1;
+                            if (reads === 1) return { done: false as const, value: 'SELECT 1;' };
+                            controller.abort();
+                            return { done: true as const, value: undefined };
+                        },
+                    };
+                },
+            },
+        });
+        const target = path.join(root, 'analytics.db');
+
+        await databasePullWithConfig('Analytics', target, { writable: true }, CONFIG, test.dependencies);
+
+        expect(test.executions.map(({ sql }) => sql)).toEqual(['SELECT 1;']);
+        expect(reads).toBe(2);
+        expect(test.closed).toEqual([1]);
+        expect(test.finalizerConfigs).toHaveLength(1);
+        expect(fs.statSync(target).mode & 0o777).toBe(0o444);
+        expect(fs.readdirSync(root)).toEqual(['analytics.db']);
+        expectNoSecrets(fs.readFileSync(target));
+    });
+
+    it('preserves confirmation and exclusive-temp safety before write access or input', async () => {
+        const databasePullWithConfig = await requirePull();
+        const root = tempRoot();
+        const target = path.join(root, 'analytics.db');
+        fs.writeFileSync(target, 'OLD REPLICA');
+        const declined = writableHarness(root, { lines: ['DELETE FROM audit_log;'] });
+        declined.dependencies.confirm = vi.fn(async () => false);
+
+        await databasePullWithConfig('Analytics', target, { writable: true }, CONFIG, declined.dependencies);
+
+        expect(declined.posts).toEqual([]);
+        expect(declined.events.some((event) => event.startsWith('input:'))).toBe(false);
+        expect(fs.readFileSync(target, 'utf8')).toBe('OLD REPLICA');
+
+        const temp = path.join(root, '.analytics.db.solidactions-task8.tmp');
+        fs.writeFileSync(temp, 'SOMEONE ELSES TEMP');
+        const collision = writableHarness(root);
+        await expect(databasePullWithConfig(
+            'Analytics',
+            target,
+            { writable: true, yes: true },
+            CONFIG,
+            collision.dependencies,
+        )).rejects.toThrow(/temporary|already exists|failed/i);
+        expect(collision.posts).toEqual([]);
+        expect(fs.readFileSync(temp, 'utf8')).toBe('SOMEONE ELSES TEMP');
+    });
+
+    it.each(['setup', 'finalization'] as const)(
+        '%s failure preserves the old target and removes only owned temporary artifacts',
+        async (failure) => {
+            const databasePullWithConfig = await requirePull();
+            const root = tempRoot();
+            const target = path.join(root, 'analytics.db');
+            const temp = path.join(root, '.analytics.db.solidactions-task8.tmp');
+            const unrelated = path.join(root, '.unrelated.tmp');
+            fs.writeFileSync(target, 'OLD REPLICA');
+            fs.writeFileSync(unrelated, 'DO NOT REMOVE');
+            const test = writableHarness(root, {
+                lines: ['.exit'],
+                sync: async () => {
+                    if (failure === 'setup') throw new Error('RAW_TRANSPORT_SECRET setup');
+                },
+                finalize: async () => {
+                    if (failure === 'finalization') throw new Error('RAW_TRANSPORT_SECRET checkpoint');
+                    return { columns: ['busy', 'log', 'checkpointed'], rows: [['0', '0', '0']] };
+                },
+            });
+
+            let caught: unknown;
+            try {
+                await databasePullWithConfig('Analytics', target, { writable: true, yes: true }, CONFIG, test.dependencies);
+            } catch (error) {
+                caught = error;
+            }
+
+            expect(caught).toBeDefined();
+            expect(test.posts.length).toBeGreaterThan(0);
+            if (failure === 'setup') expect(test.events).toContain('client:1:sync');
+            else expect(test.events).toContain('finalizer:checkpoint');
+            expect(fs.readFileSync(target, 'utf8')).toBe('OLD REPLICA');
+            expect(fs.readFileSync(unrelated, 'utf8')).toBe('DO NOT REMOVE');
+            expect(fs.existsSync(temp)).toBe(false);
+            for (const suffix of ['-wal', '-shm', '-journal', '-client_wal_index']) {
+                expect(fs.existsSync(`${temp}${suffix}`)).toBe(false);
+            }
+            expectNoSecrets(caught);
+            expectNoSecrets(test.stdout);
+            expectNoSecrets(test.stderr);
+        },
+    );
+
+    it('fails closed on an invalid expires_at without accepting SQL or leaking access metadata', async () => {
+        const databasePullWithConfig = await requirePull();
+        const root = tempRoot();
+        const test = writableHarness(root, {
+            lines: ['DELETE FROM audit_log;'],
+            expiresAt: ['not-a-timestamp'],
+        });
+
+        let caught: unknown;
+        try {
+            await databasePullWithConfig('Analytics', path.join(root, 'analytics.db'), { writable: true }, CONFIG, test.dependencies);
+        } catch (error) {
+            caught = error;
+        }
+
+        expect(caught).toBeDefined();
+        expect(test.posts).toHaveLength(1);
+        expect(test.events.some((event) => event.startsWith('input:'))).toBe(false);
+        expect(test.executions).toEqual([]);
+        expectNoSecrets(caught);
+        expectNoSecrets(test.stdout);
+        expectNoSecrets(test.stderr);
+    });
+});

--- a/tests/database-writable-pull-command.test.ts
+++ b/tests/database-writable-pull-command.test.ts
@@ -227,6 +227,8 @@ describe('database pull --writable foreground attached session', () => {
         await databasePullWithConfig('Analytics', target, { writable: true }, CONFIG, test.dependencies);
 
         expect(test.stdout[0]).toBe(WARNING);
+        expect(test.events.indexOf('mint:1')).toBeLessThan(test.events.indexOf(`stdout:${WARNING}`));
+        expect(test.events.indexOf('client:1:sync')).toBeLessThan(test.events.indexOf(`stdout:${WARNING}`));
         expect(test.events.indexOf(`stdout:${WARNING}`)).toBeLessThan(test.events.indexOf('input:1'));
         expectWriteAccess(test.posts);
         expect(test.attachedConfigs).toEqual([{

--- a/tests/database-writable-pull-command.test.ts
+++ b/tests/database-writable-pull-command.test.ts
@@ -111,7 +111,8 @@ function writableHarness(root: string, options: HarnessOptions = {}) {
                     const execution = { client, method, sql: String(statement) };
                     executions.push(execution);
                     events.push(`client:${client}:${method}`);
-                    return options.execute?.(execution) ?? {
+                    if (options.execute) return options.execute(execution);
+                    return {
                         columns: [],
                         rows: [],
                         rowsAffected: 1,
@@ -196,7 +197,13 @@ function expectWriteAccess(posts: ReturnType<typeof writableHarness>['posts']): 
 }
 
 function expectNoSecrets(value: unknown): void {
-    const rendered = typeof value === 'string' ? value : JSON.stringify(value);
+    const rendered = Buffer.isBuffer(value)
+        ? value.toString('utf8')
+        : value instanceof Uint8Array
+            ? Buffer.from(value).toString('utf8')
+            : typeof value === 'string'
+                ? value
+                : JSON.stringify(value);
     expect(rendered).not.toContain(CONFIG.apiKey);
     expect(rendered).not.toContain('fresh-write-token-sentinel');
     expect(rendered).not.toContain('physical-hostname.sentinel.invalid');
@@ -273,6 +280,42 @@ describe('database pull --writable foreground attached session', () => {
         expect(test.executions[1].sql).toBe("BEGIN;\nINSERT INTO notes(body) VALUES ('inside; transaction');\nCOMMIT;");
     });
 
+    it('renders SELECT rows, exact DML affected count, and transaction-group success in the human shell', async () => {
+        const databasePullWithConfig = await requirePull();
+        const root = tempRoot();
+        const test = writableHarness(root, {
+            lines: [
+                'SELECT id, body FROM notes;',
+                'UPDATE notes SET body = upper(body);',
+                'BEGIN;',
+                "INSERT INTO notes(body) VALUES ('grouped');",
+                'COMMIT;',
+                '.exit',
+            ],
+            execute: async ({ method, sql }) => {
+                if (method === 'executeMultiple') return undefined;
+                if (sql.startsWith('SELECT')) {
+                    return {
+                        columns: ['id', 'body'],
+                        rows: [['1', 'alpha'], ['2', 'beta']],
+                        rowsAffected: 0,
+                    };
+                }
+                return { columns: [], rows: [], rowsAffected: 3 };
+            },
+        });
+
+        await databasePullWithConfig('Analytics', path.join(root, 'analytics.db'), { writable: true }, CONFIG, test.dependencies);
+
+        expect(test.stdout[0]).toBe(WARNING);
+        expect(test.stdout[1]).toBe('id  body\n-----------\n1   alpha\n2   beta');
+        expect(test.stdout[2]).toBe('Rows affected: 3');
+        const groupOutput = test.stdout[3];
+        expect(groupOutput).toMatch(/success|executed|complete/i);
+        expect(groupOutput).not.toMatch(/rows affected|\bid\b|grouped/i);
+        expect(test.stderr).toEqual([]);
+    });
+
     it('renews 30 seconds before expiry before asking the input source for another line', async () => {
         const databasePullWithConfig = await requirePull();
         const root = tempRoot();
@@ -309,6 +352,8 @@ describe('database pull --writable foreground attached session', () => {
     it('stops before consuming more input when proactive renewal is refused', async () => {
         const databasePullWithConfig = await requirePull();
         const root = tempRoot();
+        const target = path.join(root, 'analytics.db');
+        const temp = path.join(root, '.analytics.db.solidactions-task8.tmp');
         let now = Date.parse('2026-08-07T12:00:00.000Z');
         const test = writableHarness(root, {
             now: () => now,
@@ -318,7 +363,11 @@ describe('database pull --writable foreground attached session', () => {
                 return { columns: ['value'], rows: [['1']], rowsAffected: 0 };
             },
             mint: async (attempt) => {
-                if (attempt === 2) throw new Error('RAW_TRANSPORT_SECRET fuse denied');
+                if (attempt === 2) {
+                    throw Object.assign(new Error('RAW_TRANSPORT_SECRET fuse denied'), {
+                        code: 'database_write_disabled',
+                    });
+                }
                 return {
                     url: 'libsql://physical-hostname.sentinel.invalid',
                     token: 'fresh-write-token-sentinel-1',
@@ -330,15 +379,25 @@ describe('database pull --writable foreground attached session', () => {
 
         let caught: unknown;
         try {
-            await databasePullWithConfig('Analytics', path.join(root, 'analytics.db'), { writable: true }, CONFIG, test.dependencies);
+            await databasePullWithConfig('Analytics', target, { writable: true }, CONFIG, test.dependencies);
         } catch (error) {
             caught = error;
         }
 
+        expect(caught).toBeDefined();
         expect(test.events).toContain('mint:2');
         expect(test.events).not.toContain('input:2');
         expect(test.executions.map(({ sql }) => sql)).toEqual(['SELECT 1;']);
         expect(test.closed).toEqual([1]);
+        expect(test.finalizerConfigs).toEqual([{ url: pathToFileURL(temp).href, intMode: 'string' }]);
+        expect(test.events.indexOf('client:1:close')).toBeLessThan(test.events.indexOf('finalizer:create'));
+        expect(test.events).toContain('finalizer:checkpoint');
+        expect(fs.statSync(target).mode & 0o777).toBe(0o444);
+        expect(fs.existsSync(temp)).toBe(false);
+        for (const suffix of ['-wal', '-shm', '-journal', '-client_wal_index']) {
+            expect(fs.existsSync(`${temp}${suffix}`)).toBe(false);
+        }
+        expectNoSecrets(fs.readFileSync(target));
         expectNoSecrets(caught);
         expectNoSecrets(test.stdout);
         expectNoSecrets(test.stderr);
@@ -351,8 +410,10 @@ describe('database pull --writable foreground attached session', () => {
             lines: ["INSERT INTO ledger(value) VALUES ('once');", 'SELECT count(*) FROM ledger;', '.exit'],
             execute: async ({ client, sql }) => {
                 if (client === 1) {
-                    throw Object.assign(new Error('RAW_TRANSPORT_SECRET fresh-write-token-sentinel-1'), {
-                        code: 'AUTH_TOKEN_EXPIRED',
+                    throw Object.assign(new Error(
+                        'JWT expired: RAW_TRANSPORT_SECRET fresh-write-token-sentinel-1',
+                    ), {
+                        code: 'SQLITE_AUTH',
                     });
                 }
                 return { columns: ['count(*)'], rows: [['1']], rowsAffected: 0 };
@@ -391,12 +452,12 @@ describe('database pull --writable foreground attached session', () => {
         expect(test.closed).toEqual([1]);
     });
 
-    it('refuses incomplete SQL at EOF without executing or replacing an old target', async () => {
+    it('refuses .exit with incomplete buffered SQL without executing or replacing an old target', async () => {
         const databasePullWithConfig = await requirePull();
         const root = tempRoot();
         const target = path.join(root, 'analytics.db');
         fs.writeFileSync(target, 'OLD REPLICA');
-        const test = writableHarness(root, { lines: ["INSERT INTO notes(body) VALUES ('unfinished;"] });
+        const test = writableHarness(root, { lines: ["INSERT INTO notes(body) VALUES ('unfinished;", '.exit'] });
 
         let caught: unknown;
         try {
@@ -504,8 +565,12 @@ describe('database pull --writable foreground attached session', () => {
 
             expect(caught).toBeDefined();
             expect(test.posts.length).toBeGreaterThan(0);
-            if (failure === 'setup') expect(test.events).toContain('client:1:sync');
-            else expect(test.events).toContain('finalizer:checkpoint');
+            if (failure === 'setup') {
+                expect(test.events).toContain('client:1:sync');
+                expect(test.closed).toEqual(test.attachedConfigs.map((_config, index) => index + 1));
+            } else {
+                expect(test.events).toContain('finalizer:checkpoint');
+            }
             expect(fs.readFileSync(target, 'utf8')).toBe('OLD REPLICA');
             expect(fs.readFileSync(unrelated, 'utf8')).toBe('DO NOT REMOVE');
             expect(fs.existsSync(temp)).toBe(false);
@@ -521,6 +586,9 @@ describe('database pull --writable foreground attached session', () => {
     it('fails closed on an invalid expires_at without accepting SQL or leaking access metadata', async () => {
         const databasePullWithConfig = await requirePull();
         const root = tempRoot();
+        const target = path.join(root, 'analytics.db');
+        const temp = path.join(root, '.analytics.db.solidactions-task8.tmp');
+        fs.writeFileSync(target, 'OLD REPLICA');
         const test = writableHarness(root, {
             lines: ['DELETE FROM audit_log;'],
             expiresAt: ['not-a-timestamp'],
@@ -528,15 +596,19 @@ describe('database pull --writable foreground attached session', () => {
 
         let caught: unknown;
         try {
-            await databasePullWithConfig('Analytics', path.join(root, 'analytics.db'), { writable: true }, CONFIG, test.dependencies);
+            await databasePullWithConfig('Analytics', target, { writable: true, yes: true }, CONFIG, test.dependencies);
         } catch (error) {
             caught = error;
         }
 
         expect(caught).toBeDefined();
         expect(test.posts).toHaveLength(1);
+        expect(test.attachedConfigs).toEqual([]);
+        expect(test.finalizerConfigs).toEqual([]);
         expect(test.events.some((event) => event.startsWith('input:'))).toBe(false);
         expect(test.executions).toEqual([]);
+        expect(fs.readFileSync(target, 'utf8')).toBe('OLD REPLICA');
+        expect(fs.existsSync(temp)).toBe(false);
         expectNoSecrets(caught);
         expectNoSecrets(test.stdout);
         expectNoSecrets(test.stderr);

--- a/tests/database-writable-pull-command.test.ts
+++ b/tests/database-writable-pull-command.test.ts
@@ -730,7 +730,8 @@ describe('database pull --writable foreground attached session', () => {
         }
 
         expect(caught).toBeDefined();
-        expect(test.posts).toHaveLength(2);
+        expect(test.posts).toHaveLength(1);
+        expect(test.events).not.toContain('mint:2');
         expect(test.attachedConfigs).toHaveLength(1);
         expect(test.closed).toEqual([1]);
         expect(test.events).not.toContain('input:2');

--- a/tests/database-writable-pull-command.test.ts
+++ b/tests/database-writable-pull-command.test.ts
@@ -694,6 +694,56 @@ describe('database pull --writable foreground attached session', () => {
         expectNoSecrets(caught);
     });
 
+    it('refuses a substituted temp symlink before creating a proactive-renewal client', async () => {
+        const databasePullWithConfig = await requirePull();
+        const root = tempRoot();
+        const target = path.join(root, 'analytics.db');
+        const temp = path.join(root, '.analytics.db.solidactions-task8.tmp');
+        const victim = path.join(root, 'renewal-victim.db');
+        fs.writeFileSync(target, 'OLD REPLICA');
+        fs.writeFileSync(victim, 'RENEWAL VICTIM CONTENT', { mode: 0o640 });
+        const victimMode = fs.statSync(victim).mode & 0o777;
+        let now = Date.parse('2026-08-07T12:00:00.000Z');
+        const test = writableHarness(root, {
+            lines: ['SELECT 1;', 'DELETE FROM audit_log;'],
+            now: () => now,
+            expiresAt: ['2026-08-07T12:10:00.000Z', '2026-08-07T12:20:00.000Z'],
+            execute: async () => {
+                fs.unlinkSync(temp);
+                fs.symlinkSync(victim, temp);
+                now = Date.parse('2026-08-07T12:09:31.000Z');
+                return { columns: ['value'], rows: [['1']], rowsAffected: 0 };
+            },
+        });
+
+        let caught: unknown;
+        try {
+            await databasePullWithConfig(
+                'Analytics',
+                target,
+                { writable: true, yes: true },
+                CONFIG,
+                test.dependencies,
+            );
+        } catch (error) {
+            caught = error;
+        }
+
+        expect(caught).toBeDefined();
+        expect(test.posts).toHaveLength(2);
+        expect(test.attachedConfigs).toHaveLength(1);
+        expect(test.closed).toEqual([1]);
+        expect(test.events).not.toContain('input:2');
+        expect(test.finalizerConfigs).toEqual([]);
+        expect(fs.readFileSync(target, 'utf8')).toBe('OLD REPLICA');
+        expect(fs.existsSync(temp)).toBe(false);
+        expect(fs.readFileSync(victim, 'utf8')).toBe('RENEWAL VICTIM CONTENT');
+        expect(fs.statSync(victim).mode & 0o777).toBe(victimMode);
+        expectNoSecrets(caught);
+        expectNoSecrets(test.stdout);
+        expectNoSecrets(test.stderr);
+    });
+
     it.each([
         { label: 'at the window', expiresAt: '2026-08-07T12:00:30.000Z' },
         { label: 'inside the window', expiresAt: '2026-08-07T12:00:29.999Z' },

--- a/tests/database-writable-pull-command.test.ts
+++ b/tests/database-writable-pull-command.test.ts
@@ -193,6 +193,8 @@ function expectWriteAccess(posts: ReturnType<typeof writableHarness>['posts']): 
                     'Content-Type': 'application/json',
                     'X-Workspace-Id': 'workspace-1146',
                 },
+                signal: expect.any(AbortSignal),
+                timeout: 30_000,
             },
         });
     }

--- a/tests/examples-ref.test.ts
+++ b/tests/examples-ref.test.ts
@@ -20,7 +20,14 @@ import { EXAMPLES_REF } from '../src/utils/examples-ref';
 import { rawContentUrl } from '../src/utils/github';
 import { installSkills, fetchAiHelperContent } from '../src/utils/skills';
 
+const PRE_DATABASE_GUIDANCE_REF = '3ca5fd4d3107659b27889775791f6691cf173303';
+const RELEASE_SMOKE = fs.readFileSync(path.resolve(__dirname, '../scripts/smoke-init.mjs'), 'utf8');
+
 describe('EXAMPLES_REF', () => {
+    it('moves past the pre-database-guidance examples pin', () => {
+        expect(EXAMPLES_REF).not.toBe(PRE_DATABASE_GUIDANCE_REF);
+    });
+
     it('is an immutable ref, not a moving branch', () => {
         expect(EXAMPLES_REF).not.toBe('main');
         expect(EXAMPLES_REF).not.toBe('master');
@@ -109,6 +116,9 @@ describe('solidactions-examples fetches pass the pinned ref at the call site', (
             expect(url).toContain(`/${EXAMPLES_REF}/`);
             expect(url).not.toMatch(/solidactions-examples\/main\//);
         }
+        expect(requested.some((url) => url.endsWith(
+            `/${EXAMPLES_REF}/content/skills/solidactions-deploy-and-config.md`,
+        ))).toBe(true);
     });
 
     it('fetchAiHelperContent requests the helper file at the pinned ref', async () => {
@@ -117,6 +127,13 @@ describe('solidactions-examples fetches pass the pinned ref at the call site', (
 
         expect(requested).toHaveLength(1);
         expect(requested[0]).toContain(`/${EXAMPLES_REF}/`);
+    });
+});
+
+describe('pinned canonical database guidance', () => {
+    it('makes the release smoke inspect the installed deploy skill at the pinned ref', () => {
+        expect(RELEASE_SMOKE).toContain('solidactions-deploy-and-config.md');
+        expect(RELEASE_SMOKE).toContain('## Recipe — Databases');
     });
 });
 

--- a/tests/examples-ref.test.ts
+++ b/tests/examples-ref.test.ts
@@ -24,6 +24,16 @@ const PRE_DATABASE_GUIDANCE_REF = '3ca5fd4d3107659b27889775791f6691cf173303';
 const RELEASE_SMOKE = fs.readFileSync(path.resolve(__dirname, '../scripts/smoke-init.mjs'), 'utf8');
 
 describe('EXAMPLES_REF', () => {
+    it('records the temporary PR-head pin and the mandatory pre-release mainline repin without a fabricated override', () => {
+        const source = fs.readFileSync(path.resolve(__dirname, '../src/utils/examples-ref.ts'), 'utf8');
+
+        expect(source).toContain('temporary build-time necessity');
+        expect(source).toContain('merged mainline SHA');
+        expect(source).toMatch(/before any CLI release/i);
+        expect(source).toMatch(/release ritual/i);
+        expect(source).not.toMatch(/PM[- ]directed|PM delivery override|override explicitly approved/i);
+    });
+
     it('moves past the pre-database-guidance examples pin', () => {
         expect(EXAMPLES_REF).not.toBe(PRE_DATABASE_GUIDANCE_REF);
     });

--- a/tests/fixtures/database-import/sqlite-dump.sql
+++ b/tests/fixtures/database-import/sqlite-dump.sql
@@ -1,0 +1,11 @@
+PRAGMA foreign_keys=OFF;
+BEGIN TRANSACTION;
+CREATE TABLE "audit;events" (id INTEGER PRIMARY KEY, value TEXT NOT NULL);
+INSERT INTO "audit;events" VALUES(1,'one;still one');
+CREATE TRIGGER audit_insert AFTER INSERT ON "audit;events" BEGIN
+  UPDATE "audit;events"
+  SET value = CASE WHEN NEW.value = 'raw;value' THEN 'normalized' ELSE NEW.value END
+  WHERE id = NEW.id;
+END;
+COMMIT;
+PRAGMA foreign_keys=ON;

--- a/tests/readme-contract.test.ts
+++ b/tests/readme-contract.test.ts
@@ -9,6 +9,13 @@ const COMMAND_TAXONOMY = fs.readFileSync(
     'utf8',
 );
 
+function markdownSection(markdown: string, heading: string): string {
+    const start = markdown.indexOf(heading);
+    expect(start, `missing ${heading}`).toBeGreaterThanOrEqual(0);
+    const next = markdown.indexOf('\n## ', start + heading.length);
+    return markdown.slice(start, next === -1 ? undefined : next);
+}
+
 describe('public README setup contract', () => {
     it('uses the secret-safe current login, deploy, and run commands', () => {
         expect(README).toContain('solidactions login --global');
@@ -60,5 +67,43 @@ describe('public README setup contract', () => {
 
         expect(README).not.toContain('omitting `--env` treats `<project>` as an exact slug');
         expect(README).not.toContain('project view has no implicit');
+    });
+
+    it('documents the complete vendor-neutral database CLI and its safety model', () => {
+        const guidance = markdownSection(README, '## Database CLI');
+        const commands = [
+            'solidactions database list',
+            'solidactions database create',
+            'solidactions database delete',
+            'solidactions database undelete',
+            'solidactions database schema',
+            'solidactions database query',
+            'solidactions database exec',
+            'solidactions database dump',
+            'solidactions database pull',
+            'solidactions database import',
+        ];
+
+        for (const command of commands) {
+            expect(guidance, `README missing ${command}`).toContain(command);
+        }
+
+        for (const option of ['--json', '--yes', '--from', '--writable', '--resume']) {
+            expect(guidance, `README missing ${option}`).toContain(option);
+        }
+
+        expect(guidance).toMatch(/soft-delete/i);
+        expect(guidance).toMatch(/purge clock/i);
+        expect(guidance).toMatch(/read-only local replica/i);
+        expect(guidance).toContain('.solidactions/databases/<safe-stem>.db');
+        expect(guidance).toMatch(/foreground/i);
+        expect(guidance).toMatch(/writes go to the live workspace database/i);
+        expect(guidance).toMatch(/no offline (?:merge|write-back)/i);
+        expect(guidance).toMatch(/ephemeral/i);
+        expect(guidance).toMatch(/no durable credential/i);
+        expect(guidance).toMatch(/DOWNLOAD INCOMPLETE/);
+        expect(guidance).toMatch(/checkpoint/i);
+        expect(guidance).toMatch(/avoid|without|no replay/i);
+        expect(guidance).not.toMatch(/turso|libsql/i);
     });
 });


### PR DESCRIPTION
## Summary

- add `solidactions database` list/create/delete/undelete/schema/query/exec/dump/pull/import commands
- add scoped direct libSQL access, atomic read-only replicas, foreground writable sessions, and resumable SQL imports
- publish README/bundled-skill guidance and the generated 103-command manifest

Companion PRs:

- app control plane: SolidActions/solidactions-app#1161
- bundled skill/docs: SolidActions/solidactions-examples#29

## Verification

- `npm run check:release`: 126 files / 1,233 tests
- packed CLI scaffold smoke for Claude and Agents
- generated project build
- production audit: 0 vulnerabilities
- live app/CLI end-to-end smoke for every database verb, writable pull, and import
- context-free Claude cleanroom with `--strict-mcp-config`: PASS
