### PR TITLE
Crew CLI: map workspace databases to variables

### DIFF
--- a/src/commands/crew-env-list.ts
+++ b/src/commands/crew-env-list.ts
@@ -14,6 +14,9 @@ interface CrewVariable {
     production_value: string | null;
     staging_value: string | null;
     dev_value: string | null;
+    source_type?: string;
+    workspace_database_name?: string | null;
+    token?: string;
 }
 
 /**
@@ -43,7 +46,22 @@ export async function crewEnvList(crewArg: string, options: CrewEnvListOptions =
         const variables: CrewVariable[] = response.data?.data ?? [];
 
         if (options.json) {
-            console.log(JSON.stringify(variables, null, 2));
+            const safeVariables = variables.map((variable) => {
+                if (variable.source_type !== 'workspace_database') {
+                    return variable;
+                }
+
+                const {
+                    production_value: _productionValue,
+                    staging_value: _stagingValue,
+                    dev_value: _devValue,
+                    token: _token,
+                    ...metadata
+                } = variable;
+
+                return metadata;
+            });
+            console.log(JSON.stringify(safeVariables, null, 2));
             return;
         }
 
@@ -66,13 +84,16 @@ export async function crewEnvList(crewArg: string, options: CrewEnvListOptions =
 
         for (const variable of variables) {
             const key = variable.env_name || '?';
-            const type = variable.is_secret ? chalk.yellow('secret') : chalk.gray('plain');
+            const isDatabase = variable.source_type === 'workspace_database';
+            const type = isDatabase
+                ? chalk.blue(`database:${variable.workspace_database_name ?? 'not-configured'}`)
+                : variable.is_secret ? chalk.yellow('secret') : chalk.gray('plain');
 
             console.log(
                 key.substring(0, 22).padEnd(24) +
-                formatValue(variable.production_value, variable.is_secret).padEnd(20) +
-                formatValue(variable.staging_value, variable.is_secret).padEnd(20) +
-                formatValue(variable.dev_value, variable.is_secret).padEnd(20) +
+                (isDatabase ? chalk.gray('-') : formatValue(variable.production_value, variable.is_secret)).padEnd(20) +
+                (isDatabase ? chalk.gray('-') : formatValue(variable.staging_value, variable.is_secret)).padEnd(20) +
+                (isDatabase ? chalk.gray('-') : formatValue(variable.dev_value, variable.is_secret)).padEnd(20) +
                 type
             );
         }

--- a/src/commands/crew-env-map-database.ts
+++ b/src/commands/crew-env-map-database.ts
@@ -1,0 +1,81 @@
+import axios from 'axios';
+import chalk from 'chalk';
+import { formatValidationError, getApiHeaders, requireConfigWithWorkspace } from '../utils/api';
+import { resolveCrewId } from '../utils/crew';
+import { requestDatabaseOperation } from '../utils/database-data-plane';
+import { envNameError, isReservedEnvName, isValidEnvName, reservedEnvNameError } from '../utils/env';
+
+export const CREW_DATABASE_SCOPE_WARNING = 'Applies to production, staging, and dev crew sandboxes';
+
+export interface WorkspaceDatabaseListRecord {
+    id: string;
+    name: string;
+    status: string;
+    deleted_at: string | null;
+}
+
+interface WorkspaceDatabaseListResponse {
+    databases: WorkspaceDatabaseListRecord[];
+}
+
+export function matchWorkspaceDatabase(
+    input: string,
+    databases: WorkspaceDatabaseListRecord[],
+): WorkspaceDatabaseListRecord | null {
+    return databases.find((database) => (
+        database.deleted_at === null
+        && database.status === 'ready'
+        && (database.id === input || database.name.toLowerCase() === input.toLowerCase())
+    )) ?? null;
+}
+
+export async function crewEnvMapDatabase(
+    crewArg: string,
+    key: string,
+    databaseArg: string,
+): Promise<void> {
+    if (!isValidEnvName(key)) {
+        console.error(chalk.red(envNameError(key)));
+        process.exit(1);
+    }
+    if (isReservedEnvName(key)) {
+        console.error(chalk.red(reservedEnvNameError(key)));
+        process.exit(1);
+    }
+
+    const config = await requireConfigWithWorkspace();
+    const crew = await resolveCrewId(config, crewArg);
+
+    try {
+        const result = await requestDatabaseOperation<WorkspaceDatabaseListResponse>(
+            config,
+            { operation: 'list' },
+        );
+        const database = matchWorkspaceDatabase(databaseArg, result.databases ?? []);
+        if (!database) {
+            console.error(chalk.red(`Ready database "${databaseArg}" not found in this workspace.`));
+            process.exit(1);
+        }
+
+        await axios.put(
+            `${config.host}/api/v1/crews/${crew.id}/variables/${key}`,
+            {
+                source_type: 'workspace_database',
+                workspace_database_id: database.id,
+            },
+            { headers: getApiHeaders(config, 'application/json') },
+        );
+
+        console.log(chalk.green(`Database "${database.name}" mapped to "${key}" for crew "${crew.name}".`));
+        console.log(chalk.yellow(CREW_DATABASE_SCOPE_WARNING));
+    } catch (error: any) {
+        if (error.response?.status === 422) {
+            console.error(chalk.red(formatValidationError(error.response.data)));
+        } else if (typeof error.message === 'string') {
+            console.error(chalk.red(error.message));
+        } else {
+            console.error(chalk.red('Failed to map the workspace database.'));
+        }
+        process.exit(1);
+    }
+}

--- a/src/commands/database.ts
+++ b/src/commands/database.ts
@@ -32,6 +32,7 @@ import {
 import { renderTable } from '../utils/table';
 
 export interface DatabaseRecord {
+    id?: string;
     name: string;
     status: string;
     deleted_at: string | null;
@@ -196,6 +197,7 @@ function clientDependencies(dependencies: ResolvedCommandDependencies): Database
 function stableDatabaseRecord(database: DatabaseRecord | null | undefined): DatabaseRecord {
     if (
         !database
+        || (database.id !== undefined && typeof database.id !== 'string')
         || typeof database.name !== 'string'
         || typeof database.status !== 'string'
         || typeof database.size_bytes !== 'number'
@@ -206,6 +208,7 @@ function stableDatabaseRecord(database: DatabaseRecord | null | undefined): Data
     }
 
     return {
+        ...(database.id === undefined ? {} : { id: database.id }),
         name: database.name,
         status: database.status,
         deleted_at: database.deleted_at,

--- a/src/commands/skill-run.ts
+++ b/src/commands/skill-run.ts
@@ -68,7 +68,11 @@ export function assembleEnv(opts: {
     const env: Record<string, string> = {};
 
     for (const [key, value] of Object.entries(opts.resolved)) {
-        if (isReservedEnvName(key)) {
+        // The resolve endpoint owns this database credential manifest. Local
+        // execution must pass it through with the mapped JSON values so the
+        // SDK can recognize database variables. All other platform-reserved
+        // names remain ignored and are re-added by the CLI where applicable.
+        if (key !== 'SOLIDACTIONS__DB_KEYS' && isReservedEnvName(key)) {
             warnings.push(`crew variable '${key}' is reserved (set by the platform at runtime) — ignored`);
             continue;
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,7 @@ import { crewEnvSet } from './commands/crew-env-set';
 import { crewEnvList } from './commands/crew-env-list';
 import { crewEnvDelete } from './commands/crew-env-delete';
 import { crewEnvPush } from './commands/crew-env-push';
+import { crewEnvMapDatabase } from './commands/crew-env-map-database';
 import {
     projectDisable,
     projectEnable,
@@ -613,6 +614,16 @@ crewEnv
     .option('--json', 'Output as JSON')
     .action((crewArg, options) => {
         crewEnvList(crewArg, options);
+    });
+
+crewEnv
+    .command('map-database')
+    .description('Map a workspace database into crew sandboxes')
+    .argument('<crew>', 'Crew name or id')
+    .argument('<key>', 'Variable key')
+    .argument('<database>', 'Workspace database name or id')
+    .action((crewArg, key, databaseArg) => {
+        crewEnvMapDatabase(crewArg, key, databaseArg);
     });
 
 crewEnv

--- a/tests/command-tree-export.test.ts
+++ b/tests/command-tree-export.test.ts
@@ -34,6 +34,10 @@ describe('command tree export', () => {
 
         const scheduleSet = schedule.commands.find((c: any) => c.name() === 'set');
         expect(scheduleSet.options.map((o: any) => o.long)).toContain('--paused');
+
+        const crew = program.commands.find((c: any) => c.name() === 'crew');
+        const crewEnv = crew.commands.find((c: any) => c.name() === 'env');
+        expect(crewEnv.commands.map((c: any) => c.name())).toContain('map-database');
     });
 
     it('exposes the program-level global option', () => {

--- a/tests/crew-env-map-database.test.ts
+++ b/tests/crew-env-map-database.test.ts
@@ -72,12 +72,47 @@ function setupConfig(): () => void {
     return cleanup;
 }
 
-function captureConsole(): { logs: string[]; restore: () => void } {
-    const logs: string[] = [];
-    const original = console.log;
-    console.log = (...args: any[]) => { logs.push(args.map(String).join(' ')); };
+class ProcessExitError extends Error {
+    constructor(public readonly code: number | undefined) {
+        super(`process.exit(${code})`);
+    }
+}
 
-    return { logs, restore: () => { console.log = original; } };
+function patchProcessExit(): () => void {
+    const original = process.exit.bind(process);
+    (process as any).exit = (code?: number) => { throw new ProcessExitError(code); };
+    return () => { (process as any).exit = original; };
+}
+
+async function runExpectingExit(fn: () => Promise<void>): Promise<number | undefined> {
+    const restoreExit = patchProcessExit();
+    try {
+        await fn();
+        return undefined;
+    } catch (error) {
+        if (error instanceof ProcessExitError) return error.code;
+        throw error;
+    } finally {
+        restoreExit();
+    }
+}
+
+function captureConsole(): { logs: string[]; errors: string[]; restore: () => void } {
+    const logs: string[] = [];
+    const errors: string[] = [];
+    const originalLog = console.log;
+    const originalError = console.error;
+    console.log = (...args: any[]) => { logs.push(args.map(String).join(' ')); };
+    console.error = (...args: any[]) => { errors.push(args.map(String).join(' ')); };
+
+    return {
+        logs,
+        errors,
+        restore: () => {
+            console.log = originalLog;
+            console.error = originalError;
+        },
+    };
 }
 
 describe('matchWorkspaceDatabase', () => {
@@ -98,6 +133,120 @@ describe('matchWorkspaceDatabase', () => {
 });
 
 describe('crewEnvMapDatabase', () => {
+    it('rejects an invalid variable key before making any API request', async () => {
+        const cleanup = setupConfig();
+        const { errors, restore } = captureConsole();
+        try {
+            const code = await runExpectingExit(() => crewEnvMapDatabase('42', 'HAS-DASH', 'analytics'));
+
+            expect(code).toBe(1);
+            expect(captures).toHaveLength(0);
+            expect(errors.join('\n')).toContain('Invalid variable name "HAS-DASH"');
+        } finally {
+            restore();
+            cleanup();
+        }
+    });
+
+    it('rejects a reserved variable key before making any API request', async () => {
+        const cleanup = setupConfig();
+        const { errors, restore } = captureConsole();
+        try {
+            const code = await runExpectingExit(() => crewEnvMapDatabase('42', 'SOLIDACTIONS_API_TOKEN', 'analytics'));
+
+            expect(code).toBe(1);
+            expect(captures).toHaveLength(0);
+            expect(errors.join('\n')).toContain('uses the reserved SOLIDACTIONS_ prefix');
+        } finally {
+            restore();
+            cleanup();
+        }
+    });
+
+    it('fails without a PUT when the requested database is not found', async () => {
+        const cleanup = setupConfig();
+        const { errors, restore } = captureConsole();
+        try {
+            queue(200, { databases: [], quota: { used: 0, limit: 5 } });
+
+            const code = await runExpectingExit(() => crewEnvMapDatabase('42', 'ANALYTICS_DB', 'missing'));
+
+            expect(code).toBe(1);
+            expect(captures).toHaveLength(1);
+            expect(captures[0].path).toBe('/api/v1/databases');
+            expect(errors.join('\n')).toContain('Ready database "missing" not found in this workspace.');
+        } finally {
+            restore();
+            cleanup();
+        }
+    });
+
+    it('fails without a PUT when the named database is not ready', async () => {
+        const cleanup = setupConfig();
+        const { errors, restore } = captureConsole();
+        try {
+            queue(200, {
+                databases: [{ id: 'db-1', name: 'Analytics', status: 'restoring', deleted_at: null }],
+                quota: { used: 1, limit: 5 },
+            });
+
+            const code = await runExpectingExit(() => crewEnvMapDatabase('42', 'ANALYTICS_DB', 'analytics'));
+
+            expect(code).toBe(1);
+            expect(captures).toHaveLength(1);
+            expect(errors.join('\n')).toContain('Ready database "analytics" not found in this workspace.');
+        } finally {
+            restore();
+            cleanup();
+        }
+    });
+
+    it('formats a 422 mapping validation response', async () => {
+        const cleanup = setupConfig();
+        const { errors, restore } = captureConsole();
+        try {
+            queue(200, {
+                databases: [{ id: 'db-1', name: 'Analytics', status: 'ready', deleted_at: null }],
+                quota: { used: 1, limit: 5 },
+            });
+            queue(422, {
+                message: 'The given data was invalid.',
+                errors: { workspace_database_id: ['The selected workspace database is invalid.'] },
+            });
+
+            const code = await runExpectingExit(() => crewEnvMapDatabase('42', 'ANALYTICS_DB', 'analytics'));
+
+            expect(code).toBe(1);
+            expect(captures).toHaveLength(2);
+            expect(captures[1].path).toBe('/api/v1/crews/42/variables/ANALYTICS_DB');
+            expect(errors.join('\n')).toContain('The selected workspace database is invalid.');
+        } finally {
+            restore();
+            cleanup();
+        }
+    });
+
+    it('prints a generic request error when mapping fails outside validation', async () => {
+        const cleanup = setupConfig();
+        const { errors, restore } = captureConsole();
+        try {
+            queue(200, {
+                databases: [{ id: 'db-1', name: 'Analytics', status: 'ready', deleted_at: null }],
+                quota: { used: 1, limit: 5 },
+            });
+            queue(500, { message: 'Database service unavailable.' });
+
+            const code = await runExpectingExit(() => crewEnvMapDatabase('42', 'ANALYTICS_DB', 'analytics'));
+
+            expect(code).toBe(1);
+            expect(captures).toHaveLength(2);
+            expect(errors.join('\n')).toContain('Request failed with status code 500');
+        } finally {
+            restore();
+            cleanup();
+        }
+    });
+
     it('resolves crew and database names, then PUTs only mapping metadata and prints the exact scope warning', async () => {
         const cleanup = setupConfig();
         const { logs, restore } = captureConsole();

--- a/tests/crew-env-map-database.test.ts
+++ b/tests/crew-env-map-database.test.ts
@@ -1,0 +1,167 @@
+import * as http from 'http';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import {
+    crewEnvMapDatabase,
+    matchWorkspaceDatabase,
+} from '../src/commands/crew-env-map-database';
+import { makeTmpEnv, writeGlobal } from './helpers';
+
+interface CapturedRequest {
+    method: string | undefined;
+    path: string | undefined;
+    headers: http.IncomingHttpHeaders;
+    body: any;
+}
+
+interface QueuedResponse {
+    status: number;
+    body: any;
+}
+
+let server: http.Server;
+let port: number;
+let captures: CapturedRequest[] = [];
+let responses: QueuedResponse[] = [];
+
+function queue(status: number, body: any): void {
+    responses.push({ status, body });
+}
+
+beforeAll(async () => {
+    server = http.createServer((request, response) => {
+        let rawBody = '';
+        request.on('data', (chunk) => { rawBody += chunk; });
+        request.on('end', () => {
+            captures.push({
+                method: request.method,
+                path: request.url,
+                headers: request.headers,
+                body: rawBody ? JSON.parse(rawBody) : null,
+            });
+            const queued = responses.shift() ?? { status: 500, body: { message: 'No response queued.' } };
+            response.writeHead(queued.status, { 'Content-Type': 'application/json' });
+            response.end(JSON.stringify(queued.body));
+        });
+    });
+
+    await new Promise<void>((resolve) => {
+        server.listen(0, '127.0.0.1', () => {
+            port = (server.address() as { port: number }).port;
+            resolve();
+        });
+    });
+});
+
+afterAll(() => new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+}));
+
+beforeEach(() => {
+    captures = [];
+    responses = [];
+});
+
+function setupConfig(): () => void {
+    const { cleanup } = makeTmpEnv();
+    writeGlobal(process.env.HOME!, {
+        host: `http://127.0.0.1:${port}`,
+        apiKey: 'test-api-key',
+        workspaceId: 'workspace-id',
+    });
+
+    return cleanup;
+}
+
+function captureConsole(): { logs: string[]; restore: () => void } {
+    const logs: string[] = [];
+    const original = console.log;
+    console.log = (...args: any[]) => { logs.push(args.map(String).join(' ')); };
+
+    return { logs, restore: () => { console.log = original; } };
+}
+
+describe('matchWorkspaceDatabase', () => {
+    const databases = [
+        { id: 'db-1', name: 'Analytics', status: 'ready', deleted_at: null },
+        { id: 'db-2', name: 'Archive', status: 'ready', deleted_at: null },
+    ];
+
+    it('matches a database by exact id or case-insensitive name', () => {
+        expect(matchWorkspaceDatabase('db-1', databases)).toEqual(databases[0]);
+        expect(matchWorkspaceDatabase('analytics', databases)).toEqual(databases[0]);
+    });
+
+    it('does not select a deleted database', () => {
+        expect(matchWorkspaceDatabase('db-1', [{ ...databases[0], deleted_at: '2026-08-11T00:00:00Z' }]))
+            .toBeNull();
+    });
+});
+
+describe('crewEnvMapDatabase', () => {
+    it('resolves crew and database names, then PUTs only mapping metadata and prints the exact scope warning', async () => {
+        const cleanup = setupConfig();
+        const { logs, restore } = captureConsole();
+        try {
+            queue(200, { data: [{ id: 7, name: 'Ops' }] });
+            queue(200, {
+                databases: [{
+                    id: '019ff-db-id', name: 'Analytics', status: 'ready', deleted_at: null,
+                    purge_at: null, size_bytes: 0,
+                }],
+                quota: { used: 1, limit: 5 },
+            });
+            queue(201, {
+                env_name: 'ANALYTICS_DB', source_type: 'workspace_database',
+                workspace_database_id: '019ff-db-id', workspace_database_name: 'Analytics',
+                is_secret: true,
+            });
+
+            await crewEnvMapDatabase('Ops', 'ANALYTICS_DB', 'analytics');
+
+            expect(captures).toHaveLength(3);
+            expect(captures[1]).toMatchObject({
+                method: 'POST',
+                path: '/api/v1/databases',
+                body: { operation: 'list' },
+            });
+            expect(captures[2]).toMatchObject({
+                method: 'PUT',
+                path: '/api/v1/crews/7/variables/ANALYTICS_DB',
+                body: {
+                    source_type: 'workspace_database',
+                    workspace_database_id: '019ff-db-id',
+                },
+            });
+            expect(captures[2].headers['authorization']).toBe('Bearer test-api-key');
+            expect(logs.join('\n')).toContain('Applies to production, staging, and dev crew sandboxes');
+            expect(logs.join('\n')).not.toContain('token');
+        } finally {
+            restore();
+            cleanup();
+        }
+    });
+
+    it('accepts numeric crew id and database UUID without name lookups beyond the database list', async () => {
+        const cleanup = setupConfig();
+        const { restore } = captureConsole();
+        try {
+            queue(200, {
+                databases: [{
+                    id: '019ff-db-id', name: 'Analytics', status: 'ready', deleted_at: null,
+                    purge_at: null, size_bytes: 0,
+                }],
+                quota: { used: 1, limit: 5 },
+            });
+            queue(200, {});
+
+            await crewEnvMapDatabase('42', 'ANALYTICS_DB', '019ff-db-id');
+
+            expect(captures).toHaveLength(2);
+            expect(captures[0].path).toBe('/api/v1/databases');
+            expect(captures[1].path).toBe('/api/v1/crews/42/variables/ANALYTICS_DB');
+        } finally {
+            restore();
+            cleanup();
+        }
+    });
+});

--- a/tests/crew-env.test.ts
+++ b/tests/crew-env.test.ts
@@ -497,6 +497,39 @@ describe('crewEnvList', () => {
             cleanup();
         }
     });
+
+    it('renders a workspace database mapping as database:name without any value or credential', async () => {
+        const { cleanup } = setupConfig();
+        const { logs, restore } = captureConsole();
+        try {
+            queue(200, { data: [{ id: 3, name: 'Ops' }] });
+            queue(200, {
+                data: [{
+                    id: 4,
+                    env_name: 'ANALYTICS_DB',
+                    source_type: 'workspace_database',
+                    workspace_database_id: 'database-id',
+                    workspace_database_name: 'analytics',
+                    is_secret: true,
+                    production_value: 'credential-must-not-render',
+                    staging_value: 'credential-must-not-render',
+                    dev_value: 'credential-must-not-render',
+                    token: 'token-must-not-render',
+                }],
+            });
+
+            await runExpectingExit(() => crewEnvList('Ops', {}));
+
+            const output = logs.join('\n');
+            expect(output).toContain('database:analytics');
+            expect(output).not.toContain('credential-must-not-render');
+            expect(output).not.toContain('token-must-not-render');
+            expect(output).not.toContain('••••••');
+        } finally {
+            restore();
+            cleanup();
+        }
+    });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/database-lifecycle-commands.test.ts
+++ b/tests/database-lifecycle-commands.test.ts
@@ -45,6 +45,7 @@ const CONFIG: Config = {
 };
 
 const ACTIVE: DatabaseRecord = {
+    id: 'database-active-id',
     name: 'Analytics',
     status: 'ready',
     deleted_at: null,
@@ -53,6 +54,7 @@ const ACTIVE: DatabaseRecord = {
 };
 
 const DELETED: DatabaseRecord = {
+    id: 'database-deleted-id',
     name: 'Retired',
     status: 'ready',
     deleted_at: '2026-08-07T12:00:00.000000Z',

--- a/tests/skill-run.test.ts
+++ b/tests/skill-run.test.ts
@@ -89,6 +89,29 @@ describe('assembleEnv', () => {
         expect(warnings.join('\n')).toContain('PATH');
     });
 
+    it('passes resolved workspace-database values and their database-key manifest to local skills', () => {
+        const databaseValue = JSON.stringify({
+            url: 'libsql://analytics-db.turso.io',
+            token: 'fresh-database-token',
+            name: 'analytics',
+            read_only: false,
+        });
+        const { env, warnings } = assembleEnv({
+            resolved: {
+                ANALYTICS_DB: databaseValue,
+                SOLIDACTIONS__DB_KEYS: 'ANALYTICS_DB',
+            },
+            fileVars: {},
+            storageScope: null,
+            dir: '/tmp/skill',
+            config,
+        });
+
+        expect(env.ANALYTICS_DB).toBe(databaseValue);
+        expect(env.SOLIDACTIONS__DB_KEYS).toBe('ANALYTICS_DB');
+        expect(warnings).toEqual([]);
+    });
+
     it('injects STATE_DIR only for storage.scope=crew and SHARED_DIR only for workspace', () => {
         const crew = assembleEnv({ resolved: {}, fileVars: {}, storageScope: 'crew', dir: '/tmp/skill', config });
         expect(crew.env.SOLIDACTIONS_STATE_DIR).toBe(path.join('/tmp/skill', '.sa-state'));
@@ -127,8 +150,21 @@ describe('solidactions skill run — integration', () => {
                 return;
             }
             if (req.url?.startsWith('/api/v1/crews/7/variables/resolve')) {
+                const databaseValue = JSON.stringify({
+                    url: 'libsql://analytics-db.turso.io',
+                    token: 'fresh-database-token',
+                    name: 'analytics',
+                    read_only: false,
+                });
                 res.writeHead(200, { 'Content-Type': 'application/json' });
-                res.end(JSON.stringify({ variables: { PROBE: 'resolved' }, skipped_secrets: ['HIDDEN'] }));
+                res.end(JSON.stringify({
+                    variables: {
+                        PROBE: 'resolved',
+                        ANALYTICS_DB: databaseValue,
+                        SOLIDACTIONS__DB_KEYS: 'ANALYTICS_DB',
+                    },
+                    skipped_secrets: ['HIDDEN'],
+                }));
                 return;
             }
             res.writeHead(404, { 'Content-Type': 'application/json' });
@@ -162,7 +198,11 @@ describe('solidactions skill run — integration', () => {
                         '--crew', 'my-crew',
                         '--environment', 'dev',
                         '--',
-                        'node', '-e', 'console.log("PROBE="+process.env.PROBE)',
+                        'node', '-e', [
+                            'console.log("PROBE="+process.env.PROBE)',
+                            'console.log("DB_KEYS="+process.env.SOLIDACTIONS__DB_KEYS)',
+                            'console.log("DATABASE="+process.env.ANALYTICS_DB)',
+                        ].join(';'),
                     ],
                     {
                         env: {
@@ -193,6 +233,8 @@ describe('solidactions skill run — integration', () => {
 
             expect(result.status).toBe(0);
             expect(result.stdout).toContain('PROBE=resolved');
+            expect(result.stdout).toContain('DB_KEYS=ANALYTICS_DB');
+            expect(result.stdout).toContain('DATABASE={"url":"libsql://analytics-db.turso.io","token":"fresh-database-token","name":"analytics","read_only":false}');
             expect(result.stderr).toContain('HIDDEN');
             expect(result.stderr).toContain('env:reveal');
         } finally {


### PR DESCRIPTION
## Summary

Companion CLI change for SolidActions/solidactions-app#1180.

- adds `solidactions crew env map-database <crew> <key> <database>`
- resolves ready workspace databases by name or ID through the authenticated database API
- maps the crew variable through the existing REST surface
- renders mapped values as `database:<name>` and never prints credentials
- displays the exact cross-environment warning

## Verification

- `npm test` — 1,257 passed across 128 files
- `npm run build` — passed

Companion app PR: pending (will be cross-linked after creation).
