### PR TITLE
fix: group the login workspace picker by organization (app#1194)

### DIFF
--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -21,6 +21,7 @@ import {
 } from '../utils/config-write-target';
 import {
     fetchWorkspaces,
+    formatWorkspaceWithOrg,
     matchWorkspace,
     selectWorkspaceInteractively,
     WorkspaceLookupRecord,
@@ -330,7 +331,7 @@ export async function completeLogin(
         config.workspaceId = match.id;
     } else if (workspaces.length === 1) {
         const selected = workspaces[0];
-        console.log(chalk.gray(`Auto-selected workspace: ${selected.name}`));
+        console.log(chalk.gray(`Auto-selected workspace: ${formatWorkspaceWithOrg(selected)}`));
         config.workspace = selected.slug ?? selected.name;
         config.workspaceId = selected.id;
     } else if (workspaces.length === 0) {

--- a/src/commands/workspaces.ts
+++ b/src/commands/workspaces.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk';
 import { requireConfig, requireResolvedConfig } from '../utils/api';
 import { writeWorkspaceToFile } from '../utils/config';
 import { decideWriteTarget, pathForTarget, ensureGitignoreCovers } from '../utils/config-write-target';
-import { resolveWorkspaceInput } from '../utils/workspace-lookup';
+import { formatWorkspaceWithOrg, resolveWorkspaceInput } from '../utils/workspace-lookup';
 
 export async function workspacesList() {
     const config = requireConfig();
@@ -101,6 +101,6 @@ export async function workspaceSet(input: string, options: WorkspaceSetOptions =
         await ensureGitignoreCovers(process.cwd(), !!options.gitignore);
     }
 
-    console.log(chalk.green(`Workspace set to: ${workspace.name} (${workspace.id})`));
+    console.log(chalk.green(`Workspace set to: ${formatWorkspaceWithOrg(workspace)} (${workspace.id})`));
     console.log(chalk.gray(`Saved to ${targetPath}`));
 }

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -350,7 +350,6 @@ export async function ensureWorkspaceSelected(
 
         const chosen = await selectWorkspaceInteractively(workspaces, {
             ...dependencies,
-            label: (ws) => `${ws.name} ${chalk.gray(`(${ws.org_name}, ${ws.role})`)}`,
         });
         if (!chosen) {
             process.exit(1);

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import chalk from 'chalk';
 import { Config, ResolvedConfig, resolveConfig, writeConfigFile, getGlobalConfigPath } from './config';
 import {
+    formatWorkspaceWithOrg,
     resolveWorkspaceInput,
     selectWorkspaceInteractively,
     WorkspaceLookupRecord,
@@ -338,7 +339,7 @@ export async function ensureWorkspaceSelected(
 
     if (workspaces.length === 1) {
         selected = workspaces[0];
-        console.log(chalk.gray(`Auto-selected workspace: ${selected.name}`));
+        console.log(chalk.gray(`Auto-selected workspace: ${formatWorkspaceWithOrg(selected)}`));
     } else {
         if (!process.stdin.isTTY) {
             console.error(chalk.red(
@@ -364,7 +365,6 @@ export async function ensureWorkspaceSelected(
         const targetPath = resolved?.activePath ?? getGlobalConfigPath();
         writeConfigFile(targetPath, config);
     }
-    console.log(chalk.green(`Workspace set: ${selected.name}`));
 
     return config;
 }

--- a/src/utils/workspace-lookup.ts
+++ b/src/utils/workspace-lookup.ts
@@ -61,6 +61,11 @@ export async function fetchWorkspaces(config: Config): Promise<FetchWorkspacesRe
     return { workspaces: out, scope };
 }
 
+/** Workspace name, qualified with its org name when known (e.g. `"Foo — organization Bar"`). */
+export function formatWorkspaceWithOrg(ws: WorkspaceLookupRecord): string {
+    return ws.org_name ? `${ws.name} — organization ${ws.org_name}` : ws.name;
+}
+
 /**
  * Prompt the user to pick a workspace from an already-fetched list. Auto-
  * selects when there's exactly one. Invalid answers re-prompt; EOF or a
@@ -80,7 +85,7 @@ export async function selectWorkspaceInteractively(
         return undefined;
     }
     if (workspaces.length === 1) {
-        console.log(chalk.gray(`Auto-selected workspace: ${workspaces[0].name}`));
+        console.log(chalk.gray(`Auto-selected workspace: ${formatWorkspaceWithOrg(workspaces[0])}`));
         return workspaces[0];
     }
 
@@ -88,10 +93,13 @@ export async function selectWorkspaceInteractively(
     const grouped = workspaces.some((ws) => ws.org_name);
 
     console.log(chalk.blue('\nSelect your default workspace (change anytime with `solidactions workspace set`):\n'));
+    if (grouped) {
+        console.log(chalk.gray('Workspaces are grouped by organization.\n'));
+    }
     let lastOrg: string | undefined;
     workspaces.forEach((ws, i) => {
         if (grouped && ws.org_name !== lastOrg) {
-            console.log(`  ${chalk.white(ws.org_name ?? '')}`);
+            console.log(`  ${chalk.bold(ws.org_name ?? '')}`);
             lastOrg = ws.org_name;
         }
         const indent = grouped ? '    ' : '  ';
@@ -130,7 +138,9 @@ export async function selectWorkspaceInteractively(
             }
             const index = parseInt(answer, 10) - 1;
             if (!isNaN(index) && index >= 0 && index < workspaces.length) {
-                return workspaces[index];
+                const selected = workspaces[index];
+                console.log(chalk.green(`Selected: ${formatWorkspaceWithOrg(selected)}`));
+                return selected;
             }
             console.error(chalk.red('Invalid selection. Enter one of the numbers shown.'));
         }

--- a/src/utils/workspace-lookup.ts
+++ b/src/utils/workspace-lookup.ts
@@ -90,7 +90,11 @@ export async function selectWorkspaceInteractively(
     }
 
     const label = dependencies.label ?? ((ws: WorkspaceLookupRecord) => (ws.role ? `${ws.name} (${ws.role})` : ws.name));
-    const grouped = workspaces.some((ws) => ws.org_name);
+    // Header + grouping preamble are only useful once there's more than one
+    // org to disambiguate; a single-org account would otherwise get a
+    // redundant sole header and a pointless "grouped by organization" line.
+    const orgNames = new Set(workspaces.map((ws) => ws.org_name).filter((name): name is string => !!name));
+    const grouped = orgNames.size > 1;
 
     console.log(chalk.blue('\nSelect your default workspace (change anytime with `solidactions workspace set`):\n'));
     if (grouped) {

--- a/src/utils/workspace-lookup.ts
+++ b/src/utils/workspace-lookup.ts
@@ -49,8 +49,10 @@ export async function fetchWorkspaces(config: Config): Promise<FetchWorkspacesRe
     const grouped = response.data.workspaces || response.data.teams || response.data.data || response.data;
     const out: WorkspaceLookupRecord[] = [];
     if (typeof grouped === 'object' && !Array.isArray(grouped)) {
-        for (const orgWorkspaces of Object.values(grouped)) {
-            out.push(...(orgWorkspaces as WorkspaceLookupRecord[]));
+        for (const [orgName, orgWorkspaces] of Object.entries(grouped)) {
+            for (const ws of orgWorkspaces as Array<WorkspaceLookupRecord & { tenant_name?: string }>) {
+                out.push({ ...ws, org_name: ws.tenant_name || orgName });
+            }
         }
     } else if (Array.isArray(grouped)) {
         out.push(...(grouped as WorkspaceLookupRecord[]));
@@ -82,11 +84,18 @@ export async function selectWorkspaceInteractively(
         return workspaces[0];
     }
 
-    const label = dependencies.label ?? ((ws: WorkspaceLookupRecord) => ws.name);
+    const label = dependencies.label ?? ((ws: WorkspaceLookupRecord) => (ws.role ? `${ws.name} (${ws.role})` : ws.name));
+    const grouped = workspaces.some((ws) => ws.org_name);
 
     console.log(chalk.blue('\nSelect your default workspace (change anytime with `solidactions workspace set`):\n'));
+    let lastOrg: string | undefined;
     workspaces.forEach((ws, i) => {
-        console.log(`  ${chalk.white(`${i + 1}.`)} ${label(ws)}`);
+        if (grouped && ws.org_name !== lastOrg) {
+            console.log(`  ${chalk.white(ws.org_name ?? '')}`);
+            lastOrg = ws.org_name;
+        }
+        const indent = grouped ? '    ' : '  ';
+        console.log(`${indent}${chalk.white(`${i + 1}.`)} ${label(ws)}`);
     });
     console.log('');
 

--- a/tests/ensure-workspace-selected-interactive.test.ts
+++ b/tests/ensure-workspace-selected-interactive.test.ts
@@ -109,4 +109,20 @@ describe('ensureWorkspaceSelected interactive multi-workspace selection', () => 
         expect(logLines.some((line) => line.includes('Acme Org'))).toBe(true);
         expect(logLines.some((line) => line.includes('First Workspace (admin)'))).toBe(true);
     });
+
+    it('confirms the resolved workspace exactly once, org-qualified', async () => {
+        writeGlobal(env.home, {
+            host: `http://127.0.0.1:${port}`,
+            apiKey: 'existing-token',
+        });
+
+        await ensureWorkspaceSelected(
+            { host: `http://127.0.0.1:${port}`, apiKey: 'existing-token' },
+            { question: async () => '2' },
+        );
+
+        const confirmations = logLines.filter((line) => /Selected:|Workspace set:|Auto-selected workspace:/.test(line));
+        expect(confirmations).toHaveLength(1);
+        expect(confirmations[0]).toContain('Second Workspace — organization Acme Org');
+    });
 });

--- a/tests/ensure-workspace-selected-interactive.test.ts
+++ b/tests/ensure-workspace-selected-interactive.test.ts
@@ -95,7 +95,7 @@ describe('ensureWorkspaceSelected interactive multi-workspace selection', () => 
         expect(JSON.parse(fs.readFileSync(configPath, 'utf-8')).workspaceId).toBe('ws-2');
     });
 
-    it('prints the (org_name, role) annotation for each workspace in the numbered list', async () => {
+    it('groups the numbered list under an org header and renders each row as "name (role)"', async () => {
         writeGlobal(env.home, {
             host: `http://127.0.0.1:${port}`,
             apiKey: 'existing-token',
@@ -106,6 +106,7 @@ describe('ensureWorkspaceSelected interactive multi-workspace selection', () => 
             { question: async () => '1' },
         );
 
-        expect(logLines.some((line) => line.includes('First Workspace') && line.includes('(Acme Org, admin)'))).toBe(true);
+        expect(logLines.some((line) => line.includes('Acme Org'))).toBe(true);
+        expect(logLines.some((line) => line.includes('First Workspace (admin)'))).toBe(true);
     });
 });

--- a/tests/ensure-workspace-selected-interactive.test.ts
+++ b/tests/ensure-workspace-selected-interactive.test.ts
@@ -95,7 +95,7 @@ describe('ensureWorkspaceSelected interactive multi-workspace selection', () => 
         expect(JSON.parse(fs.readFileSync(configPath, 'utf-8')).workspaceId).toBe('ws-2');
     });
 
-    it('groups the numbered list under an org header and renders each row as "name (role)"', async () => {
+    it('does not print a redundant org header for a single-org account, but still renders each row as "name (role)"', async () => {
         writeGlobal(env.home, {
             host: `http://127.0.0.1:${port}`,
             apiKey: 'existing-token',
@@ -106,7 +106,8 @@ describe('ensureWorkspaceSelected interactive multi-workspace selection', () => 
             { question: async () => '1' },
         );
 
-        expect(logLines.some((line) => line.includes('Acme Org'))).toBe(true);
+        expect(logLines.some((line) => line.trim() === 'Acme Org')).toBe(false);
+        expect(logLines.some((line) => line.toLowerCase().includes('grouped by organization'))).toBe(false);
         expect(logLines.some((line) => line.includes('First Workspace (admin)'))).toBe(true);
     });
 

--- a/tests/login-validation.test.ts
+++ b/tests/login-validation.test.ts
@@ -198,6 +198,34 @@ describe('login — validates before writing (F-C2)', () => {
         expect(out).toContain('Logged in successfully!');
     });
 
+    it('non-interactive, no --workspace: auto-selects the sole workspace with an org-qualified confirmation (real grouped-object payload)', async () => {
+        nextStatus = 200;
+        nextBody = {
+            workspaces: {
+                'Acme Org': [
+                    { id: 'ws-1', name: 'Only Workspace', slug: 'only-workspace', role: 'owner', tenant_id: 't-1', tenant_name: 'Acme Org', tenant_slug: 'acme' },
+                ],
+            },
+        };
+
+        let caught: ProcessExitError | null = null;
+        try {
+            await login('good-key', { global: true, host: HOST() });
+        } catch (e) {
+            if (e instanceof ProcessExitError) caught = e;
+            else throw e;
+        }
+
+        expect(caught).toBeNull();
+        expect(writeCount).toBe(1);
+        const globalPath = path.join(env.home, '.solidactions', 'config.json');
+        const config = JSON.parse(fs.readFileSync(globalPath, 'utf-8'));
+        expect(config.workspaceId).toBe('ws-1');
+        expect(config.workspace).toBe('only-workspace');
+        const out = logLines.join(' ');
+        expect(out).toContain('Auto-selected workspace: Only Workspace — organization Acme Org');
+    });
+
     it('non-interactive, no --workspace: leaves multiple workspaces unset with recovery guidance', async () => {
         nextStatus = 200;
         nextBody = {

--- a/tests/workspace-lookup.test.ts
+++ b/tests/workspace-lookup.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from 'vitest';
-import { matchWorkspace, WorkspaceLookupRecord } from '../src/utils/workspace-lookup';
+import http from 'http';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { fetchWorkspaces, matchWorkspace, WorkspaceLookupRecord } from '../src/utils/workspace-lookup';
 
 const workspaces: WorkspaceLookupRecord[] = [
     { id: 'uuid-1', slug: 'mercer', name: 'Mercer Workspace' },
@@ -22,5 +23,93 @@ describe('matchWorkspace', () => {
     });
     it('matches a workspace with no slug by name', () => {
         expect(matchWorkspace('No Slug', workspaces)?.id).toBe('uuid-3');
+    });
+});
+
+describe('fetchWorkspaces', () => {
+    let server: http.Server;
+    let port: number;
+    let responseBody: unknown;
+
+    beforeAll(async () => {
+        server = http.createServer((_req, res) => {
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify(responseBody));
+        });
+        await new Promise<void>((resolve) => {
+            server.listen(0, '127.0.0.1', () => {
+                port = (server.address() as { port: number }).port;
+                resolve();
+            });
+        });
+    });
+
+    afterAll(() => new Promise<void>((resolve, reject) => {
+        server.close((error) => error ? reject(error) : resolve());
+    }));
+
+    let config: { host: string; apiKey: string };
+
+    beforeEach(() => {
+        config = { host: `http://127.0.0.1:${port}`, apiKey: 'test-token' };
+    });
+
+    afterEach(() => {
+        responseBody = undefined;
+    });
+
+    it('annotates each record with org_name and role from a multi-org grouped payload', async () => {
+        responseBody = {
+            workspaces: {
+                'Acme Org': [
+                    { id: 'ws-1', name: 'First', slug: 'first', role: 'admin', tenant_id: 't-1', tenant_name: 'Acme Org', tenant_slug: 'acme' },
+                ],
+                'Globex': [
+                    { id: 'ws-2', name: 'Second', slug: 'second', role: 'member', tenant_id: 't-2', tenant_name: 'Globex', tenant_slug: 'globex' },
+                ],
+            },
+            scope: null,
+        };
+
+        const result = await fetchWorkspaces(config);
+
+        expect(result.workspaces).toEqual([
+            { id: 'ws-1', name: 'First', slug: 'first', role: 'admin', tenant_id: 't-1', tenant_name: 'Acme Org', tenant_slug: 'acme', org_name: 'Acme Org' },
+            { id: 'ws-2', name: 'Second', slug: 'second', role: 'member', tenant_id: 't-2', tenant_name: 'Globex', tenant_slug: 'globex', org_name: 'Globex' },
+        ]);
+    });
+
+    it('falls back to the grouping key for org_name when a record lacks tenant_name', async () => {
+        responseBody = {
+            workspaces: {
+                'Acme Org': [
+                    { id: 'ws-1', name: 'First', slug: 'first', role: 'admin' },
+                ],
+            },
+            scope: null,
+        };
+
+        const result = await fetchWorkspaces(config);
+
+        expect(result.workspaces).toEqual([
+            { id: 'ws-1', name: 'First', slug: 'first', role: 'admin', org_name: 'Acme Org' },
+        ]);
+    });
+
+    it('passes array-shaped payloads through unchanged', async () => {
+        responseBody = {
+            workspaces: [
+                { id: 'ws-1', name: 'First', slug: 'first' },
+                { id: 'ws-2', name: 'Second', slug: 'second', org_name: 'Preset Org', role: 'owner' },
+            ],
+            scope: null,
+        };
+
+        const result = await fetchWorkspaces(config);
+
+        expect(result.workspaces).toEqual([
+            { id: 'ws-1', name: 'First', slug: 'first' },
+            { id: 'ws-2', name: 'Second', slug: 'second', org_name: 'Preset Org', role: 'owner' },
+        ]);
     });
 });

--- a/tests/workspace-selection.test.ts
+++ b/tests/workspace-selection.test.ts
@@ -94,9 +94,63 @@ describe('interactive login workspace selection: org grouping', () => {
             question: async () => '1',
         });
 
-        const headerCount = logLines.filter((line) => line.includes('Acme Org')).length;
+        const headerCount = logLines.filter((line) => line.trim() === 'Acme Org').length;
         expect(headerCount).toBe(1);
         expect(logLines.some((line) => line.includes('1.') && line.includes('First Workspace (admin)'))).toBe(true);
         expect(logLines.some((line) => line.includes('2.') && line.includes('Second Workspace (member)'))).toBe(true);
+    });
+
+    it('prints a line naming the grouping level as organization when grouped', async () => {
+        await selectWorkspaceInteractively(multiOrgWorkspaces, {
+            question: async () => '1',
+        });
+
+        expect(logLines.some((line) => line.toLowerCase().includes('grouped by organization'))).toBe(true);
+    });
+
+    it('does not print the organization grouping line for a flat org-less list', async () => {
+        const orglessWorkspaces = [
+            { id: 'ws-1', name: 'First Workspace', slug: 'first-workspace' },
+            { id: 'ws-2', name: 'Second Workspace', slug: 'second-workspace' },
+        ];
+
+        await selectWorkspaceInteractively(orglessWorkspaces, {
+            question: async () => '1',
+        });
+
+        expect(logLines.some((line) => line.toLowerCase().includes('organization'))).toBe(false);
+    });
+
+    it('echoes the resolved selection with its org name after a valid pick', async () => {
+        const selected = await selectWorkspaceInteractively(multiOrgWorkspaces, {
+            question: async () => '4',
+        });
+
+        expect(selected?.id).toBe('ws-4');
+        expect(logLines.some((line) => line.includes('Selected: Fourth Workspace') && line.includes('Globex'))).toBe(true);
+    });
+
+    it('echoes the resolved selection without an org clause when the list has no orgs', async () => {
+        const orglessWorkspaces = [
+            { id: 'ws-1', name: 'First Workspace', slug: 'first-workspace' },
+            { id: 'ws-2', name: 'Second Workspace', slug: 'second-workspace' },
+        ];
+
+        await selectWorkspaceInteractively(orglessWorkspaces, {
+            question: async () => '2',
+        });
+
+        expect(logLines.some((line) => line.includes('Selected: Second Workspace') && !line.includes('organization'))).toBe(true);
+    });
+
+    it('names the org in the auto-selected single-workspace confirmation when known', async () => {
+        const singleWorkspaceWithOrg = [
+            { id: 'ws-1', name: 'Only Workspace', slug: 'only-workspace', org_name: 'Acme Org', role: 'owner' },
+        ];
+
+        const selected = await selectWorkspaceInteractively(singleWorkspaceWithOrg);
+
+        expect(selected?.id).toBe('ws-1');
+        expect(logLines.some((line) => line.includes('Auto-selected workspace: Only Workspace') && line.includes('Acme Org'))).toBe(true);
     });
 });

--- a/tests/workspace-selection.test.ts
+++ b/tests/workspace-selection.test.ts
@@ -84,7 +84,7 @@ describe('interactive login workspace selection: org grouping', () => {
         expect(logLines.some((line) => line.includes('2.') && line.includes('Second Workspace'))).toBe(true);
     });
 
-    it('renders a single header when every workspace shares one org', async () => {
+    it('suppresses the org header and grouping preamble when every workspace shares one org', async () => {
         const singleOrgWorkspaces = [
             { id: 'ws-1', name: 'First Workspace', slug: 'first-workspace', org_name: 'Acme Org', role: 'admin' },
             { id: 'ws-2', name: 'Second Workspace', slug: 'second-workspace', org_name: 'Acme Org', role: 'member' },
@@ -95,7 +95,8 @@ describe('interactive login workspace selection: org grouping', () => {
         });
 
         const headerCount = logLines.filter((line) => line.trim() === 'Acme Org').length;
-        expect(headerCount).toBe(1);
+        expect(headerCount).toBe(0);
+        expect(logLines.some((line) => line.toLowerCase().includes('grouped by organization'))).toBe(false);
         expect(logLines.some((line) => line.includes('1.') && line.includes('First Workspace (admin)'))).toBe(true);
         expect(logLines.some((line) => line.includes('2.') && line.includes('Second Workspace (member)'))).toBe(true);
     });

--- a/tests/workspace-selection.test.ts
+++ b/tests/workspace-selection.test.ts
@@ -143,6 +143,22 @@ describe('interactive login workspace selection: org grouping', () => {
         expect(logLines.some((line) => line.includes('Selected: Second Workspace') && !line.includes('organization'))).toBe(true);
     });
 
+    it('disambiguates two workspaces sharing the same name across different orgs via org headers and qualified rows', async () => {
+        const sameNameAcrossOrgs = [
+            { id: 'ws-1', name: 'Production', slug: 'production-acme', org_name: 'Acme Org', role: 'admin' },
+            { id: 'ws-2', name: 'Production', slug: 'production-globex', org_name: 'Globex', role: 'member' },
+        ];
+
+        const selected = await selectWorkspaceInteractively(sameNameAcrossOrgs, {
+            question: async () => '2',
+        });
+
+        expect(selected?.id).toBe('ws-2');
+        expect(logLines.some((line) => line.trim() === 'Acme Org')).toBe(true);
+        expect(logLines.some((line) => line.trim() === 'Globex')).toBe(true);
+        expect(logLines.some((line) => line.includes('Selected: Production') && line.includes('Globex'))).toBe(true);
+    });
+
     it('names the org in the auto-selected single-workspace confirmation when known', async () => {
         const singleWorkspaceWithOrg = [
             { id: 'ws-1', name: 'Only Workspace', slug: 'only-workspace', org_name: 'Acme Org', role: 'owner' },

--- a/tests/workspace-selection.test.ts
+++ b/tests/workspace-selection.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
 import { selectWorkspaceInteractively } from '../src/commands/login';
 
 const workspaces = [
@@ -22,5 +22,81 @@ describe('interactive login workspace selection', () => {
         });
 
         expect(selected).toBeUndefined();
+    });
+});
+
+describe('interactive login workspace selection: org grouping', () => {
+    let originalLog: typeof console.log;
+    let logLines: string[];
+
+    beforeEach(() => {
+        originalLog = console.log;
+        logLines = [];
+        console.log = (...args: unknown[]) => { logLines.push(args.map(String).join(' ')); };
+    });
+
+    afterEach(() => {
+        console.log = originalLog;
+    });
+
+    const multiOrgWorkspaces = [
+        { id: 'ws-1', name: 'First Workspace', slug: 'first-workspace', org_name: 'Acme Org', role: 'admin' },
+        { id: 'ws-2', name: 'Second Workspace', slug: 'second-workspace', org_name: 'Acme Org', role: 'member' },
+        { id: 'ws-3', name: 'Third Workspace', slug: 'third-workspace', org_name: 'Globex', role: 'owner' },
+        { id: 'ws-4', name: 'Fourth Workspace', slug: 'fourth-workspace', org_name: 'Globex', role: 'member' },
+    ];
+
+    it('prints one header per org and numbers continuously across groups, selecting from the second group by number', async () => {
+        const selected = await selectWorkspaceInteractively(multiOrgWorkspaces, {
+            question: async () => '4',
+        });
+
+        expect(selected?.id).toBe('ws-4');
+        expect(logLines.some((line) => line.includes('Acme Org'))).toBe(true);
+        expect(logLines.some((line) => line.includes('Globex'))).toBe(true);
+        expect(logLines.some((line) => line.includes('1.') && line.includes('First Workspace'))).toBe(true);
+        expect(logLines.some((line) => line.includes('2.') && line.includes('Second Workspace'))).toBe(true);
+        expect(logLines.some((line) => line.includes('3.') && line.includes('Third Workspace'))).toBe(true);
+        expect(logLines.some((line) => line.includes('4.') && line.includes('Fourth Workspace'))).toBe(true);
+    });
+
+    it('renders each row as "name (role)"', async () => {
+        await selectWorkspaceInteractively(multiOrgWorkspaces, {
+            question: async () => '1',
+        });
+
+        expect(logLines.some((line) => line.includes('First Workspace (admin)'))).toBe(true);
+        expect(logLines.some((line) => line.includes('Fourth Workspace (member)'))).toBe(true);
+    });
+
+    it('falls back to a flat numbered list with no headers when no workspace has an org_name', async () => {
+        const orglessWorkspaces = [
+            { id: 'ws-1', name: 'First Workspace', slug: 'first-workspace' },
+            { id: 'ws-2', name: 'Second Workspace', slug: 'second-workspace' },
+        ];
+
+        const selected = await selectWorkspaceInteractively(orglessWorkspaces, {
+            question: async () => '2',
+        });
+
+        expect(selected?.id).toBe('ws-2');
+        expect(logLines.some((line) => line.includes('1.') && line.includes('First Workspace'))).toBe(true);
+        expect(logLines.some((line) => line.includes('2.') && line.includes('Second Workspace'))).toBe(true);
+    });
+
+    it('renders a single header when every workspace shares one org', async () => {
+        const singleOrgWorkspaces = [
+            { id: 'ws-1', name: 'First Workspace', slug: 'first-workspace', org_name: 'Acme Org', role: 'admin' },
+            { id: 'ws-2', name: 'Second Workspace', slug: 'second-workspace', org_name: 'Acme Org', role: 'member' },
+        ];
+
+        await selectWorkspaceInteractively(singleOrgWorkspaces, {
+            question: async () => '1',
+        });
+
+        const headerCount = logLines.filter((line) => line.includes('Acme Org')).length;
+        expect(headerCount).toBe(1);
+        expect(logLines.some((line) => line.includes('1.') && line.includes('First Workspace (admin)'))).toBe(true);
+        expect(logLines.some((line) => line.includes('2.') && line.includes('Second Workspace (member)'))).toBe(true);
     });
 });


### PR DESCRIPTION
Fixes SolidActions/solidactions-app#1194.

`solidactions login` printed the workspace picker as a flat list of **bare workspace names**. Peter's real picker showed 7 names spanning several orgs with nothing saying which org each belonged to.

## Root cause — two layers

1. `fetchWorkspaces()` flattened the API's org-grouped payload with `out.push(...orgWorkspaces)` and never mapped `tenant_name` onto `org_name` — the field was declared on `WorkspaceLookupRecord` but never populated.
2. `completeLogin` called `selectWorkspaceInteractively` with no `label`, so the default `ws => ws.name` rendered bare names.

The API was already sufficient (`GET /api/v1/workspaces` returns `tenant_id`/`tenant_name`/`tenant_slug` per workspace **and** groups by tenant). No API change.

## What changed

`fetchWorkspaces` populates `org_name` from `tenant_name`, falling back to the payload's grouping key. The picker renders a bold header per org with **continuous 1..N numbering across groups**, so existing muscle memory and scripted answers still resolve to the same workspace. Rows carry the role. Lists with no org data keep the old flat rendering.

`ensureWorkspaceSelected` drops its bespoke `(org_name, role)` label override and shares the one rendering path.

## Second commit: what the cleanroom caught

A context-free agent ran the grouped picker cold as a first-time user. It mapped all 8 workspaces to the right org — but was inferring, not reading:

> The word "organization" does not appear anywhere on the login screen... never labels the outer level... I had no way to know whether `Test Org` was an organization, a team, a folder, a project, or a group.

> Org headers and workspace names are visually near-identical — two spaces of indent and a number, same colour. Three of the four orgs have a workspace with the identical name nested under them.

So: headers are bold, one line names the grouping level, and a pick echoes back what it resolved to, org-qualified. That echo made `ensureWorkspaceSelected`'s trailing `Workspace set: <name>` a redundant second confirmation saying strictly less, so it goes; a test pins that both callers print exactly one.

## Result

```
Select your default workspace (change anytime with `solidactions workspace set`):

Workspaces are grouped by organization.

  Test Org
    1. Test Workspace (admin)
  Peter Olson
    2. Peter's Team (owner)
    3. Peter Olson (owner)
    4. testing (admin)
  10TC
    5. 10TC (admin)
    6. 10TC Sales (member)
  SolidActions
    7. SolidActions (owner)
    8. Owners (member)

Enter number: 6
Selected: 10TC Sales — organization 10TC
```

## Verification

- `npm test` — 127 files / 1265 tests green (+10 over baseline); `npm run build` clean.
- Live smoke against a local dev stack seeded with 8 workspaces across 4 orgs, driven through a real TTY: both picker paths (`login` and `ensureWorkspaceSelected`). Answering `4` persisted the 4th workspace overall, confirmed against the DB by ID — the continuous-numbering guarantee.
- Cleanroom QA as above.

## Found but not fixed here

Filed: SolidActions/solidactions-app#1196 (`workspace set "10TC"` silently resolves to the org-wide *workspace* when the string is both an org and a workspace name — wrong-target correctness) and SolidActions/solidactions-app#1197 (login reports success + `project deploy` next-steps after selection was cancelled). Six smaller findings recorded in the app repo's `docs/dev-shop-digest.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
