### PR TITLE
cli: point 'database --help' at the direct-connection docs (app#1189)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -204,7 +204,12 @@ program
 
 // Register the complete public surface up front so help and the generated
 // command manifest stay authoritative while handlers land in focused slices.
-const database = program.command('database').description('Manage workspace databases');
+const database = program
+    .command('database')
+    .description('Manage workspace databases')
+    .addHelpText('after', `
+Connect to a Workspace Database directly (any HTTP client or libSQL-compatible
+driver): https://www.solidactions.com/docs/workspace-databases/`);
 
 database
     .command('list')

--- a/tests/database-help-docs-link.test.ts
+++ b/tests/database-help-docs-link.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Pins that `database --help` points users at the Workspace Databases docs
+ * page for connecting directly (outside the CLI) over HTTP or libSQL.
+ */
+import * as childProcess from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import { describe, expect, it } from 'vitest';
+
+const CLI_BINARY = path.resolve(__dirname, '../dist/index.js');
+
+describe('database --help — direct-connection docs pointer', () => {
+    it('CLI is built', () => {
+        expect(fs.existsSync(CLI_BINARY)).toBe(true);
+    });
+
+    it('surfaces the workspace-databases docs URL', () => {
+        const result = childProcess.spawnSync(
+            process.execPath,
+            [CLI_BINARY, 'database', '--help'],
+            { encoding: 'utf8', timeout: 15_000 },
+        );
+
+        expect(result.status).toBe(0);
+        expect(result.stdout).toContain('https://www.solidactions.com/docs/workspace-databases/');
+    });
+});


### PR DESCRIPTION
Companion to SolidActions/solidactions-app#1189.

`solidactions database --help` now points at the new public guide for reaching a Workspace Database **outside** the CLI — from any HTTP client or a libSQL-compatible driver:

```
Connect to a Workspace Database directly (any HTTP client or libSQL-compatible
driver): https://www.solidactions.com/docs/workspace-databases/
```

That page (SolidActions/solidactions-marketing#16) is the only documentation of the direct-access path, so without a pointer here a user has to already know it exists.

## Notes

- Uses `.addHelpText('after', ...)` on the `database` group, matching the existing pattern on `project view`.
- Pinned by `tests/database-help-docs-link.test.ts`, which spawns the **built** CLI and asserts the URL is in `database --help` output — same shape as the existing `tests/project-view-help.test.ts`. Written failing first, against the unmodified CLI.
- **No `database access` subcommand is added or referenced.** app#1189 was filed assuming one exists; it does not, and the gap is filed separately as SolidActions/solidactions-app#1205 rather than absorbed into a docs run.

## Verification

- New test failed before the change, passes after.
- Full suite: **128 files, 1254 tests, all passing.**
- No vendor strings introduced — this surface is deliberately vendor-neutral; `libSQL` is the sanctioned term.
