### PR TITLE
fix: clarify database mapping states

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,8 @@ env:
 
 - A global key, an `oauth:` name, and a `database:` name are **mutually exclusive**: bind each variable to exactly one. The platform enforces that server-side (HTTP 422), but do not rely on seeing that error: through CLI v3.6.0 the YAML parser keeps only the first form it recognizes — `oauth:` beats `database:` — so a declaration carrying both deploys silently as the wrong binding instead of failing.
 - `project deploy` (including `--config-only`) syncs the *complete* `env:` list to the server on every run. Any previously YAML-sourced mapping whose name no longer appears in the list is deleted — removing or emptying `env:` prunes those mappings on the next deploy. Only mappings that were never YAML-declared survive: overriding a YAML-declared variable with `env set`/`env map` doesn't change its provenance, so removing its declaration still deletes the mapping.
-- For a `database:` entry, the workflow receives a `DatabaseVar` at `ctx.vars.<NAME>` at runtime, typically wrapped with the SDK's `createDatabaseClient()`. See the SDK reference's [Workspace Databases](https://github.com/SolidActions/solidactions-ts-sdk/blob/main/docs/sdk-reference.md#workspace-databases) section for details.
+- Create the workspace database first with `solidactions database create <name>` or in the web UI. Workspace-database bindings require `@solidactions/sdk >=0.8.0`.
+- For a `database:` entry, the workflow receives a typed `DatabaseVar` at `ctx.vars.<NAME>` at runtime, typically wrapped with the SDK's `createDatabaseClient()`. The private transport payload uses `read_only`; SDK 0.8.0+ normalizes it to the public `DatabaseVar.readOnly` property. Use the typed SDK object rather than parsing the transport payload. See the SDK reference's [Workspace Databases](https://github.com/SolidActions/solidactions-ts-sdk/blob/main/docs/sdk-reference.md#workspace-databases) section for details.
 
 ## Commands
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "solidactions": "dist/index.js"
       },
       "devDependencies": {
-        "@solidactions/sdk": "^0.7.3",
+        "@solidactions/sdk": "^0.8.0",
         "@types/archiver": "^8.0.0",
         "@types/fs-extra": "^11.0.0",
         "@types/js-yaml": "^4.0.9",
@@ -498,9 +498,9 @@
       "license": "MIT"
     },
     "node_modules/@solidactions/sdk": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/@solidactions/sdk/-/sdk-0.7.3.tgz",
-      "integrity": "sha512-5b+AvRGI0PBeTXAda2zyH0BfNoaLG1mucwM0Ghh9K/bbKYFj3E7tUddFMpL/dtRs52UnR13h2ntm7VsP1KoxGA==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@solidactions/sdk/-/sdk-0.8.0.tgz",
+      "integrity": "sha512-zjUvl2R8fkZ/NzPvThq64hP7MQcqee6n+5ig4xvqbUs/GqbRQAWMly3wXx8zBpNpXmpdcRRQVxShE1SReDUQJQ==",
       "dev": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "tar": "^7.5.22"
   },
   "devDependencies": {
-    "@solidactions/sdk": "^0.7.3",
+    "@solidactions/sdk": "^0.8.0",
     "@types/archiver": "^8.0.0",
     "@types/fs-extra": "^11.0.0",
     "@types/js-yaml": "^4.0.9",

--- a/scripts/smoke-init.mjs
+++ b/scripts/smoke-init.mjs
@@ -136,9 +136,9 @@ function revParse(root, candidate) {
  * checkout does not already have it.
  *
  * CI clones the sibling repos at depth 1 with no tags, so a pinned ref the CLI
- * asks for — the SDK's `v0.7.3` tag, or an EXAMPLES_REF SHA that is not the tip
+ * asks for — the SDK's `v0.8.0` tag, or an EXAMPLES_REF SHA that is not the tip
  * of the cloned branch — simply is not present locally, and the smoke failed
- * with "File not found ... (branch: v0.7.3)". Fetching on demand keeps the CI
+ * with "File not found ... (branch: v0.8.0)". Fetching on demand keeps the CI
  * checkouts cheap while still serving exactly the ref the CLI pins to.
  *
  * Remote-tracking refs are preferred over local ones so a stale local `main`

--- a/src/commands/env-list.ts
+++ b/src/commands/env-list.ts
@@ -67,7 +67,7 @@ export async function envList(projectName?: string, options: EnvListOptions = {}
 
                 // Value display (resolved_value includes global/oauth resolution)
                 const rawValue = mapping.resolved_value ?? mapping.value;
-                const value = mapping.is_secret ? '••••••' : rawValue ? rawValue.toString() : '-';
+                let value = mapping.is_secret ? '••••••' : rawValue ? rawValue.toString() : '-';
 
                 // Type & source (mirrors UI getMappingType)
                 let type: string;
@@ -75,12 +75,31 @@ export async function envList(projectName?: string, options: EnvListOptions = {}
                 if (mapping.source_type === 'oauth_connection' && mapping.oauth_connection_id) {
                     type = 'oauth';
                     source = mapping.oauth_connection_name || 'OAuth';
+                } else if (mapping.source_type === 'workspace_database') {
+                    value = '-';
+                    type = 'database';
+                    if (mapping.workspace_database_broken) {
+                        const databaseName = mapping.yaml_default_workspace_database_name || 'Database';
+                        source = `${databaseName} (missing)`;
+                    } else {
+                        source = mapping.workspace_database_name
+                            || mapping.yaml_default_workspace_database_name
+                            || 'Database';
+                    }
                 } else if (mapping.global_variable_key) {
                     type = 'global';
                     source = mapping.global_variable_key;
                 } else if (mapping.has_value) {
                     type = 'project var';
                     source = 'local';
+                } else if (
+                    typeof mapping.yaml_default_workspace_database_name === 'string'
+                    && mapping.yaml_default_workspace_database_name.length > 0
+                    && mapping.yaml_default_not_found === true
+                ) {
+                    value = '-';
+                    type = 'database';
+                    source = `${mapping.yaml_default_workspace_database_name} (not configured)`;
                 } else {
                     type = '-';
                     source = '-';

--- a/src/utils/examples-ref.ts
+++ b/src/utils/examples-ref.ts
@@ -14,7 +14,7 @@
  * with the package it publishes. solidactions-examples does NOT version in
  * lockstep with the SDK — its newest tag (v0.7.0) predates the current template
  * by a wide margin: it declares `@solidactions/sdk` ^0.6.0 (this CLI declares
- * ^0.7.3) and lacks skills/solidactions-crew-skills.md entirely. Pinning to that
+ * ^0.8.0) and lacks skills/solidactions-crew-skills.md entirely. Pinning to that
  * tag would regress every new scaffold, so the same derived-version scheme cannot
  * apply here. A commit SHA is immutable and gives the property that actually
  * matters — the scaffold no longer moves under us.
@@ -25,10 +25,11 @@
  * users. If solidactions-examples ever starts publishing tags in step with the
  * SDK, replace this with a derivation the way sdk-version.ts does.
  *
- * Currently: solidactions-examples PR #29 head @ 8a47ced4 "docs: add database
- * CLI guidance". Pinning this immutable PR-head commit is a temporary build-time necessity
- * while the coordinated wave is pending merge; no delivery override
- * was granted. Before any CLI release, repin EXAMPLES_REF to the
- * merged mainline SHA and verify that exact ref during the release ritual.
+ * Currently: the solidactions-examples issue #1201 branch head @ cf3a0df6
+ * "docs(#1201): refresh workspace database guidance". Pinning this immutable
+ * PR-head commit is a temporary build-time necessity while the coordinated wave
+ * is pending merge. Before the examples branch is deleted, repin EXAMPLES_REF
+ * to the merged mainline SHA. Before any CLI release, verify that exact ref
+ * during the release ritual.
  */
-export const EXAMPLES_REF = 'c232c416a86f5873c4b209f83132290322495e15';
+export const EXAMPLES_REF = 'cf3a0df634895e549600fb5d632fef2ba547aa8d';

--- a/tests/env-list-database.test.ts
+++ b/tests/env-list-database.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Issue #1201 — database mappings must be diagnosable in the human table while
+ * `--json` remains the raw API projection. Uses a real in-process HTTP server;
+ * no mocks, spies, or request stubs.
+ */
+import * as http from 'http';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { envList } from '../src/commands/env-list';
+import { makeTmpEnv, writeGlobal } from './helpers';
+
+const HEALTHY_DATABASE_MAPPING = {
+    env_name: 'SYNC_DB',
+    source_type: 'workspace_database',
+    workspace_database_id: '85dc58d9-c8db-491a-81c4-e92b126e1b20',
+    workspace_database_name: 'calendar-sync',
+    workspace_database_broken: false,
+    yaml_default_not_found: false,
+    status: 'yaml_default',
+};
+
+const DELETED_DATABASE_MAPPING = {
+    id: 42,
+    env_name: 'DELETED_DB',
+    global_variable_id: null,
+    global_variable_key: null,
+    value: null,
+    is_secret: false,
+    has_value: false,
+    plain_value: null,
+    yaml_default_global_id: null,
+    yaml_default_global_key: null,
+    yaml_default_oauth_connection_name: null,
+    yaml_default_workspace_database_name: 'archived-reports',
+    source_type: 'workspace_database',
+    oauth_connection_id: null,
+    oauth_connection_name: null,
+    workspace_database_id: 'dfdd4541-664a-414b-a69c-d2a3f8c1fb47',
+    workspace_database_name: null,
+    workspace_database_broken: true,
+    source: 'yaml',
+    status: 'yaml_default',
+    global_not_found: false,
+    yaml_default_not_found: false,
+    resolved_value: null,
+    token_expires_at: null,
+    oauth_warning: null,
+};
+
+const UNRESOLVED_DATABASE_MAPPING = {
+    id: 43,
+    env_name: 'PENDING_DB',
+    global_variable_id: null,
+    global_variable_key: null,
+    value: null,
+    is_secret: false,
+    has_value: false,
+    plain_value: null,
+    yaml_default_global_id: null,
+    yaml_default_global_key: null,
+    yaml_default_oauth_connection_name: null,
+    yaml_default_workspace_database_name: 'not-yet-created',
+    source_type: 'global_variable',
+    oauth_connection_id: null,
+    oauth_connection_name: null,
+    workspace_database_id: null,
+    workspace_database_name: null,
+    workspace_database_broken: false,
+    source: 'yaml',
+    status: 'yaml_default',
+    global_not_found: false,
+    yaml_default_not_found: true,
+    resolved_value: null,
+    token_expires_at: null,
+    oauth_warning: null,
+};
+
+let responseBody: unknown[] = [];
+let server: http.Server;
+let port: number;
+
+beforeAll(async () => {
+    server = http.createServer((_request, response) => {
+        response.writeHead(200, { 'content-type': 'application/json' });
+        response.end(JSON.stringify(responseBody));
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    port = (server.address() as { port: number }).port;
+});
+
+afterAll(async () => {
+    await new Promise<void>((resolve, reject) => {
+        server.close((error) => error ? reject(error) : resolve());
+    });
+});
+
+describe('env list database mappings', () => {
+    let env: ReturnType<typeof makeTmpEnv>;
+    let originalLog: typeof console.log;
+    let output: string[];
+
+    beforeEach(() => {
+        env = makeTmpEnv();
+        writeGlobal(env.home, {
+            host: `http://127.0.0.1:${port}`,
+            apiKey: 'test-key',
+            workspaceId: 'workspace-1',
+        });
+        responseBody = [];
+        output = [];
+        originalLog = console.log;
+        console.log = (...parts: unknown[]) => output.push(parts.map(String).join(' '));
+    });
+
+    afterEach(() => {
+        console.log = originalLog;
+        env.cleanup();
+    });
+
+    it('renders the real healthy mapping shape as a database with no credential value', async () => {
+        responseBody = [HEALTHY_DATABASE_MAPPING];
+
+        await envList('calendar-worker');
+
+        const row = output.find((line) => line.includes('SYNC_DB'));
+        expect(row).toBeDefined();
+        expect(row).toMatch(/SYNC_DB\s+-\s+database\s+calendar-sync/);
+    });
+
+    it('renders a deleted database target with its YAML name and a missing marker', async () => {
+        responseBody = [DELETED_DATABASE_MAPPING];
+
+        await envList('calendar-worker');
+
+        const row = output.find((line) => line.includes('DELETED_DB'));
+        expect(row).toMatch(/DELETED_DB\s+-\s+database\s+archived-reports \(missing\)/);
+    });
+
+    it('renders an unresolved YAML database default without keying on source_type', async () => {
+        responseBody = [UNRESOLVED_DATABASE_MAPPING];
+
+        await envList('calendar-worker');
+
+        const row = output.find((line) => line.includes('PENDING_DB'));
+        expect(row).toMatch(/PENDING_DB\s+-\s+database\s+not-yet-created \(not configured\)/);
+    });
+
+    it('keeps a current global override ahead of unresolved YAML database metadata', async () => {
+        responseBody = [{
+            ...UNRESOLVED_DATABASE_MAPPING,
+            env_name: 'OVERRIDDEN_GLOBAL',
+            global_variable_id: 91,
+            global_variable_key: 'REPORTING_DATABASE_URL',
+            resolved_value: 'https://global.example',
+        }];
+
+        await envList('calendar-worker');
+
+        const row = output.find((line) => line.includes('OVERRIDDEN_GLOBAL'));
+        expect(row).toMatch(/OVERRIDDEN_GLOBAL\s+https:\/\/global\.example\s+global\s+REPORTING_DATABASE_URL/);
+        expect(row).not.toContain('not configured');
+    });
+
+    it('keeps a current OAuth override ahead of unresolved YAML database metadata', async () => {
+        responseBody = [{
+            ...UNRESOLVED_DATABASE_MAPPING,
+            env_name: 'OVERRIDDEN_OAUTH',
+            source_type: 'oauth_connection',
+            oauth_connection_id: 73,
+            oauth_connection_name: 'Google Calendar',
+        }];
+
+        await envList('calendar-worker');
+
+        const row = output.find((line) => line.includes('OVERRIDDEN_OAUTH'));
+        expect(row).toMatch(/OVERRIDDEN_OAUTH\s+-\s+oauth\s+Google Calendar/);
+        expect(row).not.toContain('not configured');
+    });
+
+    it('keeps a current local override ahead of unresolved YAML database metadata', async () => {
+        responseBody = [{
+            ...UNRESOLVED_DATABASE_MAPPING,
+            env_name: 'OVERRIDDEN_LOCAL',
+            has_value: true,
+            value: 'local-database-url',
+            resolved_value: 'local-database-url',
+        }];
+
+        await envList('calendar-worker');
+
+        const row = output.find((line) => line.includes('OVERRIDDEN_LOCAL'));
+        expect(row).toMatch(/OVERRIDDEN_LOCAL\s+local-database-url\s+project var\s+local/);
+        expect(row).not.toContain('not configured');
+    });
+
+    it('prints the exact healthy API array unchanged in JSON mode', async () => {
+        responseBody = [HEALTHY_DATABASE_MAPPING];
+
+        await envList('calendar-worker', { json: true });
+
+        expect(JSON.parse(output.join('\n'))).toEqual([HEALTHY_DATABASE_MAPPING]);
+    });
+});

--- a/tests/examples-ref.test.ts
+++ b/tests/examples-ref.test.ts
@@ -24,12 +24,18 @@ const PRE_DATABASE_GUIDANCE_REF = '3ca5fd4d3107659b27889775791f6691cf173303';
 const RELEASE_SMOKE = fs.readFileSync(path.resolve(__dirname, '../scripts/smoke-init.mjs'), 'utf8');
 
 describe('EXAMPLES_REF', () => {
+    it('pins the approved #1201 examples content commit', () => {
+        expect(EXAMPLES_REF).toBe('cf3a0df634895e549600fb5d632fef2ba547aa8d');
+    });
+
     it('records the temporary PR-head pin and the mandatory pre-release mainline repin without a fabricated override', () => {
         const source = fs.readFileSync(path.resolve(__dirname, '../src/utils/examples-ref.ts'), 'utf8');
 
         expect(source).toContain('temporary build-time necessity');
         expect(source).toContain('merged mainline SHA');
         expect(source).toMatch(/before any CLI release/i);
+        expect(source).toMatch(/before the examples\s+branch is\s+deleted/i);
+        expect(source).toContain('#1201');
         expect(source).toMatch(/release ritual/i);
         expect(source).not.toMatch(/PM[- ]directed|PM delivery override|override explicitly approved/i);
     });

--- a/tests/readme-contract.test.ts
+++ b/tests/readme-contract.test.ts
@@ -106,4 +106,15 @@ describe('public README setup contract', () => {
         expect(guidance).toMatch(/avoid|without|no replay/i);
         expect(guidance).not.toMatch(/turso|libsql/i);
     });
+
+    it('documents database binding setup and the SDK 0.8 transport boundary', () => {
+        const guidance = markdownSection(README, '### Env declarations (`solidactions.yaml`)');
+
+        expect(guidance).toContain('solidactions database create');
+        expect(guidance).toMatch(/web UI/i);
+        expect(guidance).toMatch(/@solidactions\/sdk.*>=\s*0\.8\.0/i);
+        expect(guidance).toContain('read_only');
+        expect(guidance).toContain('DatabaseVar.readOnly');
+        expect(guidance).toMatch(/typed.*DatabaseVar/i);
+    });
 });

--- a/tests/sdk-docs-ref.test.ts
+++ b/tests/sdk-docs-ref.test.ts
@@ -57,6 +57,11 @@ describe('sdkRefFromRange', () => {
 // ---------------------------------------------------------------------------
 
 describe('sdkDocsRef', () => {
+    it('pins bundled SDK documentation to the first database-capable release', () => {
+        expect(declaredSdkRange).toBe('^0.8.0');
+        expect(sdkDocsRef()).toBe('v0.8.0');
+    });
+
     it('derives the ref from the @solidactions/sdk range declared in package.json', () => {
         // Both sides read the same source, so bumping the dependency moves the
         // docs ref automatically — there is no literal here to drift.


### PR DESCRIPTION
## Summary

- render healthy, soft-deleted, and never-created workspace database mappings distinctly in `env list`
- preserve the raw API payload exactly for `env list --json`
- update delivered SDK documentation to v0.8.0
- temporarily pin scaffold content to the issue examples commit so the corrected guidance is reviewable end to end

## Verification

- focused contracts: 43/43
- full suite: 128 files / 1,262 tests
- build, source-backed scaffold smoke, package dry-run, and audit
- real-stack table/JSON comparison across all three mapping states

Tracks SolidActions/solidactions-app#1201. Companion integration PR:
SolidActions/solidactions-app#1219.

Dependency: the temporary examples commit pin points to
SolidActions/solidactions-examples#31 and must be replaced with a stable
default-branch ref after that PR merges. Do not merge this PR before that repin.
